### PR TITLE
Lesson Plans: Add input IU for adding links to slides

### DIFF
--- a/wp-content/plugins/wporg-learn/views/metabox-lesson-plan-slides.php
+++ b/wp-content/plugins/wporg-learn/views/metabox-lesson-plan-slides.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace WPOrg_Learn\View\Metabox;
+
+use WP_Post;
+
+defined( 'WPINC' ) || die();
+
+/** @var WP_Post $post */
+?>
+
+<p>
+	<label for="lesson-plan-slides-view-url"><?php esc_html_e( 'View URL', 'wporg_learn' ); ?></label>
+	<input
+		type="url"
+		name="slides-view-url"
+		id="lesson-plan-slides-view-url"
+		class="large-text"
+		value="<?php echo esc_attr( $post->slides_view_url ); ?>"
+	/>
+</p>
+
+<p>
+	<label for="lesson-plan-slides-download-url"><?php esc_html_e( 'Download URL', 'wporg_learn' ); ?></label>
+	<input
+		type="url"
+		name="slides-download-url"
+		id="lesson-plan-slides-download-url"
+		class="large-text"
+		value="<?php echo esc_attr( $post->slides_download_url ); ?>"
+	/>
+</p>
+
+<?php wp_nonce_field( 'lesson-plan-metaboxes', 'lesson-plan-metabox-nonce' ); ?>

--- a/wp-content/themes/pub/wporg-learn-2020/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2020/functions.php
@@ -204,24 +204,6 @@ function wporg_post_type_is_lesson() {
 }
 
 /**
- * Returns the custom field view_lesson_plan_slides_url, if it doesn't exists returns false
- *
- * @return string|bool
- */
-function wporg_get_slides_url() {
-	return get_post_meta( get_the_ID(), 'view_lesson_plan_slides_url', true );
-}
-
-/**
- * Returns the custom field download_lesson_plan_slides_url, if it doesn't exists returns false
- *
- * @return string|bool
- */
-function wporg_get_download_slides_url() {
-	return get_post_meta( get_the_ID(), 'download_lesson_plan_slides_url', true );
-}
-
-/**
  * Modify the excerpt length for our custom post types.
  *
  * @param int $length Excerpt length.

--- a/wp-content/themes/pub/wporg-learn-2020/template-parts/content-single.php
+++ b/wp-content/themes/pub/wporg-learn-2020/template-parts/content-single.php
@@ -7,8 +7,6 @@
  * @package WPBBP
  */
 
-$slides_url   = wporg_get_slides_url();
-$download_url = wporg_get_download_slides_url();
 ?>
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
@@ -43,21 +41,27 @@ $download_url = wporg_get_download_slides_url();
 					</ul>
 
 					<ul class="lp-links">
-
-					<?php if ( $slides_url ) : ?>
-						<li>
-							<a href="<?php echo esc_url( $slides_url ); ?>" target="_blank"><span class="dashicons dashicons-admin-page"></span> <?php esc_html_e( 'View Lesson Plan Slides', 'wporg-learn' ); ?></a>
-						</li>
-					<?php endif; ?>
-
-					<?php if ( $download_url ) : ?>
-						<li>
-							<a href="<?php echo esc_url( $download_url ); ?>"><span class="dashicons dashicons-download"></span> <?php esc_html_e( 'Download Lesson Slides', 'wporg-learn' ); ?></a>
-						</li>
-					<?php endif; ?>
-			
+						<?php if ( $post->slides_view_url ) : ?>
+							<li>
+								<a href="<?php echo esc_attr( $post->slides_view_url ); ?>" target="_blank">
+									<span class="dashicons dashicons-admin-page"></span>
+									<?php esc_html_e( 'View Lesson Plan Slides', 'wporg-learn' ); ?>
+								</a>
+							</li>
+						<?php endif; ?>
+						<?php if ( $post->slides_download_url ) : ?>
+							<li>
+								<a href="<?php echo esc_attr( $post->slides_download_url ); ?>">
+									<span class="dashicons dashicons-download"></span>
+									<?php esc_html_e( 'Download Lesson Slides', 'wporg-learn' ); ?>
+								</a>
+							</li>
+						<?php endif; ?>
 						<!-- <li>
-							<a href="#" target="_blank"><span class="dashicons dashicons-admin-post"></span> <?php esc_html_e( 'Print Lesson Plan', 'wporg-learn' ); ?></a>
+							<a href="#" target="_blank">
+								<span class="dashicons dashicons-admin-post"></span>
+								<?php esc_html_e( 'Print Lesson Plan', 'wporg-learn' ); ?>
+							</a>
 						</li> -->
 					</ul>
 


### PR DESCRIPTION
Adds a "Slides" metabox to the Edit Lesson Plan screen with inputs for "View URL" and "Download URL". The corresponding postmeta keys are checked in the Lesson Plan single page template and buttons are displayed if URL values are available.

<img src="https://user-images.githubusercontent.com/916023/99737483-41e90180-2a7d-11eb-8c01-a5a8304de2a2.jpg" width="272" height="auto" />

Fixes #151 