### PR TITLE
Update Title and Intro Text

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2020/header.php
+++ b/wp-content/themes/pub/wporg-learn-2020/header.php
@@ -43,7 +43,7 @@ if ( is_front_page() ) {
 				<p class="site-description">
 					<?php
 					/* Translators: subhead */
-					_e('Whether you&#8217;re a first-time blogger or seasoned developer, there&#8217;s always more to learn. From the contributors who make WordPress, these vast resourses will help you learn more about WordPress and teach it to others.', 'wporg-forums');
+					_e('Whether you&#8217;re a first-time blogger or seasoned developer, there&#8217;s always more to learn. From community members all over the world, these vast resourses will help you learn more about WordPress and teach it to others.', 'wporg-forums');
 					?>
 				</p>
 

--- a/wp-content/themes/pub/wporg-learn-2020/header.php
+++ b/wp-content/themes/pub/wporg-learn-2020/header.php
@@ -38,12 +38,12 @@ if ( is_front_page() ) {
 				<?php
 				if ( is_front_page() ) {
 				?>
-				<h1 class="site-title"><a href="<?php echo esc_url(home_url('/')); ?>" rel="home"><?php _ex('Help Others Learn WordPress', 'Site title', 'wporg-forums'); ?></a></h1>
+				<h1 class="site-title"><a href="<?php echo esc_url(home_url('/')); ?>" rel="home"><?php _ex('Learn WordPress', 'Site title', 'wporg-forums'); ?></a></h1>
 
 				<p class="site-description">
 					<?php
 					/* Translators: subhead */
-					_e('Whether you&#8217;re a first-time blogger or seasoned developer, there&#8217;s always more to learn. From the contributors who make WordPress, these vast resourses will help you teach WordPress to others.', 'wporg-forums');
+					_e('Whether you&#8217;re a first-time blogger or seasoned developer, there&#8217;s always more to learn. From the contributors who make WordPress, these vast resourses will help you learn more about WordPress and teach it to others.', 'wporg-forums');
 					?>
 				</p>
 


### PR DESCRIPTION
This PR updates the title and intro text.

Fixes #36.

In these future, it's possible these could be pulled from the site's name and description.