### PR TITLE
Generate translatable strings for non-static front end UI

### DIFF
--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -26,7 +26,8 @@ jobs:
         run: php ./bin/i18n.php
 
       - name: Commit and push
-        uses: actions-js/push@v1.2
+        # Using a specific hash here instead of a tagged version, for risk mitigation, since this action modifies our repo.
+        uses: actions-js/push@4decc2887d2770f29177082be3c8b04d342f5b64
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: try/generate-i18n # TODO change this to trunk

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -31,3 +31,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: try/generate-i18n # TODO change this to trunk
           message: Update translation strings
+# Test again if commit will still happen with no term changes

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -30,5 +30,5 @@ jobs:
         uses: actions-js/push@4decc2887d2770f29177082be3c8b04d342f5b64
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: try/generate-i18n # TODO change this to trunk
+          branch: trunk
           message: Update translation strings

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -31,5 +31,3 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: try/generate-i18n # TODO change this to trunk
           message: Update translation strings
-
-# Test if commit will still happen with no term changes

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -1,8 +1,8 @@
 name: I18n
 
 on:
-  push: # TODO change this to a schedule
-    branches: [ try/generate-i18n ]
+  schedule:
+    - cron: '0 6,18 * * *'
 
 jobs:
   translation-strings:

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -31,4 +31,3 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: try/generate-i18n # TODO change this to trunk
           message: Update translation strings
-# Test minor change to terms

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -31,3 +31,5 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: try/generate-i18n # TODO change this to trunk
           message: Update translation strings
+
+# Test if commit will still happen with no term changes

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -1,0 +1,32 @@
+name: I18n
+
+on:
+  push:
+    branches: [ try/generate-i18n ]
+
+jobs:
+  translation-strings:
+    name: Translation strings
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set PHP version
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 7.4
+          tools: composer:v2
+
+      - name: Install dependencies
+        run: composer install
+
+      - name: Run translation script
+        run: php ./bin/i18n.php
+
+      - name: Commit and push
+        uses: actions-js/push@v1.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          message: Update translation strings

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -31,4 +31,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: try/generate-i18n # TODO change this to trunk
           message: Update translation strings
-# Test again if commit will still happen with no term changes
+# Test minor change to terms

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -1,7 +1,7 @@
 name: I18n
 
 on:
-  push:
+  push: # TODO change this to a schedule
     branches: [ try/generate-i18n ]
 
 jobs:
@@ -29,4 +29,5 @@ jobs:
         uses: actions-js/push@v1.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: try/generate-i18n # TODO change this to trunk
           message: Update translation strings

--- a/bin/i18n.php
+++ b/bin/i18n.php
@@ -83,8 +83,6 @@ function get_taxonomy_terms( $taxonomy ) {
  * @return string
  */
 function get_file_header() {
-	$time = gmdate( 'Y-m-d H:i:s O' );
-
 	$file_header = <<<HEADER
 <?php
 /**
@@ -94,8 +92,6 @@ function get_file_header() {
  *
  * ⚠️ This is a generated file. Do not edit manually. See bin/i18n.php.
  * ⚠️ Do not require or include this file anywhere.
- *
- * Last updated: $time
  */
 
 
@@ -161,8 +157,20 @@ function main() {
 		mkdir( $path );
 	}
 
-	$file_header = get_file_header();
 	$file_name = 'translation-strings.php';
+	$file_header = <<<HEADER
+<?php
+/**
+ * Generated file for translation strings.
+ *
+ * Used to import additional strings into the learn-wordpress translation project.
+ *
+ * ⚠️ This is a generated file. Do not edit manually. See bin/i18n.php.
+ * ⚠️ Do not require or include this file anywhere.
+ */
+
+
+HEADER;
 
 	file_put_contents( $path . '/' . $file_name, $file_header . $file_content );
 

--- a/bin/i18n.php
+++ b/bin/i18n.php
@@ -1,0 +1,175 @@
+#!/usr/bin/php
+<?php
+
+namespace WPOrg_Learn\Bin\I18n;
+
+use Requests;
+
+require_once dirname( __DIR__ ) . '/vendor/autoload.php';
+
+const ENDPOINT_BASE = 'https://learn.wordpress.org/wp-json/wp/v2/';
+
+/**
+ * Get data about taxonomies from a REST API endpoint.
+ *
+ * @param array $valid_post_types Slugs of post types that support the taxonomies we want.
+ *
+ * @return array
+ */
+function get_taxonomies( array $valid_post_types = array() ) {
+	$endpoint = ENDPOINT_BASE . 'taxonomies';
+
+	$response = Requests::get( $endpoint );
+
+	if ( 200 !== $response->status_code ) {
+		die( 'Could not retrieve taxonomy data.' );
+	}
+
+	$taxonomies = json_decode( $response->body, true );
+
+	if ( ! is_array( $taxonomies ) ) {
+		die( 'Taxonomies request returned unexpected data.' );
+	}
+
+	if ( count( $valid_post_types ) > 0 ) {
+		$taxonomies = array_filter(
+			$taxonomies,
+			function( $tax ) use ( $valid_post_types ) {
+				$supported_types = $tax['types'];
+				$matches = array_intersect( $supported_types, $valid_post_types );
+
+				return count( $matches ) > 0;
+			}
+		);
+	}
+
+	return $taxonomies;
+}
+
+/**
+ * Get data about a taxonomy's terms from a REST API endpoint.
+ *
+ * @param string $taxonomy
+ *
+ * @return array
+ */
+function get_taxonomy_terms( $taxonomy ) {
+	$endpoint = ENDPOINT_BASE . $taxonomy . '?per_page=100';
+
+	$response = Requests::get( $endpoint );
+
+	if ( 200 !== $response->status_code ) {
+		die( sprintf(
+			'Could not retrieve terms for %s.',
+			$taxonomy // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		) );
+	}
+
+	$terms = json_decode( $response->body, true );
+
+	if ( ! is_array( $terms ) ) {
+		die( sprintf(
+			'Terms request for %s returned unexpected data.',
+			$taxonomy // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		) );
+	}
+
+	return $terms;
+}
+
+/**
+ * The header for the generated file.
+ *
+ * @return string
+ */
+function get_file_header() {
+	$time = gmdate( 'Y-m-d H:i:s O' );
+
+	$file_header = <<<HEADER
+<?php
+/**
+ * Generated file for translation strings.
+ *
+ * Used to import additional strings into the learn-wordpress translation project.
+ *
+ * ⚠️ This is a generated file. Do not edit manually. See bin/i18n.php.
+ * ⚠️ Do not require or include this file anywhere.
+ *
+ * Last updated: $time
+ */
+
+
+HEADER;
+
+	return $file_header;
+}
+
+/**
+ * Run the script.
+ */
+function main() {
+	if ( 'cli' === php_sapi_name() ) {
+		echo "\n";
+		echo "Retrieving taxonomies...\n";
+	}
+
+	$valid_post_types = array(
+		'lesson-plan',
+		'wporg_workshop',
+		'course',
+		'lesson',
+	);
+	$taxonomies = get_taxonomies( $valid_post_types );
+
+	if ( 'cli' === php_sapi_name() ) {
+		echo "Retrieving terms...\n";
+		echo "\n";
+	}
+
+	$terms_by_tax = array();
+	foreach ( $taxonomies as $taxonomy ) {
+		$terms = get_taxonomy_terms( $taxonomy['slug'] );
+
+		if ( count( $terms ) > 0 ) {
+			$terms_by_tax[ $taxonomy['name'] ] = $terms;
+		}
+
+		unset( $terms );
+	}
+
+	$file_content = '';
+	foreach ( $terms_by_tax as $tax_label => $terms ) {
+		$label = addcslashes( $tax_label, "'" );
+
+		foreach ( $terms as $term ) {
+			$name = addcslashes( $term['name'], "'" );
+			$file_content .= "_x( '{$name}', '$label term name', 'wporg-learn' );\n";
+
+			if ( 'cli' === php_sapi_name() ) {
+				echo "$name\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			}
+
+			if ( $term['description'] ) {
+				$description = addcslashes( $term['description'], "'" );
+				$file_content .= "_x( '{$description}', '$label term description', 'wporg-learn' );\n";
+			}
+		}
+	}
+
+	$path = dirname( __DIR__ ) . '/extra';
+	if ( ! is_readable( $path ) ) {
+		mkdir( $path );
+	}
+
+	$file_header = get_file_header();
+	$file_name = 'translation-strings.php';
+
+	file_put_contents( $path . '/' . $file_name, $file_header . $file_content );
+
+	if ( 'cli' === php_sapi_name() ) {
+		echo "\n";
+		echo "Done.\n";
+	}
+}
+
+main();

--- a/bin/i18n.php
+++ b/bin/i18n.php
@@ -78,29 +78,6 @@ function get_taxonomy_terms( $taxonomy ) {
 }
 
 /**
- * The header for the generated file.
- *
- * @return string
- */
-function get_file_header() {
-	$file_header = <<<HEADER
-<?php
-/**
- * Generated file for translation strings.
- *
- * Used to import additional strings into the learn-wordpress translation project.
- *
- * ⚠️ This is a generated file. Do not edit manually. See bin/i18n.php.
- * ⚠️ Do not require or include this file anywhere.
- */
-
-
-HEADER;
-
-	return $file_header;
-}
-
-/**
  * Run the script.
  */
 function main() {

--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,8 @@
 	"require-dev": {
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
 		"wp-coding-standards/wpcs": "2.*",
-		"phpcompatibility/phpcompatibility-wp": "*"
+		"phpcompatibility/phpcompatibility-wp": "*",
+		"rmccue/requests": "^1.7"
 	},
 	"scripts": {
 		"format": "phpcbf -p",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "67ff88d4c0fa894fc767f710c066bc9d",
+    "content-hash": "c189b8939918e54c9733d2234dda46e8",
     "packages": [
         {
             "name": "composer/installers",
@@ -194,15 +194,15 @@
         },
         {
             "name": "wpackagist-plugin/jetpack",
-            "version": "9.4.1",
+            "version": "9.5.2",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/jetpack/",
-                "reference": "tags/9.4.1"
+                "reference": "tags/9.5.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/jetpack.9.4.1.zip"
+                "url": "https://downloads.wordpress.org/plugin/jetpack.9.5.2.zip"
             },
             "require": {
                 "composer/installers": "~1.0"
@@ -212,15 +212,15 @@
         },
         {
             "name": "wpackagist-plugin/sensei-lms",
-            "version": "3.8.1",
+            "version": "3.9.1",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/sensei-lms/",
-                "reference": "tags/3.8.1"
+                "reference": "tags/3.9.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/sensei-lms.3.8.1.zip"
+                "url": "https://downloads.wordpress.org/plugin/sensei-lms.3.9.1.zip"
             },
             "require": {
                 "composer/installers": "~1.0"
@@ -489,6 +489,59 @@
                 "source": "https://github.com/PHPCompatibility/PHPCompatibilityWP"
             },
             "time": "2021-02-15T12:58:46+00:00"
+        },
+        {
+            "name": "rmccue/requests",
+            "version": "v1.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/rmccue/Requests.git",
+                "reference": "87932f52ffad70504d93f04f15690cf16a089546"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/rmccue/Requests/zipball/87932f52ffad70504d93f04f15690cf16a089546",
+                "reference": "87932f52ffad70504d93f04f15690cf16a089546",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2"
+            },
+            "require-dev": {
+                "requests/test-server": "dev-master"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Requests": "library/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "ISC"
+            ],
+            "authors": [
+                {
+                    "name": "Ryan McCue",
+                    "homepage": "http://ryanmccue.info"
+                }
+            ],
+            "description": "A HTTP library written in PHP, for human beings.",
+            "homepage": "http://github.com/rmccue/Requests",
+            "keywords": [
+                "curl",
+                "fsockopen",
+                "http",
+                "idna",
+                "ipv6",
+                "iri",
+                "sockets"
+            ],
+            "support": {
+                "issues": "https://github.com/rmccue/Requests/issues",
+                "source": "https://github.com/rmccue/Requests/tree/master"
+            },
+            "time": "2016-10-13T00:11:37+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",

--- a/extra/translation-strings.php
+++ b/extra/translation-strings.php
@@ -48,7 +48,7 @@ _x( 'Beginner', 'Experience Levels term name', 'wporg-learn' );
 _x( 'Intermediate', 'Experience Levels term name', 'wporg-learn' );
 _x( 'Advanced site management', 'Workshop Series term name', 'wporg-learn' );
 _x( 'Contributing to WordPress', 'Workshop Series term name', 'wporg-learn' );
-_x( 'Get involved in contributing to WordPress - no matter you do with WordPress there\'s a way that you can be a part of building the project and community. You will need to <a href="https://learn.wordpress.org/workshop/set-up-a-wordpress-org-account/">set up a WordPress.org profile</a> in order to contribute.', 'Workshop Series term description', 'wporg-learn' );
+_x( 'Get involved in contributing to WordPress - no matter you do with WordPress there\'s a way that you can be a part of building the project and community. You will need to <a href="https://learn.wordpress.org/workshop/set-up-a-wordpress-org-account">set up a WordPress.org profile</a> in order to contribute.', 'Workshop Series term description', 'wporg-learn' );
 _x( 'Developing for the Block Editor', 'Workshop Series term name', 'wporg-learn' );
 _x( 'This series is aimed at WordPress developers interested in developing for the block editor.', 'Workshop Series term description', 'wporg-learn' );
 _x( 'Diverse Speaker Training', 'Workshop Series term name', 'wporg-learn' );

--- a/extra/translation-strings.php
+++ b/extra/translation-strings.php
@@ -6,8 +6,6 @@
  *
  * ⚠️ This is a generated file. Do not edit manually. See bin/i18n.php.
  * ⚠️ Do not require or include this file anywhere.
- *
- * Last updated: 2021-04-02 17:49:10 +0000
  */
 
 _x( 'All', 'Audiences term name', 'wporg-learn' );

--- a/extra/translation-strings.php
+++ b/extra/translation-strings.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Generated file for translation strings.
+ *
+ * Used to import additional strings into the learn-wordpress translation project.
+ *
+ * ⚠️ This is a generated file. Do not edit manually. See bin/i18n.php.
+ * ⚠️ Do not require or include this file anywhere.
+ *
+ * Last updated: 2021-04-02 17:36:14 +0000
+ */
+
+_x( 'All', 'Audiences term name', 'wporg-learn' );
+_x( 'Contributor', 'Audiences term name', 'wporg-learn' );
+_x( 'Designers', 'Audiences term name', 'wporg-learn' );
+_x( 'Developers', 'Audiences term name', 'wporg-learn' );
+_x( 'Speakers', 'Audiences term name', 'wporg-learn' );
+_x( 'Users', 'Audiences term name', 'wporg-learn' );
+_x( 'Builder', 'Lesson Categories term name', 'wporg-learn' );
+_x( 'Developing or Customizing with code.', 'Lesson Categories term description', 'wporg-learn' );
+_x( 'Español', 'Lesson Categories term name', 'wporg-learn' );
+_x( 'General', 'Lesson Categories term name', 'wporg-learn' );
+_x( 'History of WordPress, About the Community, Open Source, or other broad overview lessons', 'Lesson Categories term description', 'wporg-learn' );
+_x( 'General Admin', 'Lesson Categories term name', 'wporg-learn' );
+_x( 'Using admin settings, the dashboard, posts, pages,', 'Lesson Categories term description', 'wporg-learn' );
+_x( 'Plugin', 'Lesson Categories term name', 'wporg-learn' );
+_x( 'Plugin Dev', 'Lesson Categories term name', 'wporg-learn' );
+_x( 'Speaker', 'Lesson Categories term name', 'wporg-learn' );
+_x( 'Templates', 'Lesson Categories term name', 'wporg-learn' );
+_x( 'How to get started writing lesson plans, templates for lessons, guidelines for Learn', 'Lesson Categories term description', 'wporg-learn' );
+_x( 'Theme', 'Lesson Categories term name', 'wporg-learn' );
+_x( 'Theme Dev', 'Lesson Categories term name', 'wporg-learn' );
+_x( 'User', 'Lesson Categories term name', 'wporg-learn' );
+_x( '15', 'Duration term name', 'wporg-learn' );
+_x( '30', 'Duration term name', 'wporg-learn' );
+_x( '45', 'Duration term name', 'wporg-learn' );
+_x( '60', 'Duration term name', 'wporg-learn' );
+_x( 'Get Started', 'Lesson Groups term name', 'wporg-learn' );
+_x( 'Speaker Training', 'Lesson Groups term name', 'wporg-learn' );
+_x( 'Demonstration', 'Instruction Types term name', 'wporg-learn' );
+_x( 'Discussion', 'Instruction Types term name', 'wporg-learn' );
+_x( 'Exercises', 'Instruction Types term name', 'wporg-learn' );
+_x( 'Feedback', 'Instruction Types term name', 'wporg-learn' );
+_x( 'Lecture', 'Instruction Types term name', 'wporg-learn' );
+_x( 'Show &amp; Tell', 'Instruction Types term name', 'wporg-learn' );
+_x( 'Tutorial', 'Instruction Types term name', 'wporg-learn' );
+_x( 'Advanced', 'Experience Levels term name', 'wporg-learn' );
+_x( 'Any', 'Experience Levels term name', 'wporg-learn' );
+_x( 'Beginner', 'Experience Levels term name', 'wporg-learn' );
+_x( 'Intermediate', 'Experience Levels term name', 'wporg-learn' );
+_x( 'Advanced site management', 'Workshop Series term name', 'wporg-learn' );
+_x( 'Contributing to WordPress', 'Workshop Series term name', 'wporg-learn' );
+_x( 'Get involved in contributing to WordPress - no matter you do with WordPress there\'s a way that you can be a part of building the project and community. You will need to <a href="https://learn.wordpress.org/workshop/set-up-a-wordpress-org-account/">set up a WordPress.org profile</a> in order to contribute.', 'Workshop Series term description', 'wporg-learn' );
+_x( 'Developing for the Block Editor', 'Workshop Series term name', 'wporg-learn' );
+_x( 'This series is aimed at WordPress developers interested in developing for the block editor.', 'Workshop Series term description', 'wporg-learn' );
+_x( 'Diverse Speaker Training', 'Workshop Series term name', 'wporg-learn' );
+_x( 'This series is for people from marginalized or underrepresented groups who are thinking about speaking at WordPress events. You do not need to have any experience in public speaking, and this series is for all levels of experience. Topics include finding a talk topic, writing a pitch, creating the talk, becoming a better speaker, creating great slides, handling tough questions, and more!', 'Workshop Series term description', 'wporg-learn' );
+_x( 'Editor de Bloques - Tutorial básico', 'Workshop Series term name', 'wporg-learn' );
+_x( 'En esta serio de tutoriales, o WorkShops, se abordan los conceptos básico, y no tanto, para poder adentrarnos en el fascinante mundo del desarrollo en el editor de bloques de WordPress, también conocido como Gutenberg.
+Partiendo de lo indispensable, iremos viendo sección tras sección, video tras video, cómo poder implementar nuestras propias ideas, necesidades, requerimientos, etc. de una manera simple y al alcance de todo el mundo.', 'Workshop Series term description', 'wporg-learn' );
+_x( 'Organizing WordPress Meetups', 'Workshop Series term name', 'wporg-learn' );
+_x( 'This series aimed at all WordPress Community members across the world that are interested in organizing WordPress meetups. You will learn how to organize a local WordPress Meetup, the important things to keep in mind while organizing a meetup, and how to keep your local meetup group active.', 'Workshop Series term description', 'wporg-learn' );
+_x( 'Seguridad en WordPress', 'Workshop Series term name', 'wporg-learn' );
+_x( 'Using the Block Editor', 'Workshop Series term name', 'wporg-learn' );
+_x( 'Learn how to get the most out of the WordPress block editor when publishing your content.', 'Workshop Series term description', 'wporg-learn' );
+_x( 'WordPress の基本', 'Workshop Series term name', 'wporg-learn' );
+_x( 'WordPress for Kids', 'Workshop Series term name', 'wporg-learn' );
+_x( 'WordPress Troubleshooting', 'Workshop Series term name', 'wporg-learn' );
+_x( 'Learn how to troubleshoot WordPress issues.', 'Workshop Series term description', 'wporg-learn' );
+_x( 'Block Development', 'Topics term name', 'wporg-learn' );
+_x( 'Block Editor', 'Topics term name', 'wporg-learn' );
+_x( 'Community Team', 'Topics term name', 'wporg-learn' );
+_x( 'Contributing', 'Topics term name', 'wporg-learn' );
+_x( 'Core', 'Topics term name', 'wporg-learn' );
+_x( 'CSS', 'Topics term name', 'wporg-learn' );
+_x( 'Diversity', 'Topics term name', 'wporg-learn' );
+_x( 'eCommerce', 'Topics term name', 'wporg-learn' );
+_x( 'Gutenberg', 'Topics term name', 'wporg-learn' );
+_x( 'Hosting', 'Topics term name', 'wporg-learn' );
+_x( 'Meetups', 'Topics term name', 'wporg-learn' );
+_x( 'Open-Source', 'Topics term name', 'wporg-learn' );
+_x( 'Publishing', 'Topics term name', 'wporg-learn' );
+_x( 'Security', 'Topics term name', 'wporg-learn' );
+_x( 'Translation', 'Topics term name', 'wporg-learn' );
+_x( 'Troubleshooting', 'Topics term name', 'wporg-learn' );
+_x( 'Sessions on WordPress Troubleshooting.', 'Topics term description', 'wporg-learn' );
+_x( 'UI', 'Topics term name', 'wporg-learn' );
+_x( 'WordPress', 'Topics term name', 'wporg-learn' );

--- a/extra/translation-strings.php
+++ b/extra/translation-strings.php
@@ -7,7 +7,7 @@
  * ⚠️ This is a generated file. Do not edit manually. See bin/i18n.php.
  * ⚠️ Do not require or include this file anywhere.
  *
- * Last updated: 2021-04-02 17:36:14 +0000
+ * Last updated: 2021-04-02 17:49:10 +0000
  */
 
 _x( 'All', 'Audiences term name', 'wporg-learn' );

--- a/wp-content/plugins/wporg-learn/inc/admin.php
+++ b/wp-content/plugins/wporg-learn/inc/admin.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace WPOrg_Learn\Admin;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Actions and filters.
+ */
+add_action( 'admin_notices', __NAMESPACE__ . '\show_term_translation_notice' );
+
+/**
+ * Show a notice on taxonomy term screens about terms being translatable.
+ *
+ * @return void
+ */
+function show_term_translation_notice() {
+	global $pagenow, $taxnow, $typenow;
+
+	if ( 'edit-tags.php' !== $pagenow ) {
+		return;
+	}
+
+	$valid_post_types = array(
+		'lesson-plan',
+		'wporg_workshop',
+		'course',
+		'lesson',
+	);
+
+	if ( ! in_array( $typenow, $valid_post_types, true ) ) {
+		return;
+	}
+
+	if ( empty( $taxnow ) ) {
+		return;
+	}
+
+	$taxonomy = get_taxonomy( $taxnow );
+	$labels   = get_taxonomy_labels( $taxonomy );
+
+	?>
+	<div class="notice notice-info is-dismissible">
+		<p>
+			<?php
+			printf(
+				wp_kses_post( __( '
+					Names and descriptions of %1$s can be translated via the Learn WordPress <a href="%2$s">translation project</a>. Once you have added or changed a term\'s name or description, it may take up to 24 hours before it is available for translation.
+				', 'wporg-learn' ) ),
+				esc_html( $labels->name ),
+				'https://translate.wordpress.org/projects/meta/learn-wordpress/'
+			);
+			?>
+		</p>
+	</div>
+	<?php
+}

--- a/wp-content/plugins/wporg-learn/inc/i18n.php
+++ b/wp-content/plugins/wporg-learn/inc/i18n.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace WPOrg_Learn\I18n;
+
+use WP_Term;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Actions and filters.
+ */
+add_filter( 'get_term', __NAMESPACE__ . '\translate_term', 10, 2 );
+add_filter( 'get_terms', __NAMESPACE__ . '\translate_terms', 10, 2 );
+
+/**
+ * Translate a term's name and description in certain contexts.
+ *
+ * @param WP_Term|string $term
+ *
+ * @return WP_Term
+ */
+function translate_term( $term, $taxonomy_slug ) {
+	if ( 'en_US' === get_locale() ) {
+		return $term;
+	}
+
+	// Terms shouldn't be translated in the UI for editing them.
+	if ( is_admin() ) {
+		return $term;
+	}
+
+	$taxonomy = get_taxonomy( $taxonomy_slug );
+	$valid_post_types = array(
+		'lesson-plan',
+		'wporg_workshop',
+		'course',
+		'lesson',
+	);
+	$supported_types = $taxonomy->object_type;
+
+	if ( count( array_intersect( $supported_types, $valid_post_types ) ) < 1 ) {
+		return $term;
+	}
+
+	if ( $term instanceof WP_Term ) {
+		$term->name = esc_html( translate_with_gettext_context(
+			html_entity_decode( $term->name ), // phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText
+			"{$taxonomy->label} term name", // phpcs:ignore WordPress.WP.I18n.InterpolatedVariableContext
+			'wporg-learn'
+		) );
+
+		if ( $term->description ) {
+			$term->description = wp_kses_post( translate_with_gettext_context(
+				html_entity_decode( $term->description ), // phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText
+				"{$taxonomy->label} term description", // phpcs:ignore WordPress.WP.I18n.InterpolatedVariableContext
+				'wporg-learn'
+			) );
+		}
+	} elseif ( is_string( $term ) ) {
+		$term = esc_html( translate_with_gettext_context(
+			html_entity_decode( $term ), // phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText
+			"{$taxonomy->label} term name", // phpcs:ignore WordPress.WP.I18n.InterpolatedVariableContext
+			'wporg-learn'
+		) );
+	}
+
+	return $term;
+}
+
+/**
+ * Translate a group of terms.
+ *
+ * @param WP_Term[] $terms
+ *
+ * @return WP_Term[]
+ */
+function translate_terms( array $terms, array $taxonomies ) {
+	if ( 'en_US' === get_locale() ) {
+		return $terms;
+	}
+
+	// Terms shouldn't be translated in the UI for editing them.
+	if ( is_admin() ) {
+		return $terms;
+	}
+
+	$first_term = reset( $terms );
+	if ( ! $first_term instanceof WP_Term && ! is_string( $first_term ) ) {
+		return $terms;
+	}
+
+	// If the terms query has multiple taxonomies, we don't know which one a term will belong to.
+	if ( count( $taxonomies ) > 1 ) {
+		return $terms;
+	}
+
+	$taxonomy = reset( $taxonomies );
+
+	foreach ( $terms as $index => $term ) {
+		$terms[ $index ] = translate_term( $term, $taxonomy );
+	}
+
+	return $terms;
+}

--- a/wp-content/plugins/wporg-learn/wporg-learn.php
+++ b/wp-content/plugins/wporg-learn/wporg-learn.php
@@ -68,6 +68,7 @@ function load_files() {
 	require_once get_includes_path() . 'class-markdown-import.php';
 	require_once get_includes_path() . 'events.php';
 	require_once get_includes_path() . 'form.php';
+	require_once get_includes_path() . 'i18n.php';
 	require_once get_includes_path() . 'post-meta.php';
 	require_once get_includes_path() . 'post-type.php';
 	require_once get_includes_path() . 'sensei.php';

--- a/wp-content/plugins/wporg-learn/wporg-learn.php
+++ b/wp-content/plugins/wporg-learn/wporg-learn.php
@@ -64,6 +64,7 @@ function get_views_path() {
  * @return void
  */
 function load_files() {
+	require_once get_includes_path() . 'admin.php';
 	require_once get_includes_path() . 'blocks.php';
 	require_once get_includes_path() . 'class-markdown-import.php';
 	require_once get_includes_path() . 'events.php';


### PR DESCRIPTION
This adds a script that retrieves taxonomy term names and descriptions from Learn WP via the REST API and writes them to a file that can get picked up by the pot file generator. This way the terms will get imported into the `learn-wordpress` translation project and can get translated by community volunteers.

This new script should get run by a scheduled GitHub action and committed directly back to this repo. The generated file is outside of the wp-content directory, so it should never end up being committed to SVN or otherwise make an appearance on the production server.

This also adds the filter to dynamically translate term names and descriptions when they are output on the front end, and adds a notice on term edit screens so users know that the strings will get translated.

Refs #187 