### PR TITLE
Updating workshop presenter application link

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2020/archive-wporg_workshop.php
+++ b/wp-content/themes/pub/wporg-learn-2020/archive-wporg_workshop.php
@@ -12,7 +12,7 @@ get_header();?>
 	<section>
 		<div class="row align-middle between section-heading section-heading--with-space">
 			<h1 class="section-heading_title h2"><?php esc_html_e( 'Workshops', 'wporg-learn' ); ?></h1>
-			<a class="section-heading_link button button-large" href="https://wordcampcentral.survey.fm/learn-wordpress-workshop-application"><?php esc_html_e( 'Submit Workshop Idea', 'wporg-learn' ); ?></a>
+			<a class="section-heading_link button button-large" href="https://learn.wordpress.org/workshop-presenter-application/"><?php esc_html_e( 'Submit Workshop Idea', 'wporg-learn' ); ?></a>
 		</div>
 		<hr>
 		<?php get_template_part( 'template-parts/component', 'featured-workshop' ); ?>

--- a/wp-content/themes/pub/wporg-learn-2020/template-parts/component-submit-idea-cta.php
+++ b/wp-content/themes/pub/wporg-learn-2020/template-parts/component-submit-idea-cta.php
@@ -16,5 +16,5 @@ $args = wp_parse_args( $args );
 		<div class="content-icon"><span class="dashicons dashicons-<?php echo esc_attr( $args['icon'] ); ?>"></span></div>
 	<?php endif; ?>
 	<h2><?php esc_html_e( 'Have an Idea for a Workshop? Let us know!', 'wporg-learn' ); ?></h2>
-	<a class="button button-primary button-large" href="https://wordcampcentral.survey.fm/learn-wordpress-workshop-application"><?php esc_html_e( 'Submit an Idea', 'wporg-learn' ); ?></a>
+	<a class="button button-primary button-large" href="https://learn.wordpress.org/workshop-presenter-application/"><?php esc_html_e( 'Submit an Idea', 'wporg-learn' ); ?></a>
 </section>


### PR DESCRIPTION
This PR changes the link for the workshop presenter application to use a form that will create a ticket in a Learn WordPress mailbox in HelpScout.

Relates #23. 