### PR TITLE
Move the submit cta to a template and make the icon optional.

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2020/archive-lesson-plan.php
+++ b/wp-content/themes/pub/wporg-learn-2020/archive-lesson-plan.php
@@ -31,7 +31,7 @@ get_header();
 
 	</main><!-- #main -->
 
-	<?php wporg_submit_idea_cta(); ?>
+	<?php get_template_part( 'template-parts/component', 'submit-idea-cta' ); ?>
 
 <?php
 get_footer();

--- a/wp-content/themes/pub/wporg-learn-2020/archive-wporg_workshop.php
+++ b/wp-content/themes/pub/wporg-learn-2020/archive-wporg_workshop.php
@@ -20,7 +20,7 @@ get_header();?>
 	</section>
 	<hr>
 
-	<?php wporg_submit_idea_cta(); ?>
+	<?php get_template_part( 'template-parts/component', 'submit-idea-cta' ); ?>
 </main>
 
 <?php

--- a/wp-content/themes/pub/wporg-learn-2020/front-page.php
+++ b/wp-content/themes/pub/wporg-learn-2020/front-page.php
@@ -60,7 +60,7 @@ get_header();?>
 		</section>
 		<hr>
 		
-		<?php wporg_submit_idea_cta(); ?>
+		<?php get_template_part( 'template-parts/component', 'submit-idea-cta', array( 'icon' => 'lightbulb' ) ); ?>
 
 		<?php if ( ! is_active_sidebar( 'front-page-blocks' ) ) : ?>
 			<?php //get_template_part( 'template-parts/bbpress', 'front' ); ?>

--- a/wp-content/themes/pub/wporg-learn-2020/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2020/functions.php
@@ -199,21 +199,6 @@ return get_post_meta( get_the_ID(), 'download_lesson_plan_slides_url', true );
 }
 
 /**
- * Submit CTA button
- *
- * @package WPBBP
- */
-function wporg_submit_idea_cta() { ?>
-
-	<section class="submit-idea-cta">
-		<div class="content-icon"><span class="dashicons dashicons-lightbulb"></span></div>
-		<h2><?php _e( 'Have an Idea for a Workshop? Let us know!' ); ?></h2>
-		<a class="button button-primary button-large" href="https://wordcampcentral.survey.fm/learn-wordpress-workshop-application"><?php _e( 'Submit an Idea' ); ?></a>
-	</section>
-
-<?php }
-
-/**
  * Returns whether all post for workshop
  *
  * @return array

--- a/wp-content/themes/pub/wporg-learn-2020/template-parts/component-submit-idea-cta.php
+++ b/wp-content/themes/pub/wporg-learn-2020/template-parts/component-submit-idea-cta.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Template part for displaying a submit idea CTA
+ *
+ * @link https://codex.wordpress.org/Template_Hierarchy
+ *
+ * @package WPBBP
+ */
+
+$args = wp_parse_args( $args );
+
+?>
+
+<section class="submit-idea-cta">
+	<?php if( isset( $args['icon'] ) ) :?>
+		<div class="content-icon"><span class="dashicons dashicons-<?php echo $args['icon']; ?>"></span></div>
+	<?php endif; ?>
+	<h2><?php _e( 'Have an Idea for a Workshop? Let us know!' ); ?></h2>
+	<a class="button button-primary button-large" href="https://wordcampcentral.survey.fm/learn-wordpress-workshop-application"><?php _e( 'Submit an Idea' ); ?></a>
+</section>


### PR DESCRIPTION
### Description
This PR moves the "Have an Idea for a Workshop? Let us know!" do a template and makes the icon optional (match the designs.) 

See Issue:  #18 