### PR TITLE
Workshops: Tweaks to details output, add seconds field for duration

### DIFF
--- a/wp-content/plugins/wporg-learn/inc/blocks.php
+++ b/wp-content/plugins/wporg-learn/inc/blocks.php
@@ -2,6 +2,8 @@
 
 namespace WPOrg_Learn\Blocks;
 
+use function WPOrg_Learn\Post_Meta\get_workshop_duration;
+
 defined( 'WPINC' ) || die();
 
 /**
@@ -61,8 +63,9 @@ function workshop_details_init() {
  */
 function workshop_details_render_callback( $attributes, $content ) {
 	$post = get_post();
-	$topics = wp_get_post_terms( $post->ID, 'topic' );
-	$level = wp_get_post_terms( $post->ID, 'level' );
+	$topics = wp_get_post_terms( $post->ID, 'topic', array( 'fields' => 'names' ) );
+	$level = wp_get_post_terms( $post->ID, 'level', array( 'fields' => 'names' ) );
+	$captions = get_post_meta( $post->ID, 'video_caption_language' );
 
 	return sprintf(
 		'<ul class="wp-block-wporg-learn-workshop-details">
@@ -72,11 +75,11 @@ function workshop_details_render_callback( $attributes, $content ) {
 			<li><b>Language</b><span>%4$s</span></li>
 			<li><b>Captions</b><span>%5$s</span></li>
 		</ul>',
-		$post->duration,
-		$topics && $topics[0] ? $topics[0]->name : '',
-		$level && $level[0] ? $level[0]->name : '',
-		$post->video_language,
-		$post->video_caption_language
+		get_workshop_duration( $post, 'string' ),
+		implode( ', ', array_map( 'esc_html', $topics ) ),
+		implode( ', ', array_map( 'esc_html', $level ) ),
+		esc_html( $post->video_language ),
+		implode( ', ', array_map( 'esc_html', $captions ) )
     );
 }
 

--- a/wp-content/plugins/wporg-learn/inc/post-meta.php
+++ b/wp-content/plugins/wporg-learn/inc/post-meta.php
@@ -79,7 +79,7 @@ function register_workshop_meta() {
  * @return int|DateInterval|string
  */
 function get_workshop_duration( WP_Post $workshop, $format = 'raw' ) {
-	$raw_duration = $workshop->duration ?: 0;
+	$raw_duration = $workshop->duration ? absint( $workshop->duration ) : 0;
 	$interval = date_diff( new DateTime( '@0' ), new DateTime( "@$raw_duration" ) ); // The '@' ignores timezone.
 	$return = null;
 
@@ -88,7 +88,7 @@ function get_workshop_duration( WP_Post $workshop, $format = 'raw' ) {
 			$return = $interval;
 			break;
 		case 'string':
-			$return = human_readable_duration( $interval->format( 'HH:ii:ss' ) );
+			$return = human_readable_duration( $interval->format( '%H:%I:%S' ) );
 			break;
 		case 'raw':
 		default:
@@ -157,8 +157,8 @@ function save_workshop_metabox_fields( $post_id, WP_Post $post ) {
 	}
 
 	$duration = filter_input( INPUT_POST, 'duration', FILTER_SANITIZE_NUMBER_INT, FILTER_REQUIRE_ARRAY );
-	if ( isset( $duration['h'], $duration['m'] ) ) {
-		$duration = $duration['h'] * HOUR_IN_SECONDS + $duration['m'] * MINUTE_IN_SECONDS;
+	if ( isset( $duration['h'], $duration['m'], $duration['s'] ) ) {
+		$duration = $duration['h'] * HOUR_IN_SECONDS + $duration['m'] * MINUTE_IN_SECONDS + $duration['s'];
 		update_post_meta( $post_id, 'duration', $duration );
 	}
 

--- a/wp-content/plugins/wporg-learn/views/metabox-workshop-details.php
+++ b/wp-content/plugins/wporg-learn/views/metabox-workshop-details.php
@@ -28,6 +28,17 @@
 		/>
 		<?php _e( 'minutes', 'wporg_learn' ); ?>
 	</label>
+	<label for="workshop-duration-seconds">
+		<input
+				id="workshop-duration-seconds"
+				name="duration[s]"
+				class="tiny-text"
+				type="number"
+				value="<?php echo absint( $duration_interval->s ); ?>"
+				max="59"
+		/>
+		<?php _e( 'seconds', 'wporg_learn' ); ?>
+	</label>
 </p>
 
 <?php // todo Change this to a select dropdown with locale values. ?>


### PR DESCRIPTION
* Fix bug in `get_workshop_duration` that prevented output when string format specified
* Update workshop details rendering to correctly output human readable string for the duration and allow for comma separated lists on fields where multiple values may be present (topics, levels, captions)
* Add seconds field to the duration in the details metabox

Fixes #35