### PR TITLE
Lesson Plans: Add ID to sort order to prevent "random" sorting.

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2020/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2020/functions.php
@@ -243,16 +243,6 @@ function wporg_archive_modify_query( WP_Query $query ) {
 
 	if ( $query->is_main_query() && $query->is_post_type_archive( $valid_post_types ) ) {
 		wporg_archive_maybe_apply_query_filters( $query );
-		// Some lesson plans were created at exactly the same second, so we're adding the ID to the implicit sort order to avoid randomization.
-		if ( $query->is_post_type_archive( 'lesson-plan' ) && empty( $query->get( 'orderby' ) ) ) {
-			$query->set(
-				'orderby',
-				array(
-					'post_date' => 'DESC',
-					'ID' => 'ASC',
-				)
-			);
-		}
 
 		if ( $query->is_post_type_archive( 'wporg_workshop' ) && true !== $query->get( 'wporg_workshop_filters' ) ) {
 			$featured = wporg_get_featured_workshops();
@@ -262,6 +252,20 @@ function wporg_archive_modify_query( WP_Query $query ) {
 				$query->set( 'post__not_in', array( $featured->ID ) );
 			}
 		}
+	}
+
+	// Some lesson plans were created at exactly the same second, so we're adding the ID to the implicit sort order to avoid randomization.
+	if (
+		( $query->is_post_type_archive( 'lesson-plan' ) || $query->is_tax( 'wporg_lesson_category' ) ) &&
+		empty( $query->get( 'orderby' ) )
+	) {
+		$query->set(
+			'orderby',
+			array(
+				'post_date' => 'DESC',
+				'ID' => 'ASC',
+			)
+		);
 	}
 
 	if ( $query->is_main_query() && $query->is_tax( 'wporg_workshop_series' ) ) {

--- a/wp-content/themes/pub/wporg-learn-2020/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2020/functions.php
@@ -243,6 +243,16 @@ function wporg_archive_modify_query( WP_Query $query ) {
 
 	if ( $query->is_main_query() && $query->is_post_type_archive( $valid_post_types ) ) {
 		wporg_archive_maybe_apply_query_filters( $query );
+		// Some lesson plans were created at exactly the same second, so we're adding the ID to the implicit sort order to avoid randomization.
+		if ( $query->is_post_type_archive( 'lesson-plan' ) && empty( $query->get( 'orderby' ) ) ) {
+			$query->set(
+				'orderby',
+				array(
+					'post_date' => 'DESC',
+					'ID' => 'ASC',
+				)
+			);
+		}
 
 		if ( $query->is_post_type_archive( 'wporg_workshop' ) && true !== $query->get( 'wporg_workshop_filters' ) ) {
 			$featured = wporg_get_featured_workshops();


### PR DESCRIPTION
Some lesson plans were created at exactly the same second, so ordering by date becomes somewhat random. This is noticeable across pages, where some lesson plans would show up on page 1 and page 2 of the archive due to how the SQL queries work.  In this PR, I've explicitly set the sort order, using date descending and ID ascending, so it will go in order of post creation.

I didn't swap fully to post ID sorting in case users want to change the post dates.

Fixes #116.

To test:

- Check on production since it has the edge-case data
- There should be no repeat lesson plans between pages
- This should apply to /lesson-plans and the lesson plans by category