### PR TITLE
Move Workshop meta from Inspector panel to Details block

### DIFF
--- a/wp-content/plugins/wporg-learn/inc/post-meta.php
+++ b/wp-content/plugins/wporg-learn/inc/post-meta.php
@@ -17,7 +17,7 @@ add_action( 'init', __NAMESPACE__ . '\register' );
 add_action( 'add_meta_boxes', __NAMESPACE__ . '\add_lesson_plan_metaboxes' );
 add_action( 'add_meta_boxes', __NAMESPACE__ . '\add_workshop_metaboxes' );
 add_action( 'save_post_lesson-plan', __NAMESPACE__ . '\save_lesson_plan_metabox_fields' );
-add_action( 'save_post_wporg_workshop', __NAMESPACE__ . '\save_workshop_metabox_fields' );
+//add_action( 'save_post_wporg_workshop', __NAMESPACE__ . '\save_workshop_metabox_fields' );
 
 /**
  * Register all post meta keys.
@@ -289,21 +289,21 @@ function save_lesson_plan_metabox_fields( $post_id ) {
  * Todo these should be replaced with block editor panels.
  */
 function add_workshop_metaboxes() {
-	add_meta_box(
-		'workshop-details',
-		__( 'Workshop Details', 'wporg_learn' ),
-		__NAMESPACE__ . '\render_metabox_workshop_details',
-		'wporg_workshop',
-		'side'
-	);
-
-	add_meta_box(
-		'workshop-presenters',
-		__( 'Presenters', 'wporg_learn' ),
-		__NAMESPACE__ . '\render_metabox_workshop_presenters',
-		'wporg_workshop',
-		'side'
-	);
+//	add_meta_box(
+//		'workshop-details',
+//		__( 'Workshop Details', 'wporg_learn' ),
+//		__NAMESPACE__ . '\render_metabox_workshop_details',
+//		'wporg_workshop',
+//		'side'
+//	);
+//
+//	add_meta_box(
+//		'workshop-presenters',
+//		__( 'Presenters', 'wporg_learn' ),
+//		__NAMESPACE__ . '\render_metabox_workshop_presenters',
+//		'wporg_workshop',
+//		'side'
+//	);
 
 	add_meta_box(
 		'workshop-application',
@@ -319,31 +319,31 @@ function add_workshop_metaboxes() {
  *
  * @param WP_Post $post
  */
-function render_metabox_workshop_details( WP_Post $post ) {
-	$duration_interval = get_workshop_duration( $post, 'interval' );
-	$locales           = get_locales_with_english_names();
-	$captions          = get_post_meta( $post->ID, 'video_caption_language' ) ?: array();
-	$all_lessons       = get_posts( array(
-		'post_type'      => 'lesson',
-		'post_status'    => 'publish',
-		'posts_per_page' => 999,
-		'orderby'        => 'title',
-		'order'          => 'asc',
-	) );
-
-	require get_views_path() . 'metabox-workshop-details.php';
-}
+//function render_metabox_workshop_details( WP_Post $post ) {
+//	$duration_interval = get_workshop_duration( $post, 'interval' );
+//	$locales           = get_locales_with_english_names();
+//	$captions          = get_post_meta( $post->ID, 'video_caption_language' ) ?: array();
+//	$all_lessons       = get_posts( array(
+//		'post_type'      => 'lesson',
+//		'post_status'    => 'publish',
+//		'posts_per_page' => 999,
+//		'orderby'        => 'title',
+//		'order'          => 'asc',
+//	) );
+//
+//	require get_views_path() . 'metabox-workshop-details.php';
+//}
 
 /**
  * Render the Presenters meta box.
  *
  * @param WP_Post $post
  */
-function render_metabox_workshop_presenters( WP_Post $post ) {
-	$presenters = get_post_meta( $post->ID, 'presenter_wporg_username' ) ?: array();
-
-	require get_views_path() . 'metabox-workshop-presenters.php';
-}
+//function render_metabox_workshop_presenters( WP_Post $post ) {
+//	$presenters = get_post_meta( $post->ID, 'presenter_wporg_username' ) ?: array();
+//
+//	require get_views_path() . 'metabox-workshop-presenters.php';
+//}
 
 /**
  * Render the Original Application meta box.
@@ -365,43 +365,43 @@ function render_metabox_workshop_application( WP_Post $post ) {
  *
  * @param int $post_id
  */
-function save_workshop_metabox_fields( $post_id ) {
-	if ( wp_is_post_revision( $post_id ) || ! current_user_can( 'edit_post', $post_id ) ) {
-		return;
-	}
-
-	// This nonce field is rendered in the Workshop Details metabox.
-	$nonce = filter_input( INPUT_POST, 'workshop-metabox-nonce' );
-	if ( ! wp_verify_nonce( $nonce, 'workshop-metaboxes' ) ) {
-		return;
-	}
-
-	$duration = filter_input( INPUT_POST, 'duration', FILTER_SANITIZE_NUMBER_INT, FILTER_REQUIRE_ARRAY );
-	if ( isset( $duration['h'], $duration['m'], $duration['s'] ) ) {
-		$duration = $duration['h'] * HOUR_IN_SECONDS + $duration['m'] * MINUTE_IN_SECONDS + $duration['s'];
-		update_post_meta( $post_id, 'duration', $duration );
-	}
-
-	$video_language = filter_input( INPUT_POST, 'video-language' );
-	update_post_meta( $post_id, 'video_language', $video_language );
-
-	$captions = filter_input( INPUT_POST, 'video-caption-language', FILTER_DEFAULT, FILTER_REQUIRE_ARRAY );
-	delete_post_meta( $post_id, 'video_caption_language' );
-	if ( is_array( $captions ) ) {
-		foreach ( $captions as $caption ) {
-			add_post_meta( $post_id, 'video_caption_language', $caption );
-		}
-	}
-
-	$lesson_id = filter_input( INPUT_POST, 'linked-lesson-id', FILTER_SANITIZE_NUMBER_INT );
-	update_post_meta( $post_id, 'linked_lesson_id', $lesson_id );
-
-	$presenter_wporg_username = filter_input( INPUT_POST, 'presenter-wporg-username' );
-	$usernames                = array_map( 'trim', explode( ',', $presenter_wporg_username ) );
-	delete_post_meta( $post_id, 'presenter_wporg_username' );
-	if ( is_array( $usernames ) ) {
-		foreach ( $usernames as $username ) {
-			add_post_meta( $post_id, 'presenter_wporg_username', $username );
-		}
-	}
-}
+//function save_workshop_metabox_fields( $post_id ) {
+//	if ( wp_is_post_revision( $post_id ) || ! current_user_can( 'edit_post', $post_id ) ) {
+//		return;
+//	}
+//
+//	// This nonce field is rendered in the Workshop Details metabox.
+//	$nonce = filter_input( INPUT_POST, 'workshop-metabox-nonce' );
+//	if ( ! wp_verify_nonce( $nonce, 'workshop-metaboxes' ) ) {
+//		return;
+//	}
+//
+//	$duration = filter_input( INPUT_POST, 'duration', FILTER_SANITIZE_NUMBER_INT, FILTER_REQUIRE_ARRAY );
+//	if ( isset( $duration['h'], $duration['m'], $duration['s'] ) ) {
+//		$duration = $duration['h'] * HOUR_IN_SECONDS + $duration['m'] * MINUTE_IN_SECONDS + $duration['s'];
+//		update_post_meta( $post_id, 'duration', $duration );
+//	}
+//
+//	$video_language = filter_input( INPUT_POST, 'video-language' );
+//	update_post_meta( $post_id, 'video_language', $video_language );
+//
+//	$captions = filter_input( INPUT_POST, 'video-caption-language', FILTER_DEFAULT, FILTER_REQUIRE_ARRAY );
+//	delete_post_meta( $post_id, 'video_caption_language' );
+//	if ( is_array( $captions ) ) {
+//		foreach ( $captions as $caption ) {
+//			add_post_meta( $post_id, 'video_caption_language', $caption );
+//		}
+//	}
+//
+//	$lesson_id = filter_input( INPUT_POST, 'linked-lesson-id', FILTER_SANITIZE_NUMBER_INT );
+//	update_post_meta( $post_id, 'linked_lesson_id', $lesson_id );
+//
+//	$presenter_wporg_username = filter_input( INPUT_POST, 'presenter-wporg-username' );
+//	$usernames                = array_map( 'trim', explode( ',', $presenter_wporg_username ) );
+//	delete_post_meta( $post_id, 'presenter_wporg_username' );
+//	if ( is_array( $usernames ) ) {
+//		foreach ( $usernames as $username ) {
+//			add_post_meta( $post_id, 'presenter_wporg_username', $username );
+//		}
+//	}
+//}

--- a/wp-content/plugins/wporg-learn/inc/post-type.php
+++ b/wp-content/plugins/wporg-learn/inc/post-type.php
@@ -210,28 +210,31 @@ function generate_workshop_template_structure() {
 					array(
 						'className' => 'workshop-page_sidebar',
 						'width'     => '33.333%',
+						'templateLock' => 'all',
+							// ^ not working. should prevent add/removing blocks to the column
+							// only want to change inputs inside thw details block
 					),
 					array(
 						array( 'wporg-learn/workshop-details' ),
-						array(
-							'core/button',
-							array(
-								'className'    => 'is-style-secondary-full-width',
-								'text'         => __( 'Join a Group Discussion', 'wporg-learn' ),
-								'url'          => 'https://www.meetup.com/learn-wordpress-discussions/events/',
-								'borderRadius' => 5,
-							),
-						),
-						array(
-							'core/paragraph',
-							array(
-								'className' => 'terms',
-								'content'   => sprintf(
-									__( 'You must agree to our <a href="%s">Code of Conduct</a> in order to participate.', 'wporg-learn' ),
-									'https://learn.wordpress.org/code-of-conduct/'
-								),
-							),
-						),
+//						array(
+//							'core/button',
+//							array(
+//								'className'    => 'is-style-secondary-full-width',
+//								'text'         => __( 'Join a Group Discussion', 'wporg-learn' ),
+//								'url'          => 'https://www.meetup.com/learn-wordpress-discussions/events/',
+//								'borderRadius' => 5,
+//							),
+//						),
+//						array(
+//							'core/paragraph',
+//							array(
+//								'className' => 'terms',
+//								'content'   => sprintf(
+//									__( 'You must agree to our <a href="%s">Code of Conduct</a> in order to participate.', 'wporg-learn' ),
+//									'https://learn.wordpress.org/code-of-conduct/'
+//								),
+//							),
+//						),
 					),
 				), // End column block.
 			),

--- a/wp-content/plugins/wporg-learn/js/workshop-details/src/edit.js
+++ b/wp-content/plugins/wporg-learn/js/workshop-details/src/edit.js
@@ -1,18 +1,115 @@
 /**
  * WordPress dependencies
  */
+import { useBlockProps } from '@wordpress/block-editor';
+import { TextControl } from '@wordpress/components';
+import { useEntityProp } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { Placeholder } from '@wordpress/components';
 
-export default function Edit() {
-	return (
-		<Placeholder label={ __( 'Workshop Details', 'wporg-learn' ) }>
-			<p>
-				{ __(
-					'This will be dynamically populated based on settings in the Workshop Details meta box.',
-					'wporg-learn'
-				) }
+
+export default function Edit( { setAttributes, attributes } ) {
+	const blockProps = useBlockProps();
+
+    const postType = useSelect(
+        ( select ) => select( 'core/editor' ).getCurrentPostType(),
+        []
+    );
+
+	const [ meta, setMeta ] = useEntityProp( 'postType', postType, 'meta' );
+
+	//console.log( meta);
+
+	//Temporary work around for https://core.trac.wordpress.org/ticket/52787
+	for ( const [ key, value ] of Object.entries( meta ) ) {
+		if ( Array.isArray( value ) && 0 === value.length ) {
+			delete meta[ key ];
+		}
+	}
+
+    function updateMetaValue( key, value ) {
+	    meta[ key ] = value;
+
+        setMeta( { meta } );
+    }
+
+    return (
+        <div { ...blockProps }>
+
+	        {/* change all these to more specific UI components that match their data, e.g., dropdowns, etc*/}
+
+	        <p>
+	            <TextControl
+	                label="duration"
+	                value={ meta['duration'] }
+	                onChange={ value => updateMetaValue( 'duration', value ) }
+	            />
+	            {/* hour minite seconds - have to present ui in sep fields, or can combine and still keep separate in db?
+	            use <time> ? */}
 			</p>
-		</Placeholder>
-	);
+
+	        <p>
+	            <TextControl
+	                label="presenter_wporg_username"
+	                value={ ( meta['presenter_wporg_username'] || [] ).join( ', ' ) }
+	                onChange={ value => updateMetaValue( 'presenter_wporg_username', value.replace( ' ', '' ).split( ',' ) ) }
+	            />
+	            {/*
+					- selectwoo multi? no b/c 12m users.
+					- tags instead of freeform? no b/c already using postmeta. unless can keep in postmeta but use tag ui
+	            */}
+            </p>
+
+	        <p>
+	            Language
+		        <select>
+			        <option>
+				        Esperantu
+			        </option>
+		        </select>
+		        {/* selectWoo or the native G components corey's working on */}
+	        </p>
+
+	    <p>
+		        Captions
+	</p>
+
+		<p>
+		        Linked Quiz
+		        <select>
+			        <option>
+				        Esperantu
+			        </option>
+		        </select>
+		        {/* selectWoo or the native G components corey's working on */}
+	</p>
+
+	        <p>
+		        <button>join a group discussion</button>
+</p>
+
+			<p>
+			    You must agree to our <a href="%s">Code of Conduct</a> in order to participate
+						{/*https://learn.wordpress.org/code-of-conduct/*/}
+			</p>
+        </div>
+
+	    // translate strings
+	    // make sure the html, css, etc for all ^ matches the front end, maybe make it DRY
+	    // how are old posts affected, especially on the front end? need a flag to separate old from new?
+	    // make sure to test all the optional fields on the front end
+    );
+
+	/*
+
+	move old stuff here
+	any changes to front end?
+	make sure update all code that references this stuff - should be limited though b/c still storing in postmeta
+
+	pr explain
+		better UX b/c WYSIWYG, don't have to deal w/ expanding/collapsing inspector panels
+		reduces the problems laid out in #195 by consoloading into a single block
+		lets us add/edit future posts w/out having to change past posts (won't apply retoriactively)
+
+	*/
 }

--- a/wp-content/plugins/wporg-learn/js/workshop-details/src/index.js
+++ b/wp-content/plugins/wporg-learn/js/workshop-details/src/index.js
@@ -1,24 +1,9 @@
-/**
- * Registers a new block provided a unique name and an object defining its behavior.
- *
- * @see https://developer.wordpress.org/block-editor/developers/block-api/#registering-a-block
+/*
+ * WordPress dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
-
-/**
- * Retrieves the translation of text.
- *
- * @see https://developer.wordpress.org/block-editor/packages/packages-i18n/
- */
 import { __ } from '@wordpress/i18n';
 
-/**
- * Lets webpack process CSS, SASS or SCSS files referenced in JavaScript files.
- * All files containing `style` keyword are bundled together. The code used
- * gets applied both to the front of your site and to the editor.
- *
- * @see https://www.npmjs.com/package/@wordpress/scripts#using-css
- */
 import './style.scss';
 
 /**
@@ -26,54 +11,19 @@ import './style.scss';
  */
 import Edit from './edit';
 
-/**
- * Every block starts by registering a new block type definition.
- *
- * @see https://developer.wordpress.org/block-editor/developers/block-api/#registering-a-block
- */
-registerBlockType( 'wporg-learn/workshop-details', {
-	/**
-	 * This is the display title for your block, which can be translated with `i18n` functions.
-	 * The block inserter will show this name.
-	 */
-	title: __( 'Workshop Details', 'wporg-learn' ),
 
-	/**
-	 * This is a short description for your block, can be translated with `i18n` functions.
-	 * It will be shown in the Block Tab in the Settings Sidebar.
-	 */
+registerBlockType( 'wporg-learn/workshop-details', {
+	title: __( 'Workshop Details', 'wporg-learn' ),
 	description: __(
 		'Show details about the workshop, pulled from post meta.',
 		'wporg-learn'
 	),
-
-	/**
-	 * Blocks are grouped into categories to help users browse and discover them.
-	 * The categories provided by core are `common`, `embed`, `formatting`, `layout` and `widgets`.
-	 */
 	category: 'widgets',
-
-	/**
-	 * An icon property should be specified to make it easier to identify a block.
-	 * These can be any of WordPress’ Dashicons, or a custom svg element.
-	 */
 	icon: 'smiley',
-
-	/**
-	 * Optional block extended support features.
-	 */
 	supports: {
-		// Removes support for an HTML mode.
 		html: false,
 	},
 
-	/**
-	 * @see ./edit.js
-	 */
 	edit: Edit,
-
-	/**
-	 * @see ./save.js
-	 */
 	save: () => null,
 } );

--- a/wp-content/plugins/wporg-learn/views/block-workshop-details.php
+++ b/wp-content/plugins/wporg-learn/views/block-workshop-details.php
@@ -27,4 +27,19 @@ defined( 'WPINC' ) || die();
 			</a>
 		</div>
 	<?php endif; ?>
+
+	<div class="wp-block-button is-style-secondary-full-width">
+		<a class="wp-block-button__link" href="https://www.meetup.com/learn-wordpress-discussions/events/" style="border-radius:5px">
+			<?php esc_html_e( 'Join a Group Discussion', 'wporg-learn' ); ?>
+		</a>
+	</div>
+
+	<p class="terms">
+		<?php
+		printf(
+			wp_kses_post( __( 'You must agree to our <a href="%s">Code of Conduct</a> in order to participate.', 'wporg-learn' ) ),
+			'https://learn.wordpress.org/code-of-conduct/'
+		);
+		?>
+	</p>
 </div>


### PR DESCRIPTION
_This is a rough WIP to get early feedback on the idea._

The faux meta boxes were removed, and the content there was put inside the Details block instead.

![Screen Shot 2021-03-22 at 9 27 59 AM](https://user-images.githubusercontent.com/484068/112027842-d24f5580-8af4-11eb-9ce4-a77d57cd1ce4.png)

Inspector panels are inconvenient to work with, having this content in the block itself feels truer to Gutenberg's promise that WYSIWYG. That also lets us render things like the "Join..." button and CoC link programmatically, instead of hardcoding it in `post_content` (see #195 for details on the problem that solves).

The data like Duration is still saved to post meta like before.

Related #200