### PR TITLE
Link all the buckets to the lesson plan & workshop lander.

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2020/front-page.php
+++ b/wp-content/themes/pub/wporg-learn-2020/front-page.php
@@ -65,17 +65,17 @@ get_header();?>
 				<div class="lesson-item">
 					<h2 class="h4 title"><?php _e( 'User-oriented Lesson Plans' ); ?></h2>
 					<p><?php _e( 'User lessons are targeted towards end-users, those who actually publish content.' ); ?></p>
-					<a class="viewmore" href="#"><?php _e( 'View the lesson plans' ); ?></a>
+					<a class="viewmore" href="/lesson-plans"><?php _e( 'View the lesson plans' ); ?></a>
 				</div>
 				<div class="lesson-item">
 					<h2 class="h4 title"><?php _e( 'Theme-oriented Lesson Plans' ); ?></h2>
 					<p><?php _e( 'Theme lessons are targeted towards entry-level developers, those who actually write code.' ); ?></p>
-					<a class="viewmore" href="#"><?php _e( 'View the lesson plans' ); ?></a>
+					<a class="viewmore" href="/lesson-plans"><?php _e( 'View the lesson plans' ); ?></a>
 				</div>
 				<div class="lesson-item">
 					<h2 class="h4 title"><?php _e( 'Plugin-oriented Lesson Plans' ); ?></h2>
 					<p><?php _e( 'Plugin lessons are targeted towards entry-level developers, those who actually write code.' ); ?></p>
-					<a class="viewmore" href="#"><?php _e( 'View the lesson plans' ); ?></a>
+					<a class="viewmore" href="/lesson-plans"><?php _e( 'View the lesson plans' ); ?></a>
 				</div>
 			</div>
 
@@ -83,17 +83,17 @@ get_header();?>
 				<div class="lesson-item">
 					<h2 class="h4 title"><?php _e( 'Half-day Workshop Ideas' ); ?></h2>
 					<p><?php _e( 'Concepts and activities for workshops that are only a few hours long.' ); ?></p>
-					<a class="viewmore" href="#"><?php _e( 'View the Workshop Ideas' ); ?></a>
+					<a class="viewmore" href="/workshops"><?php _e( 'View the Workshop Ideas' ); ?></a>
 				</div>
 				<div class="lesson-item">
 					<h2 class="h4 title"><?php _e( 'Full-day Workshop Ideas' ); ?></h2>
 					<p><?php _e( 'Concepts and activities for workshops that fill the whole day.' ); ?></p>
-					<a class="viewmore" href="#"><?php _e( 'View the Workshop Ideas' ); ?></a>
+					<a class="viewmore" href="/workshops"><?php _e( 'View the Workshop Ideas' ); ?></a>
 				</div>
 				<div class="lesson-item">
 					<h2 class="h4 title"><?php _e( 'Multi-day Workshop Ideas' ); ?></h2>
 					<p><?php _e( 'Concepts and activities for workshops that span the course of 2 or more days.' ); ?></p>
-					<a class="viewmore" href="#"><?php _e( 'View the Workshop Ideas' ); ?></a>
+					<a class="viewmore" href="/workshops"><?php _e( 'View the Workshop Ideas' ); ?></a>
 				</div>
 			</div>
 
@@ -101,12 +101,12 @@ get_header();?>
 				<div class="lesson-item">
 					<h2 class="h4 title"><?php _e( 'Want to Help More People Speak at Meetups and WordCamps?' ); ?></h2>
 					<p><?php _e( 'WordPress is a built on a community where diversity and inclusion are key to growth. Meetups and WordCamps are the best way to teach others about WordPress on a local level and these resources can help diversify the speakers at these events.' ); ?></p>
-					<a class="viewmore" href="#"><?php _e( 'View the Speaker Diversity Lesson plans' ); ?></a>
+					<a class="viewmore" href="/lesson-plans"><?php _e( 'View the Speaker Diversity Lesson plans' ); ?></a>
 				</div>
 				<div class="lesson-item">
 					<h2 class="h4 title"><?php _e( 'Helpful Links' ); ?></h2>
-					<a class="viewmore" href="#"><?php _e( 'WordCamp Central' ); ?></a> <br />
-					<a class="viewmore" href="#"><?php _e( 'WordPress Meetups' ); ?></a>
+					<a class="viewmore" href="//central.wordcamp.org/"><?php _e( 'WordCamp Central' ); ?></a> <br />
+					<a class="viewmore" href="//make.wordpress.org/community/meetups/"><?php _e( 'WordPress Meetups' ); ?></a>
 				</div>
 			</div>
 		</section>


### PR DESCRIPTION
This PR adds links to the homepage buckets. This PR will link any lesson plan content bucket to `lesson-plans` and any workshop bucket to `workshops`.

I tried a few different layouts, adding/removing copy, and couldn't find one that worked since we don't have categorization on the lesson-plan or workshop archives yet. I tried the homepage without the content but it makes it pretty lean and since the buckets still provide important information about what lesson plans/workshops are, and their 'kinds', I thought that even if they all link the same place, the content stays,...... it may be the best approach. 

Any other thoughts on what can be done here?
@hlashbrooke @coreymckrill

Addresses: #57 