### PR TITLE
Add excerpt to the post type and grab the latest workshop for now, instead of a featured one.

### DIFF
--- a/wp-content/plugins/wporg-learn/inc/post-type.php
+++ b/wp-content/plugins/wporg-learn/inc/post-type.php
@@ -100,7 +100,7 @@ function register_workshop() {
 		'label'                 => __( 'Workshop', 'wporg_learn' ),
 		'description'           => __( 'WordPress.org Training Workshop', 'wporg_learn' ),
 		'labels'                => $labels,
-		'supports'              => array( 'title', 'editor', 'comments', 'revisions', 'custom-fields', 'thumbnail' ),
+		'supports'              => array( 'title', 'editor', 'comments', 'revisions', 'custom-fields', 'thumbnail', 'excerpt' ),
 		'taxonomies'            => array( 'level', 'topic' ),
 		'hierarchical'          => true,
 		'public'                => true,

--- a/wp-content/themes/pub/wporg-learn-2020/template-parts/component-featured-workshop.php
+++ b/wp-content/themes/pub/wporg-learn-2020/template-parts/component-featured-workshop.php
@@ -23,7 +23,7 @@ $featured_workshop = wporg_get_workshops( $args );
 		<a class="featured-workshop_title" href="<?php echo esc_url( get_the_permalink() ); ?>"><?php echo the_title() ?></a>
 		<div class="row">
 			<div class="col-8">	
-				<p><?php echo get_the_excerpt(); ?></p>
+				<p><?php the_excerpt(); ?></p>
 			</div>
 			<div class="col-4 featured-workshop_content_author">
 				<?php get_template_part( 'template-parts/component', 'author' ); ?>

--- a/wp-content/themes/pub/wporg-learn-2020/template-parts/component-featured-workshop.php
+++ b/wp-content/themes/pub/wporg-learn-2020/template-parts/component-featured-workshop.php
@@ -8,7 +8,7 @@
  * @package WPBBP
  */
 
-$args = array( 'category_name' => 'Featured', 'posts_per_page' => '1' );
+$args = array( 'posts_per_page' => '1' );
 
 $featured_workshop = wporg_get_workshops( $args );
 ?>
@@ -23,7 +23,7 @@ $featured_workshop = wporg_get_workshops( $args );
 		<a class="featured-workshop_title" href="<?php echo esc_url( get_the_permalink() ); ?>"><?php echo the_title() ?></a>
 		<div class="row">
 			<div class="col-8">	
-				<p>With WordPress moving more and more into the world of blocks, knowing how to build your own blocks has become valuable knowledge. However, if you are a plugin or theme developer, you might not be sure where to start. This workshop will serve as a guide to building your first block.</p>
+				<p><?php echo get_the_excerpt(); ?></p>
 			</div>
 			<div class="col-4 featured-workshop_content_author">
 				<?php get_template_part( 'template-parts/component', 'author' ); ?>


### PR DESCRIPTION
### Description

This PR:
- Turns on the excerpt field to be used in the featured workshop section of the workshop archive. 
- Grabs only one workshop to display
  - Categories were removed from `workshop`s because they are currently creating issues with lesson-plan code.