### PR TITLE
Workshop template: Update the link for discussion groups

### DIFF
--- a/wp-content/plugins/wporg-learn/inc/post-type.php
+++ b/wp-content/plugins/wporg-learn/inc/post-type.php
@@ -81,8 +81,8 @@ function register_workshop() {
 		array(
 			array( 'wporg-learn/workshop-details' ),
 			array( 'core/button', array(
-				'text'         => __( 'Join a Group Discussion', 'wporg-learn' ),
-				'url'          => 'https://wordpress.org',
+				'text'         => __( 'Join a discussion group', 'wporg-learn' ),
+				'url'          => 'https://www.meetup.com/learn-wordpress-discussions/events/',
 				'borderRadius' => 5,
 				'className'    => 'is-style-secondary-full-width',
 			) ),

--- a/wp-content/plugins/wporg-learn/inc/post-type.php
+++ b/wp-content/plugins/wporg-learn/inc/post-type.php
@@ -81,7 +81,7 @@ function register_workshop() {
 		array(
 			array( 'wporg-learn/workshop-details' ),
 			array( 'core/button', array(
-				'text'         => __( 'Join a discussion group', 'wporg-learn' ),
+				'text'         => __( 'Join a Group Discussion', 'wporg-learn' ),
 				'url'          => 'https://www.meetup.com/learn-wordpress-discussions/events/',
 				'borderRadius' => 5,
 				'className'    => 'is-style-secondary-full-width',


### PR DESCRIPTION
This changes the link that will be applied to the "Join a discussion group" button on new workshop posts. Existing workshop posts will have to be updated manually. Fixing #65 would eliminate the need for changes like this.

Fixes #61 