### PR TITLE
Fix for duplicate lesson plans

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2020/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2020/functions.php
@@ -82,6 +82,7 @@ function wporg_get_tax_slugs_from_workshop() {
  */
 function wporg_get_lesson_plans_by_tax_slugs_query( $slugs ) {
 	$args = array(
+		'order'     => 'asc',
 		'post_type' => 'lesson-plan',
 		'tax_query' => array(
 			array(


### PR DESCRIPTION
Fix for [#116 ](https://github.com/WordPress/learn/issues/116)
Adds an order argument to the lesson plan query so pagination is reliable.