### PR TITLE
Workshop Details: Make the human readable duration more succinct

### DIFF
--- a/wp-content/plugins/wporg-learn/inc/post-meta.php
+++ b/wp-content/plugins/wporg-learn/inc/post-meta.php
@@ -103,7 +103,7 @@ function get_workshop_duration( WP_Post $workshop, $format = 'raw' ) {
 					);
 				}
 			} elseif ( $interval->i > 0 ) {
-				$return = $minutes = human_time_diff( 0, $interval->i * MINUTE_IN_SECONDS );
+				$return = human_time_diff( 0, $interval->i * MINUTE_IN_SECONDS );
 			} elseif ( $interval->s > 0 ) {
 				$return = human_time_diff( 0, $interval->s );
 			}

--- a/wp-content/plugins/wporg-learn/inc/post-meta.php
+++ b/wp-content/plugins/wporg-learn/inc/post-meta.php
@@ -88,7 +88,35 @@ function get_workshop_duration( WP_Post $workshop, $format = 'raw' ) {
 			$return = $interval;
 			break;
 		case 'string':
-			$return = human_readable_duration( $interval->format( '%H:%I:%S' ) );
+			if ( $interval->d > 0 ) {
+				$return = human_time_diff( 0, $interval->d * DAY_IN_SECONDS );
+			} elseif ( $interval->h > 0 ) {
+				$return = $hours = human_time_diff( 0, $interval->h * HOUR_IN_SECONDS );
+
+				if ( $interval->i > 0 ) {
+					$minutes = human_time_diff( 0, $interval->i * MINUTE_IN_SECONDS );
+					$return = sprintf(
+						// translators: 1 is a string like "2 hours". 2 is a string like "20 mins".
+						_x( '%1$s, %2$s', 'hours and minutes','wporg-learn' ),
+						$hours,
+						$minutes
+					);
+				}
+			} elseif ( $interval->i > 0 ) {
+				$return = $minutes = human_time_diff( 0, $interval->i * MINUTE_IN_SECONDS );
+
+				if ( $interval->s > 0 ) {
+					$seconds = human_time_diff( 0, $interval->s );
+					$return = sprintf(
+						// translators: 1 is a string like "20 mins". 2 is a string like "32 seconds".
+						_x( '%1$s, %2$s', 'minutes and seconds','wporg-learn' ),
+						$minutes,
+						$seconds
+					);
+				}
+			} elseif ( $interval->s > 0 ) {
+				$return = human_time_diff( 0, $interval->s );
+			}
 			break;
 		case 'raw':
 		default:

--- a/wp-content/plugins/wporg-learn/inc/post-meta.php
+++ b/wp-content/plugins/wporg-learn/inc/post-meta.php
@@ -104,16 +104,6 @@ function get_workshop_duration( WP_Post $workshop, $format = 'raw' ) {
 				}
 			} elseif ( $interval->i > 0 ) {
 				$return = $minutes = human_time_diff( 0, $interval->i * MINUTE_IN_SECONDS );
-
-				if ( $interval->s > 0 ) {
-					$seconds = human_time_diff( 0, $interval->s );
-					$return = sprintf(
-						// translators: 1 is a string like "20 mins". 2 is a string like "32 seconds".
-						_x( '%1$s, %2$s', 'minutes and seconds','wporg-learn' ),
-						$minutes,
-						$seconds
-					);
-				}
 			} elseif ( $interval->s > 0 ) {
 				$return = human_time_diff( 0, $interval->s );
 			}


### PR DESCRIPTION
```
    Under 1 hour?
    -> "43 minutes"

    Over 1 hour?
    -> "1 Hour, 43 minutes."

    Between 24 & 48 hours?
    -> "1 day" (round up?)

I think we don't ever show seconds.
```

There might be a time when the duration is only in seconds, though, so in that case we'll show seconds.

Fixes #60 