### PR TITLE
Workshops: Move layout elements from `post_content` to theme.

### DIFF
--- a/wp-content/plugins/wporg-learn/inc/post-meta.php
+++ b/wp-content/plugins/wporg-learn/inc/post-meta.php
@@ -376,6 +376,9 @@ function save_workshop_metabox_fields( $post_id ) {
 		return;
 	}
 
+	$video_url = filter_input( INPUT_POST, 'video-url', FILTER_SANITIZE_URL );
+	update_post_meta( $post_id, 'video_url', esc_url_raw( $video_url ) );
+
 	$duration = filter_input( INPUT_POST, 'duration', FILTER_SANITIZE_NUMBER_INT, FILTER_REQUIRE_ARRAY );
 	if ( isset( $duration['h'], $duration['m'], $duration['s'] ) ) {
 		$duration = $duration['h'] * HOUR_IN_SECONDS + $duration['m'] * MINUTE_IN_SECONDS + $duration['s'];

--- a/wp-content/plugins/wporg-learn/inc/post-meta.php
+++ b/wp-content/plugins/wporg-learn/inc/post-meta.php
@@ -68,6 +68,18 @@ function register_workshop_meta() {
 
 	register_post_meta(
 		$post_type,
+		'video_url',
+		array(
+			'description'       => __( "The URL of the Workshop's video.", 'wporg_learn' ),
+			'type'              => 'string',
+			'single'            => true,
+			'sanitize_callback' => 'esc_url_raw',
+			'show_in_rest'      => true,
+		)
+	);
+
+	register_post_meta(
+		$post_type,
 		'duration',
 		array(
 			'description'       => __( 'The duration in seconds of the workshop. Should be converted to a human readable string for display.', 'wporg_learn' ),
@@ -377,7 +389,7 @@ function save_workshop_metabox_fields( $post_id ) {
 	}
 
 	$video_url = filter_input( INPUT_POST, 'video-url', FILTER_SANITIZE_URL );
-	update_post_meta( $post_id, 'video_url', esc_url_raw( $video_url ) );
+	update_post_meta( $post_id, 'video_url', $video_url );
 
 	$duration = filter_input( INPUT_POST, 'duration', FILTER_SANITIZE_NUMBER_INT, FILTER_REQUIRE_ARRAY );
 	if ( isset( $duration['h'], $duration['m'], $duration['s'] ) ) {

--- a/wp-content/plugins/wporg-learn/inc/post-type.php
+++ b/wp-content/plugins/wporg-learn/inc/post-type.php
@@ -148,7 +148,7 @@ function register_workshop() {
 /**
  * Create an array representation of a workshop's content template.
  *
- * Note that if this template structure changes, the content in views/content-workshop.php
+ * ⚠️ Note that if this template structure changes, the content in views/content-workshop.php
  * will also need to be updated.
  *
  * @return array
@@ -156,87 +156,42 @@ function register_workshop() {
 function generate_workshop_template_structure() {
 	$template = array(
 		array(
-			'core/embed',
+			'core/paragraph',
 			array(
-				'className'        => 'workshop-page_video',
-				'providerNameSlug' => 'wordpress-tv',
+				'placeholder' => __( 'Describe what the workshop is about.', 'wporg-learn' ),
+			),
+		),
+
+		// Learning outcomes
+		array(
+			'core/heading',
+			array(
+				'level'   => '2',
+				'content' => __( 'Learning outcomes', 'wporg-learn' ),
 			),
 		),
 		array(
-			'core/columns',
-			array( 'className' => 'workshop-page_content' ),
+			'core/list',
 			array(
-				array(
-					'core/column',
-					array( 'width' => '66.66%' ),
-					array(
-						array(
-							'core/paragraph',
-							array(
-								'placeholder' => __( 'Describe what the workshop is about.', 'wporg-learn' ),
-							),
-						),
-						array(
-							'core/heading',
-							array(
-								'level'   => '2',
-								'content' => __( 'Learning outcomes', 'wporg-learn' ),
-							),
-						),
-						array(
-							'core/list',
-							array(
-								'className' => 'workshop-page_list',
-								'ordered'   => true,
-							),
-						),
-						array(
-							'core/heading',
-							array(
-								'level'   => '2',
-								'content' => __( 'Comprehension questions', 'wporg-learn' ),
-							),
-						),
-						array(
-							'core/list',
-							array(
-								'className' => 'workshop-page_list',
-							),
-						),
-					),
-				), // End column block.
-				array(
-					'core/column',
-					array(
-						'className' => 'workshop-page_sidebar',
-						'width'     => '33.333%',
-					),
-					array(
-						array( 'wporg-learn/workshop-details' ),
-						array(
-							'core/button',
-							array(
-								'className'    => 'is-style-secondary-full-width',
-								'text'         => __( 'Join a Group Discussion', 'wporg-learn' ),
-								'url'          => 'https://www.meetup.com/learn-wordpress-discussions/events/',
-								'borderRadius' => 5,
-							),
-						),
-						array(
-							'core/paragraph',
-							array(
-								'className' => 'terms',
-								'content'   => sprintf(
-									__( 'You must agree to our <a href="%s">Code of Conduct</a> in order to participate.', 'wporg-learn' ),
-									'https://learn.wordpress.org/code-of-conduct/'
-								),
-							),
-						),
-					),
-				), // End column block.
+				'className' => 'workshop-page_list',
+				'ordered'   => true,
 			),
-		), // End columns block.
-		array( 'core/separator' ),
+		),
+
+		// Comprehension questions
+		array(
+			'core/heading',
+			array(
+				'level'   => '2',
+				'content' => __( 'Comprehension questions', 'wporg-learn' ),
+			),
+		),
+		array(
+			'core/list',
+			array(
+				'className' => 'workshop-page_list',
+			),
+		),
 	);
 
 	return $template;

--- a/wp-content/plugins/wporg-learn/inc/post-type.php
+++ b/wp-content/plugins/wporg-learn/inc/post-type.php
@@ -137,7 +137,6 @@ function register_workshop() {
 		'publicly_queryable'  => true,
 		'capability_type'     => 'page',
 		'show_in_rest'        => true,
-		'template_lock'       => 'all',
 		'rewrite'             => array( 'slug' => 'workshop' ),
 		'template'            => generate_workshop_template_structure(),
 	);

--- a/wp-content/plugins/wporg-learn/views/content-workshop.php
+++ b/wp-content/plugins/wporg-learn/views/content-workshop.php
@@ -1,69 +1,37 @@
 <?php
+
 /**
  * Content for auto-generated workshop posts.
  *
- * Note that if the template for the workshop post type changes, this will need to be updated as well.
+ * ⚠️ Note that if the template for the workshop post type changes, this will need to be updated as well.
+ *
+ * phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- The data from this file is being saved to
+ * the database rather than output; therefore it should be validated rather than escaped. It's validated by
+ * `validate_workshop_application_form_submission()`, which strips all HTML tags.
  */
 
 /** @var array $blurbs */
+
 ?>
-<!-- wp:core-embed/wordpress-tv {"className":"workshop-page_video"} /-->
 
-<!-- wp:columns {"className":"workshop-page_content"} -->
-<div class="wp-block-columns workshop-page_content">
-	<!-- wp:column {"width":66.66} -->
-	<div class="wp-block-column" style="flex-basis:66.66%">
-		<?php echo $blurbs['description']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+<?php echo $blurbs['description']; ?>
 
-		<!-- wp:heading {"level":"2"} -->
-		<h2><?php esc_html_e( 'Learning outcomes', 'wporg-learn' ); ?></h2>
-		<!-- /wp:heading -->
+<!-- wp:heading {"level":"2"} -->
+<h2><?php esc_html_e( 'Learning outcomes', 'wporg-learn' ); ?></h2>
+<!-- /wp:heading -->
 
-		<!-- wp:list {"ordered":true,"className":"workshop-page_list"} -->
-		<ol class="workshop-page_list">
-			<?php echo $blurbs['learning-objectives']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-		</ol>
-		<!-- /wp:list -->
+<!-- wp:list {"ordered":true,"className":"workshop-page_list"} -->
+<ol class="workshop-page_list">
+	<?php echo $blurbs['learning-objectives']; ?>
+</ol>
+<!-- /wp:list -->
 
-		<!-- wp:heading {"level":"2"} -->
-		<h2><?php esc_html_e( 'Comprehension questions', 'wporg-learn' ); ?></h2>
-		<!-- /wp:heading -->
+<!-- wp:heading {"level":"2"} -->
+<h2><?php esc_html_e( 'Comprehension questions', 'wporg-learn' ); ?></h2>
+<!-- /wp:heading -->
 
-		<!-- wp:list {"className":"workshop-page_list"} -->
-		<ul class="workshop-page_list">
-			<?php echo $blurbs['comprehension-questions']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-		</ul>
-		<!-- /wp:list -->
-	</div>
-	<!-- /wp:column -->
-
-	<!-- wp:column {"width":33.333,"className":"workshop-page_sidebar"} -->
-	<div class="wp-block-column workshop-page_sidebar" style="flex-basis:33.333%">
-		<!-- wp:wporg-learn/workshop-details /-->
-
-		<!-- wp:button {"borderRadius":5,"className":"is-style-secondary-full-width"} -->
-		<div class="wp-block-button is-style-secondary-full-width">
-			<a class="wp-block-button__link" href="https://www.meetup.com/learn-wordpress-discussions/events/" style="border-radius:5px">
-				<?php esc_html_e( 'Join a Group Discussion', 'wporg-learn' ); ?>
-			</a>
-		</div>
-		<!-- /wp:button -->
-
-		<!-- wp:paragraph {"className":"terms"} -->
-		<p class="terms">
-			<?php
-			printf(
-				wp_kses_post( __( 'You must agree to our <a href="%s">Code of Conduct</a> in order to participate.', 'wporg-learn' ) ),
-				'https://learn.wordpress.org/code-of-conduct/'
-			);
-			?>
-		</p>
-		<!-- /wp:paragraph -->
-	</div>
-	<!-- /wp:column -->
-</div>
-<!-- /wp:columns -->
-
-<!-- wp:separator -->
-<hr class="wp-block-separator"/>
-<!-- /wp:separator -->
+<!-- wp:list {"className":"workshop-page_list"} -->
+<ul class="workshop-page_list">
+	<?php echo $blurbs['comprehension-questions']; ?>
+</ul>
+<!-- /wp:list -->

--- a/wp-content/plugins/wporg-learn/views/metabox-workshop-details.php
+++ b/wp-content/plugins/wporg-learn/views/metabox-workshop-details.php
@@ -12,6 +12,18 @@
 ?>
 
 <p>
+	<label><?php esc_html_e( 'WordPress.tv URL', 'wporg_learn' ); ?></label><br />
+	<label for="workshop-video-url">
+		<textarea
+			id="workshop-video-url"
+			name="video-url"
+			class="large-text"
+			rows="4"
+		><?php echo esc_url( $post->video_url ); ?></textarea>
+	</label>
+</p>
+
+<p>
 	<label><?php esc_html_e( 'Duration', 'wporg_learn' ); ?></label><br />
 	<label for="workshop-duration-hours">
 		<input
@@ -20,6 +32,7 @@
 			class="tiny-text"
 			type="number"
 			value="<?php echo absint( $duration_interval->h ); ?>"
+			min="0"
 			max="23"
 		/>
 		<?php esc_html_e( 'hours', 'wporg_learn' ); ?>
@@ -31,6 +44,7 @@
 			class="tiny-text"
 			type="number"
 			value="<?php echo absint( $duration_interval->i ); ?>"
+			min="0"
 			max="59"
 		/>
 		<?php esc_html_e( 'minutes', 'wporg_learn' ); ?>
@@ -42,6 +56,7 @@
 				class="tiny-text"
 				type="number"
 				value="<?php echo absint( $duration_interval->s ); ?>"
+				min="0"
 				max="59"
 		/>
 		<?php esc_html_e( 'seconds', 'wporg_learn' ); ?>

--- a/wp-content/themes/pub/wporg-learn-2020/single-wporg_workshop.php
+++ b/wp-content/themes/pub/wporg-learn-2020/single-wporg_workshop.php
@@ -18,7 +18,9 @@ get_header();
 			 * newer posts only store prose there. Meta data, layout, etc is handled in
 			 * `content-workshop-single.php`.
 			 */
-			$layout_hardcoded = has_block( 'core/columns' ) && has_block( 'core/separator' );
+			$layout_hardcoded = has_block( 'core/columns' )
+				&& has_block( 'wporg-learn/workshop-details' )
+				&& has_block( 'core/separator' );
 
 			if ( $layout_hardcoded ) {
 				get_template_part( 'template-parts/content', 'workshop-single-hardcoded' );

--- a/wp-content/themes/pub/wporg-learn-2020/single-wporg_workshop.php
+++ b/wp-content/themes/pub/wporg-learn-2020/single-wporg_workshop.php
@@ -12,7 +12,19 @@ get_header();
 		<?php
 		while ( have_posts() ) {
 			the_post();
-			get_template_part( 'template-parts/content', 'workshop-single' );
+
+			/*
+			 * Old posts have the layout and presentation of meta data hardcoded into `post_content`, but
+			 * newer posts only store prose there. Meta data, layout, etc is handled in
+			 * `content-workshop-single.php`.
+			 */
+			$layout_hardcoded = has_block( 'core/columns' ) && has_block( 'core/separator' );
+
+			if ( $layout_hardcoded ) {
+				get_template_part( 'template-parts/content', 'workshop-single-hardcoded' );
+			} else {
+				get_template_part( 'template-parts/content', 'workshop-single' );
+			}
 		}
 		?>
 	</main><!-- #main -->

--- a/wp-content/themes/pub/wporg-learn-2020/template-parts/content-workshop-single-hardcoded.php
+++ b/wp-content/themes/pub/wporg-learn-2020/template-parts/content-workshop-single-hardcoded.php
@@ -1,0 +1,40 @@
+<?php
+/*
+ * This deprecated template is for old posts that have Column/Embed/etc blocks hardcoded into `post_content`.
+ * See `single-wporg_workshop.php`.
+ */
+
+?>
+<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+	<section>
+		<div class="row align-middle between section-heading section-heading--with-space">
+			<h1 class="section-heading_title h2"><?php the_title(); ?></h1>
+		</div>
+		<hr>
+		<div class="workshop-page">
+			<?php the_content(); ?>
+			<?php if ( is_object_in_term( get_the_ID(), 'wporg_workshop_series' ) ) : ?>
+				<?php get_template_part( 'template-parts/component', 'series-navigation' ); ?>
+				<hr class="wp-block-separator" />
+			<?php endif; ?>
+			<?php foreach ( wporg_get_workshop_presenters() as $presenter ) : ?>
+				<section class="row workshop-page_section"">
+					<div class="col-4">
+						<?php
+						get_template_part(
+							'template-parts/component',
+							'workshop-presenter',
+							array(
+								'presenter' => $presenter,
+							)
+						);
+						?>
+					</div>
+					<div class="col-8 workshop-page_biography">
+						<?php echo wp_kses_data( wpautop( wporg_get_workshop_presenter_bio( $presenter ) ) ); ?>
+					</div>
+				</section>
+			<?php endforeach; ?>
+		</div>
+	</section>
+</article>

--- a/wp-content/themes/pub/wporg-learn-2020/template-parts/content-workshop-single.php
+++ b/wp-content/themes/pub/wporg-learn-2020/template-parts/content-workshop-single.php
@@ -1,15 +1,60 @@
+<?php
+
+global $wp_embed;
+
+?>
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
 	<section>
 		<div class="row align-middle between section-heading section-heading--with-space">
 			<h1 class="section-heading_title h2"><?php the_title(); ?></h1>
 		</div>
+
 		<hr>
+
 		<div class="workshop-page">
-			<?php the_content(); ?>
+			<?php if ( $post->video_url ) : ?>
+				<figure class="workshop-page_video">
+					<?php echo $wp_embed->autoembed( $post->video_url ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+				</figure>
+			<?php endif; ?>
+
+			<div class="wp-block-columns workshop-page_content">
+				<div class="wp-block-column" style="flex-basis:66.66%">
+					<?php the_content(); ?>
+				</div>
+
+				<div class="wp-block-column workshop-page_sidebar" style="flex-basis:33.333%">
+					<div>
+						<?php echo render_block( array( 'blockName' => 'wporg-learn/workshop-details' ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+					</div>
+
+					<div class="wp-block-button is-style-secondary-full-width">
+						<a
+							class="wp-block-button__link"
+							href="https://www.meetup.com/learn-wordpress-discussions/events/"
+							style="border-radius:5px"
+						>
+							<?php esc_html_e( 'Join a Group Discussion', 'wporg-learn' ); ?>
+						</a>
+					</div>
+
+					<p class="terms">
+						<?php printf(
+							wp_kses_data( __( 'You must agree to our <a href="%s">Code of Conduct</a> in order to participate.', 'wporg-learn' ) ),
+							esc_url( get_permalink( get_page_by_path( 'code-of-conduct' ) ) )
+						); ?>
+					</p>
+
+				</div> <!-- end sidebar column -->
+			</div> <!-- end columns -->
+
+			<hr class="wp-block-separator">
+
 			<?php if ( is_object_in_term( get_the_ID(), 'wporg_workshop_series' ) ) : ?>
 				<?php get_template_part( 'template-parts/component', 'series-navigation' ); ?>
 				<hr class="wp-block-separator" />
 			<?php endif; ?>
+
 			<?php foreach ( wporg_get_workshop_presenters() as $presenter ) : ?>
 				<section class="row workshop-page_section"">
 					<div class="col-4">
@@ -23,11 +68,13 @@
 						);
 						?>
 					</div>
+
 					<div class="col-8 workshop-page_biography">
 						<?php echo wp_kses_post( wpautop( wporg_get_workshop_presenter_bio( $presenter ) ) ); ?>
 					</div>
 				</section>
 			<?php endforeach; ?>
-		</div>
+
+		</div> <!-- end workshop-page -->
 	</section>
 </article>


### PR DESCRIPTION
Having them in `post_content` means that we have to manually update all existing posts every time we change the layout.

See #195, https://wordpress.slack.com/archives/C01KC5VDQBC/p1616436392000400

Closes #201 

Blocker for #200