### PR TITLE
Update the url to be workshop/id.

### DIFF
--- a/wp-content/plugins/wporg-learn/inc/post-type.php
+++ b/wp-content/plugins/wporg-learn/inc/post-type.php
@@ -117,6 +117,7 @@ function register_workshop() {
 		'capability_type'       => 'page',
 		'show_in_rest'          => true,
 		'template_lock'         => 'all',
+		'rewrite'               => array( 'slug' => 'workshop' ),
 		'template' => array(
 			array( 'core/group',
 			array( 'className' => 'workshop-page_content' ),

--- a/wp-content/plugins/wporg-learn/wporg-learn.php
+++ b/wp-content/plugins/wporg-learn/wporg-learn.php
@@ -168,3 +168,16 @@ add_action( 'wp_head', function(){
 	</style>
 	<?php
 });
+
+/**
+ * Filter to change wporg_workshop post type url
+ */
+function wporg_workshop_register_post_type_args( $args, $post_type ) {
+    if ( 'wporg_workshop' === $post_type ) {
+        $args['rewrite']['slug'] = 'workshop';
+    }
+
+    return $args;
+}
+
+add_filter( 'register_post_type_args', 'wporg_workshop_register_post_type_args', 10, 2 );

--- a/wp-content/plugins/wporg-learn/wporg-learn.php
+++ b/wp-content/plugins/wporg-learn/wporg-learn.php
@@ -168,16 +168,3 @@ add_action( 'wp_head', function(){
 	</style>
 	<?php
 });
-
-/**
- * Filter to change wporg_workshop post type url
- */
-function wporg_workshop_register_post_type_args( $args, $post_type ) {
-    if ( 'wporg_workshop' === $post_type ) {
-        $args['rewrite']['slug'] = 'workshop';
-    }
-
-    return $args;
-}
-
-add_filter( 'register_post_type_args', 'wporg_workshop_register_post_type_args', 10, 2 );


### PR DESCRIPTION
### Description
This PR adds a filter to plugin to change the urls from `wporg_workshop/${id}` to `workshop/${id}`.

Addresses: #22 