### PR TITLE
Install composer dependencies before building yarn workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 	"scripts": {
 		"install:env": "./bin/index.sh",
 		"install:githooks": "mv .git/hooks .git/hooks_orig && ln -s ../.githooks .git/hooks",
-		"create": "yarn workspaces run build && composer install && yarn run install:env",
+		"create": "composer install && yarn workspaces run build && yarn run install:env",
 		"wp-env": "wp-env",
 		"lint:php": "composer run lint",
 		"format:php": "composer run format"


### PR DESCRIPTION
Composer dependencies appear to be required for the `wporg-learn-2020` build to succeed. Without them, the build fails due to SASS files being erased, which results in an error:

```shell
Fatal error: Error: no mixin named breakpoint
        on line 41 of css/components/_featured-workshop.scss
        from line 3 of css/components/_components.scss
        from line 29 of css/style.scss
>> 			@include breakpoint( $breakpoint-tablet ) {
```

I wasn't able to figure out why not having composer dependencies results in the SASS files being erased, but I can consistently reproduce the issue, and can consistently verify that installing composer dependencies before building the yarn workspace fixes the issue.