### PR TITLE
Locale-related enhancements for workshops

### DIFF
--- a/wp-content/plugins/wporg-learn/inc/admin.php
+++ b/wp-content/plugins/wporg-learn/inc/admin.php
@@ -14,6 +14,7 @@ defined( 'WPINC' ) || die();
 add_action( 'admin_notices', __NAMESPACE__ . '\show_term_translation_notice' );
 add_filter( 'manage_wporg_workshop_posts_columns', __NAMESPACE__ . '\add_workshop_list_table_columns' );
 add_action( 'manage_wporg_workshop_posts_custom_column', __NAMESPACE__ . '\render_workshop_list_table_columns', 10, 2 );
+add_filter( 'manage_edit-wporg_workshop_sortable_columns', __NAMESPACE__ . '\add_workshop_list_table_sortable_columns' );
 add_action( 'restrict_manage_posts', __NAMESPACE__ . '\add_workshop_list_table_filters', 10, 2 );
 add_action( 'pre_get_posts', __NAMESPACE__ . '\handle_workshop_list_table_filters' );
 
@@ -93,7 +94,11 @@ function render_workshop_list_table_columns( $column_name, $post_id ) {
 
 	switch ( $column_name ) {
 		case 'video_language':
-			echo esc_html( get_locale_name_from_code( $post->video_language, 'english' ) );
+			printf(
+				'%s [%s]',
+				esc_html( get_locale_name_from_code( $post->video_language, 'english' ) ),
+				esc_html( $post->video_language )
+			);
 			break;
 		case 'video_caption_language':
 			$captions = get_post_meta( $post->ID, 'video_caption_language' );
@@ -109,6 +114,19 @@ function render_workshop_list_table_columns( $column_name, $post_id ) {
 			) );
 			break;
 	}
+}
+
+/**
+ * Make additional columns sortable.
+ *
+ * @param array $sortable_columns
+ *
+ * @return array
+ */
+function add_workshop_list_table_sortable_columns( $sortable_columns ) {
+	$sortable_columns['video_language'] = 'video_language';
+
+	return $sortable_columns;
 }
 
 /**
@@ -178,6 +196,11 @@ function handle_workshop_list_table_filters( WP_Query $query ) {
 			);
 
 			$query->set( 'meta_query', $meta_query );
+		}
+
+		if ( 'video_language' === $query->get( 'orderby' ) ) {
+			$query->set( 'meta_key', 'video_language' );
+			$query->set( 'orderby', 'meta_value' );
 		}
 	}
 }

--- a/wp-content/plugins/wporg-learn/inc/admin.php
+++ b/wp-content/plugins/wporg-learn/inc/admin.php
@@ -2,12 +2,16 @@
 
 namespace WPOrg_Learn\Admin;
 
+use function WordPressdotorg\Locales\get_locale_name_from_code;
+
 defined( 'WPINC' ) || die();
 
 /**
  * Actions and filters.
  */
 add_action( 'admin_notices', __NAMESPACE__ . '\show_term_translation_notice' );
+add_filter( 'manage_wporg_workshop_posts_columns', __NAMESPACE__ . '\add_workshop_list_table_columns' );
+add_action( 'manage_wporg_workshop_posts_custom_column', __NAMESPACE__ . '\render_workshop_list_table_columns', 10, 2 );
 
 /**
  * Show a notice on taxonomy term screens about terms being translatable.
@@ -54,4 +58,51 @@ function show_term_translation_notice() {
 		</p>
 	</div>
 	<?php
+}
+
+/**
+ * Add additional columns to the post list table for workshops.
+ *
+ * @param array $columns
+ *
+ * @return array
+ */
+function add_workshop_list_table_columns( $columns ) {
+	$columns = array_slice( $columns, 0, -2, true )
+	           + array( 'video_language' => __( 'Language', 'wporg-learn' ) )
+	           + array( 'video_caption_language' => __( 'Captions', 'wporg-learn' ) )
+	           + array_slice( $columns, -2, 2, true );
+
+	return $columns;
+}
+
+/**
+ * Render the cell contents for the additional columns in the post list table for workshops.
+ *
+ * @param string $column_name
+ * @param int    $post_id
+ *
+ * @return void
+ */
+function render_workshop_list_table_columns( $column_name, $post_id ) {
+	$post = get_post( $post_id );
+
+	switch ( $column_name ) {
+		case 'video_language':
+			echo esc_html( get_locale_name_from_code( $post->video_language, 'english' ) );
+			break;
+		case 'video_caption_language':
+			$captions = get_post_meta( $post->ID, 'video_caption_language' );
+
+			echo esc_html( implode(
+				', ',
+				array_map(
+					function( $caption_lang ) {
+						return get_locale_name_from_code( $caption_lang, 'english' );
+					},
+					$captions
+				)
+			) );
+			break;
+	}
 }

--- a/wp-content/plugins/wporg-learn/inc/admin.php
+++ b/wp-content/plugins/wporg-learn/inc/admin.php
@@ -187,7 +187,10 @@ function handle_workshop_list_table_filters( WP_Query $query ) {
 			$meta_query = $query->get( 'meta_query', array() );
 
 			if ( ! empty( $meta_query ) ) {
-				$meta_query['relation'] = 'AND';
+				$meta_query = array(
+					'relation' => 'AND',
+					$meta_query,
+				);
 			}
 
 			$meta_query[] = array(

--- a/wp-content/plugins/wporg-learn/inc/post-meta.php
+++ b/wp-content/plugins/wporg-learn/inc/post-meta.php
@@ -217,22 +217,32 @@ function get_workshop_duration( WP_Post $workshop, $format = 'raw' ) {
 /**
  * Get a list of locales that are associated with at least one workshop.
  *
+ * Optionally only published workshops.
+ *
  * @param string $meta_key
  * @param string $label_language
+ * @param bool   $published_only
  *
  * @return array
  */
-function get_available_workshop_locales( $meta_key, $label_language = 'english' ) {
+function get_available_workshop_locales( $meta_key, $label_language = 'english', $published_only = true ) {
 	global $wpdb;
 
+	$and_post_status = '';
+	if ( $published_only ) {
+		$and_post_status = "AND posts.post_status = 'publish'";
+	}
+
 	$results = $wpdb->get_col( $wpdb->prepare(
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $and_post_status contains no user input.
 		"
 			SELECT DISTINCT postmeta.meta_value
 			FROM {$wpdb->postmeta} postmeta
-				JOIN {$wpdb->posts} posts ON posts.ID = postmeta.post_id AND posts.post_status = 'publish'
+				JOIN {$wpdb->posts} posts ON posts.ID = postmeta.post_id $and_post_status
 			WHERE postmeta.meta_key = %s
 		",
 		$meta_key
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 	) );
 
 	if ( empty( $results ) ) {

--- a/wp-content/plugins/wporg-learn/inc/post-meta.php
+++ b/wp-content/plugins/wporg-learn/inc/post-meta.php
@@ -227,10 +227,10 @@ function get_available_workshop_locales( $meta_key, $label_language = 'english' 
 
 	$results = $wpdb->get_col( $wpdb->prepare(
 		"
-			SELECT DISTINCT meta_value
-			FROM $wpdb->postmeta
-			WHERE meta_key = %s
-			ORDER BY meta_value ASC
+			SELECT DISTINCT postmeta.meta_value
+			FROM {$wpdb->postmeta} postmeta
+				JOIN {$wpdb->posts} posts ON posts.ID = postmeta.post_id AND posts.post_status = 'publish'
+			WHERE postmeta.meta_key = %s
 		",
 		$meta_key
 	) );

--- a/wp-content/plugins/wporg-learn/inc/post-type.php
+++ b/wp-content/plugins/wporg-learn/inc/post-type.php
@@ -10,8 +10,6 @@ defined( 'WPINC' ) || die();
  * Actions and filters.
  */
 add_action( 'init', __NAMESPACE__ . '\register' );
-add_filter( 'manage_wporg_workshop_posts_columns', __NAMESPACE__ . '\add_workshop_list_table_columns' );
-add_action( 'manage_wporg_workshop_posts_custom_column', __NAMESPACE__ . '\render_workshop_list_table_columns', 10, 2 );
 add_filter( 'jetpack_copy_post_post_types', __NAMESPACE__ . '\jetpack_copy_post_post_types' );
 add_filter( 'jetpack_sitemap_post_types', __NAMESPACE__ . '\jetpack_sitemap_post_types' );
 add_filter( 'jetpack_page_sitemap_other_urls', __NAMESPACE__ . '\jetpack_page_sitemap_other_urls' );
@@ -194,53 +192,6 @@ function generate_workshop_template_structure() {
 	);
 
 	return $template;
-}
-
-/**
- * Add additional columns to the post list table for workshops.
- *
- * @param array $columns
- *
- * @return array
- */
-function add_workshop_list_table_columns( $columns ) {
-	$columns = array_slice( $columns, 0, -2, true )
-				+ array( 'video_language' => __( 'Language', 'wporg-learn' ) )
-				+ array( 'video_caption_language' => __( 'Captions', 'wporg-learn' ) )
-				+ array_slice( $columns, -2, 2, true );
-
-	return $columns;
-}
-
-/**
- * Render the cell contents for the additional columns in the post list table for workshops.
- *
- * @param string $column_name
- * @param int    $post_id
- *
- * @return void
- */
-function render_workshop_list_table_columns( $column_name, $post_id ) {
-	$post = get_post( $post_id );
-
-	switch ( $column_name ) {
-		case 'video_language':
-			echo esc_html( get_locale_name_from_code( $post->video_language, 'english' ) );
-			break;
-		case 'video_caption_language':
-			$captions = get_post_meta( $post->ID, 'video_caption_language' );
-
-			echo esc_html( implode(
-				', ',
-				array_map(
-					function( $caption_lang ) {
-						return get_locale_name_from_code( $caption_lang, 'english' );
-					},
-					$captions
-				)
-			) );
-			break;
-	}
 }
 
 /**

--- a/wp-content/plugins/wporg-learn/views/form-workshop-application.php
+++ b/wp-content/plugins/wporg-learn/views/form-workshop-application.php
@@ -244,7 +244,13 @@ $prefix = 'submission:';
 				<select id="language" name="language" class="do-select2" required>
 					<?php foreach ( get_locales_with_native_names() as $code => $name ) : ?>
 						<option value="<?php echo esc_attr( $code ); ?>" <?php selected( $code, $form['language'] ); ?>>
-							<?php echo esc_html( $name ); ?>
+							<?php
+							printf(
+								'%s [%s]',
+								esc_html( $name ),
+								esc_html( $code ),
+							);
+							?>
 						</option>
 					<?php endforeach; ?>
 				</select>

--- a/wp-content/themes/pub/wporg-learn-2020/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2020/functions.php
@@ -344,6 +344,23 @@ function wporg_archive_maybe_apply_query_filters( WP_Query &$query ) {
 	if ( is_array( $filters ) ) {
 		$filters = array_filter( $filters );
 
+		// If both language and captions filters are set, we assume an "OR" relationship.
+		if ( isset( $filters['captions'], $filters['language'] ) ) {
+			$meta_query[] = array(
+				'relation' => 'OR',
+				array(
+					'key'   => $entity_map['captions'],
+					'value' => $filters['captions'],
+				),
+				array(
+					'key'   => $entity_map['language'],
+					'value' => $filters['language'],
+				),
+			);
+
+			unset( $filters['captions'], $filters['language'] );
+		}
+
 		foreach ( $filters as $filter_name => $filter_value ) {
 			switch ( $filter_name ) {
 				case 'search':

--- a/wp-content/themes/pub/wporg-learn-2020/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2020/functions.php
@@ -293,6 +293,30 @@ add_action( 'pre_get_posts', 'wporg_archive_modify_query' );
 /**
  * Modify the workshop post type archive query to prioritize workshops in the user's locale.
  *
+ * In order to show all workshops, but with the ones that are presented/captioned in the user's locale shown first, we
+ * need to modify the posts query in ways that can't be done through the WP_Query or WP_Meta_Query APIs. Instead, here,
+ * we're filtering the individual clauses of the query to add the pieces we need.
+ *
+ * Examples, slightly truncated for simplicity:
+ *
+ * Before:
+ * SELECT SQL_CALC_FOUND_ROWS wp_posts.ID
+ * FROM wp_posts
+ * WHERE 1=1
+ * AND wp_posts.post_type = 'wporg_workshop'
+ * ORDER BY wp_posts.post_date DESC
+ *
+ * After:
+ * SELECT SQL_CALC_FOUND_ROWS wp_posts.*,
+ *   MAX( IF( pmeta.meta_key = 'video_language' AND pmeta.meta_value LIKE 'art_%', 1, 0 ) ) AS has_language,
+ *   MAX( IF( pmeta.meta_key = 'video_caption_language' AND pmeta.meta_value LIKE 'art_%', 1, 0 ) ) AS has_caption
+ * FROM wp_posts
+ * INNER JOIN wp_postmeta pmeta ON ( wp_posts.ID = pmeta.post_id )
+ * WHERE 1=1
+ * AND wp_posts.post_type = 'wporg_workshop'
+ * GROUP BY wp_posts.ID
+ * ORDER BY has_language DESC, has_caption DESC, wp_posts.post_date DESC
+ *
  * @param array    $clauses
  * @param WP_Query $query
  *
@@ -305,17 +329,27 @@ function wporg_archive_query_prioritize_locale( $clauses, $query ) {
 
 	global $wpdb;
 
-	$locale      = get_locale() ?: 'en_US';
+	$locale      = get_locale();
 	$locale_root = preg_replace( '#^([a-z]{2,3}_?)[a-zA-Z_-]*#', '$1', $locale, -1, $count );
 
 	if ( $count ) {
-		$clauses['fields']  .= ", MAX( IF( {$wpdb->postmeta}.meta_key = 'video_language' AND {$wpdb->postmeta}.meta_value LIKE '{$locale_root}%', 1, 0 ) ) AS has_language";
-		$clauses['fields']  .= ", MAX( IF( {$wpdb->postmeta}.meta_key = 'video_caption_language' AND {$wpdb->postmeta}.meta_value LIKE '{$locale_root}%', 1, 0 ) ) AS has_caption";
+		/**
+		 * $clauses['fields'] contains the SELECT part of the query.
+		 *
+		 * The extra fields clauses are calculated fields that will contain a `1` if the workshop post row has a postmeta
+		 * value that matches the locale root. The MAX() and the groupby clause below ensure that all the rows for a
+		 * given workshop are consolidated into one with the highest value in the calculated column. Without the
+		 * grouping, there would be a separate row for each postmeta value for each workshop post.
+		 */
+		$clauses['fields']  .= ",
+			MAX( IF( pmeta.meta_key = 'video_language' AND pmeta.meta_value LIKE '{$locale_root}%', 1, 0 ) ) AS has_language
+		";
+		$clauses['fields']  .= ",
+			MAX( IF( pmeta.meta_key = 'video_caption_language' AND pmeta.meta_value LIKE '{$locale_root}%', 1, 0 ) ) AS has_caption
+		";
+		$clauses['join']    .= " INNER JOIN {$wpdb->postmeta} pmeta ON ( {$wpdb->posts}.ID = pmeta.post_id )";
+		// This orderby clause ensures that the workshops are sorted by the values in the calculated columns first.
 		$clauses['orderby'] = 'has_language DESC, has_caption DESC, ' . $clauses['orderby'];
-
-		if ( false === strpos( $clauses['join'], "INNER JOIN {$wpdb->postmeta}" ) ) {
-			$clauses['join'] .= " INNER JOIN {$wpdb->postmeta} ON ( {$wpdb->posts}.ID = {$wpdb->postmeta}.post_id )";
-		}
 
 		if ( false === strpos( $clauses['groupby'], "{$wpdb->posts}.ID" ) ) {
 			$clauses['groupby'] = "{$wpdb->posts}.ID";

--- a/wp-content/themes/pub/wporg-learn-2020/template-parts/component-workshop-filters.php
+++ b/wp-content/themes/pub/wporg-learn-2020/template-parts/component-workshop-filters.php
@@ -56,7 +56,13 @@ $buckets = array(
 								value="<?php echo esc_attr( $item_value ); ?>"
 								<?php selected( $item_value, filter_input( INPUT_GET, $bucket['name'] ) ); ?>
 							>
-								<?php echo esc_html( $item_label ); ?>
+								<?php
+								printf(
+									'%s [%s]',
+									esc_html( $item_label ),
+									esc_html( $item_value ),
+								);
+								?>
 							</option>
 						<?php endforeach; ?>
 					</select>

--- a/wp-content/themes/pub/wporg-learn-2020/template-parts/component-workshop-filters.php
+++ b/wp-content/themes/pub/wporg-learn-2020/template-parts/component-workshop-filters.php
@@ -56,13 +56,15 @@ $buckets = array(
 								value="<?php echo esc_attr( $item_value ); ?>"
 								<?php selected( $item_value, filter_input( INPUT_GET, $bucket['name'] ) ); ?>
 							>
-								<?php
-								printf(
-									'%s [%s]',
-									esc_html( $item_label ),
-									esc_html( $item_value ),
-								);
-								?>
+								<?php if ( in_array( $bucket['name'], array( 'language', 'captions' ) ) ) :
+									printf(
+										'%s [%s]',
+										esc_html( $item_label ),
+										esc_html( $item_value ),
+									);
+								else :
+									echo esc_html( $item_label );
+								endif; ?>
 							</option>
 						<?php endforeach; ?>
 					</select>


### PR DESCRIPTION
This PR provides a series of fixes and enhancements for issues related to the locale switching that was added in #202.

* [x] Sort the workshops on the archive page based on the chosen locale; Fixes #188 
* [x] Show locale codes (e.g. `en_US`) in the dropdown for the workshop application and in workshop filters; Fixes #189 
* [x] Only show locales in the workshop filters that are for published workshops; Fixes #190 
* [x] Add locale-based filtering and sorting to the workshops list table; Fixes #193 

