### PR TITLE
Update the first category name and set the lesson plans to it.

### DIFF
--- a/bin/index.sh
+++ b/bin/index.sh
@@ -19,6 +19,9 @@ npm run wp-env run cli wp theme activate pub/wporg-learn-2020
 ## Install dependencies
 yarn
 
+## Rename the default category
+npm run wp-env run cli "wp term update category 1 --name=All --slug=all"
+
 ## Import lesson plans
 npm run wp-env run cli wp cron event run wporg_learn_manifest_import
 npm run wp-env run cli wp cron event run wporg_learn_markdown_import

--- a/wp-content/plugins/wporg-learn/inc/class-markdown-import.php
+++ b/wp-content/plugins/wporg-learn/inc/class-markdown-import.php
@@ -98,6 +98,7 @@ class Markdown_Import {
 			'post_parent' => $post_parent,
 			'post_title'  => sanitize_text_field( wp_slash( $doc['title'] ) ),
 			'post_name'   => sanitize_title_with_dashes( $doc['slug'] ),
+			'post_category' => array( 1 )
 		);
 		$post_id = wp_insert_post( $post_data );
 		if ( ! $post_id ) {


### PR DESCRIPTION
### Description
This PR changes the name & slug of the `uncategorized` category and sets all the imported lesson plans to that category.

This makes sure the archive page displays something.

It's a potential solution for #31.

Next iteration, we could ask the training team to update the manifest to have more categories.

![](https://d.pr/i/mMgY7g.png)