### PR TITLE
Use default video poster if no featured image was set for a workshop

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2020/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2020/functions.php
@@ -270,7 +270,7 @@ function wporg_get_post_thumbnail( $post, $size = 'post-thumbnail' ) {
         foreach ( get_post_meta( $post->ID, '', true ) as $key => $value ) {
             if ( substr( $key, 0, 8 ) === '_oembed_' && preg_match( '#https://video.wordpress.com/embed/(\w+)#', $value[0], $match ) ) {
                 $video = videopress_get_video_details( $match[1] );
-                if ( is_object( $video ) && isset( $video->poster ) ) {
+                if ( !is_wp_error( $video ) && isset( $video->poster ) ) {
                     return '<img class="attachment-' . esc_attr( $size ) . ' wp-post-image" src=' . esc_url( $video->poster ) . ' loading="lazy" />';
                 }
             }

--- a/wp-content/themes/pub/wporg-learn-2020/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2020/functions.php
@@ -254,3 +254,27 @@ function wporg_get_workshop_presenters( $workshop = null ) {
 
 	return $wp_users;
 }
+
+/**             
+ * Display a featured image, falling back to the VideoPress thumbnail if no featured image was explicitly set.
+ *          
+ * @param $post The Workshop post for which we want the thumbnail.
+ * @param $size The image size: 'medium', 'full'.
+ */     
+function wporg_get_post_thumbnail( $post, $size = 'post-thumbnail' ) {
+    $thumbnail = get_the_post_thumbnail( $post, $size );
+    if ( $thumbnail ) {
+        return $thumbnail;
+    } else {
+        $post = get_post( $post );
+        foreach ( get_post_meta( $post->ID, '', true ) as $key => $value ) {
+            if ( substr( $key, 0, 8 ) === '_oembed_' && preg_match( '#https://video.wordpress.com/embed/(\w+)#', $value[0], $match ) ) {
+                $video = videopress_get_video_details( $match[1] );
+                if ( is_object( $video ) && isset( $video->poster ) ) {
+                    return '<img class="attachment-' . esc_attr( $size ) . ' wp-post-image" src=' . esc_url( $video->poster ) . ' loading="lazy" />';
+                }
+            }
+        }
+    }
+}
+

--- a/wp-content/themes/pub/wporg-learn-2020/template-parts/component-featured-workshop.php
+++ b/wp-content/themes/pub/wporg-learn-2020/template-parts/component-featured-workshop.php
@@ -12,7 +12,7 @@ $featured_workshop = wporg_get_workshops( array( 'posts_per_page' => 1 ) );
 
 <div class="featured-workshop">
 	<?php while ( $featured_workshop->have_posts() ) : $featured_workshop->the_post(); ?>
-		<div class="featured-workshop_video"><?php the_post_thumbnail( 'full' ); ?></div>
+		<div class="featured-workshop_video"><?php echo wporg_get_post_thumbnail( $post, 'full' ); ?></div>
 		<div class="featured-workshop_content">
 			<a class="featured-workshop_title" href="<?php echo esc_url( get_the_permalink() ); ?>"><?php echo the_title() ?></a>
 			<div class="row">

--- a/wp-content/themes/pub/wporg-learn-2020/template-parts/component-video-grid-item.php
+++ b/wp-content/themes/pub/wporg-learn-2020/template-parts/component-video-grid-item.php
@@ -11,7 +11,7 @@
 
 <li class="col-4 video-grid_item">
 	<a class="video-grid_item_link" href="<?php echo esc_url( get_the_permalink() ); ?>">
-		<?php echo wporg_get_post_thumbnail( $post, 'medium' );; ?>
+		<?php echo wporg_get_post_thumbnail( $post, 'medium' ); ?>
 		<?php the_title(); ?>
 	</a>
 </li>

--- a/wp-content/themes/pub/wporg-learn-2020/template-parts/component-video-grid-item.php
+++ b/wp-content/themes/pub/wporg-learn-2020/template-parts/component-video-grid-item.php
@@ -11,11 +11,7 @@
 
 <li class="col-4 video-grid_item">
 	<a class="video-grid_item_link" href="<?php echo esc_url( get_the_permalink() ); ?>">
-		<?php if( has_post_thumbnail() ) : ?>
-			<?php echo the_post_thumbnail( 'medium' ); ?>
-		<?php else : ?>
-			<div class="video-grid_item--no-image"></div>
-		<? endif; ?>
+		<?php echo wporg_get_post_thumbnail( $post, 'medium' );; ?>
 		<?php the_title(); ?>
 	</a>
 </li>


### PR DESCRIPTION
This is a quick stab at fixing #39.

I considered using Photon but I don't think it makes a significant difference in this case - it's using the VideoPress poster image, retrieved via `videopress_get_video_details()`, which is hosted on videos.files.wordpress.com. It might be worth adding that if we want to properly resize and/or crop, but I think the video posters will naturally be small enough already for this to work as a MVP.
