### PR TITLE
Try to force screen readers to use select instead of select2

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2020/js/filters.js
+++ b/wp-content/themes/pub/wporg-learn-2020/js/filters.js
@@ -8,5 +8,11 @@
 		$( '.filter-group-select' ).select2( {
 			allowClear: true,
 		} );
+
+		// Try to force screen readers to use select element and hide select2
+		if ( $( '.filter-group-select' ).hasClass( 'select2-hidden-accessible' ) ) {
+			$( '.selection' ).attr( { 'aria-hidden': 'true', 'tabindex': '-1' } );
+			$( '.filter-group-select' ).removeAttr( 'aria-hidden' ).attr( 'tabindex', '0' );
+		}
 	} );
 } )( jQuery );


### PR DESCRIPTION
Due to the way select2 implements fake selects, it does not allow the HTML label to be assigned to the element causing an accessibility issue. This fix will allow screen readers to use select and select2 to be inaccessible by screen readers. There's a reason why the good old select combo box should be here to stay, it's accessible and it works.

I tried to test this as best I could on Mac, not sure how this will play on Windows because my computer is too old to run Docker. I am thinking accessibility will be a lot better this way.