### PR TITLE
Theme: Add workaround to mitigate SyntaxHighlighter html entities bug

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2020/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2020/functions.php
@@ -623,3 +623,17 @@ function wporg_learn_noindex( $noindex ) {
 	return $noindex;
 }
 add_filter( 'wporg_noindex_request', 'wporg_learn_noindex' );
+
+/**
+ * Fixes bug in (or at least in using) SyntaxHighlighter code shortcodes that
+ * causes double-encoding of `>` character.
+ *
+ * Copied from themes/pub/wporg-developer/inc/formatting.php
+ *
+ * @param string $content The text being handled as code.
+ * @return string
+ */
+function wporg_learn_fix_code_entity_encoding( $content ) {
+	return str_replace( '&amp;gt;', '&gt;', $content );
+}
+add_filter( 'syntaxhighlighter_htmlresult', 'wporg_learn_fix_code_entity_encoding', 20 );


### PR DESCRIPTION
In some cases the `>` is getting double encoded. In lesson plans, for example, this is causing all code snippets to have `&gt;` instead of `>`. This simply undoes the double-encoding. Ideally this can get fixed upstream.

See https://github.com/Automattic/syntaxhighlighter/issues/108

Fixes #158