### PR TITLE
Theme: Use profiles.wordpress.org to show workshop presenter bios

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -3,7 +3,8 @@
 		"WP_DEBUG": true,
 		"SCRIPT_DEBUG": true,
 		"WP_DEBUG_LOG": "/tmp/wp-errors.log",
-		"FS_METHOD": "direct"
+		"FS_METHOD": "direct",
+		"WP_ENVIRONMENT_TYPE": "local"
 	},
 	"core": "WordPress/WordPress#master",
 	"plugins": [],

--- a/wp-content/themes/pub/wporg-learn-2020/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2020/functions.php
@@ -302,6 +302,45 @@ function wporg_get_workshop_presenters( $workshop = null ) {
 }
 
 /**
+ * Get the bio of a user, either from profiles.wordpress.org or usermeta.
+ *
+ * This relies on the availability of the `bpmain_bp_xprofile_data` table, so for local environments
+ * it falls back on values in `usermeta`.
+ *
+ * @param WP_User $user
+ *
+ * @return string
+ */
+function wporg_get_workshop_presenter_bio( WP_User $user ) {
+	global $wpdb;
+
+	$bio = '';
+
+	if ( 'local' !== wp_get_environment_type() ) {
+		$xprofile_field_id = 3;
+
+		$sql = $wpdb->prepare(
+			'
+				SELECT value
+				FROM bpmain_bp_xprofile_data
+				WHERE user_id = %1$d
+				AND field_id = %2$d
+			',
+			$user->ID,
+			$xprofile_field_id
+		);
+
+		$bio = $wpdb->get_var( $sql, ARRAY_A ) ?: ''; // phpcs:ignore WordPress.DB.PreparedSQL -- prepare called above.
+	}
+
+	if ( ! $bio ) {
+		$bio = $user->description;
+	}
+
+	return $bio;
+}
+
+/**
  * Display a featured image, falling back to the VideoPress thumbnail if no featured image was explicitly set.
  *
  * @param WP_Post $post The Workshop post for which we want the thumbnail.

--- a/wp-content/themes/pub/wporg-learn-2020/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2020/functions.php
@@ -330,7 +330,7 @@ function wporg_get_workshop_presenter_bio( WP_User $user ) {
 			$xprofile_field_id
 		);
 
-		$bio = $wpdb->get_var( $sql, ARRAY_A ) ?: ''; // phpcs:ignore WordPress.DB.PreparedSQL -- prepare called above.
+		$bio = $wpdb->get_var( $sql ) ?: ''; // phpcs:ignore WordPress.DB.PreparedSQL -- prepare called above.
 	}
 
 	if ( ! $bio ) {

--- a/wp-content/themes/pub/wporg-learn-2020/template-parts/content-workshop-single.php
+++ b/wp-content/themes/pub/wporg-learn-2020/template-parts/content-workshop-single.php
@@ -23,7 +23,9 @@
 						);
 						?>
 					</div>
-					<p class="col-8 workshop-page_biography"><?php echo esc_html( $presenter->description ); ?></p>
+					<div class="col-8 workshop-page_biography">
+						<?php echo wp_kses_post( wpautop( wporg_get_workshop_presenter_bio( $presenter ) ) ); ?>
+					</div>
 				</section>
 			<?php endforeach; ?>
 		</div>


### PR DESCRIPTION
This makes a user's wporg profile the canonical source for their
biography blurb when they are listed as a presenter for a workshop.
Since it relies on a db table that won't exist in local dev
environments, and because some people haven't filled out their
wporg profile fields, it falls back on the description usermeta field
if the wporg profile's "About Me" field is blank.

Fixes 106