### PR TITLE
Use a literal percent sign, to make it easier for translators

### DIFF
--- a/wp-content/plugins/wporg-learn/views/locale-notice.php
+++ b/wp-content/plugins/wporg-learn/views/locale-notice.php
@@ -15,9 +15,9 @@ defined( 'WPINC' ) || die();
 		<?php
 		printf(
 			wp_kses_post(
-				/* translators: %s is a URL. */
+				/* translators: %s is a URL. If you translate 'percent' to '%' please encode it as '%%' and discard the GlotPress warning. */
 				__(
-					'⚠️ The translation for this locale is incomplete. Help us get to 100%% by <a href="%s">contributing a translation</a>.',
+					'⚠️ The translation for this locale is incomplete. Help us get to 100 percent by <a href="%s">contributing a translation</a>.',
 					'wporg-learn'
 				)
 			),

--- a/wp-content/plugins/wporg-learn/views/locale-notice.php
+++ b/wp-content/plugins/wporg-learn/views/locale-notice.php
@@ -17,7 +17,7 @@ defined( 'WPINC' ) || die();
 			wp_kses_post(
 				/* translators: %s is a URL. */
 				__(
-					'⚠️ The translation for this locale is incomplete. Help us get to 100 percent by <a href="%s">contributing a translation</a>.',
+					'⚠️ The translation for this locale is incomplete. Help us get to 100%% by <a href="%s">contributing a translation</a>.',
 					'wporg-learn'
 				)
 			),


### PR DESCRIPTION
This string is commonly translated to `... 100% by <a href="%s"> ...` by translators, which results in the string not displaying on the site, due to a mismatched printf parameters, and generating lovely PHP Warnings.
```
E_WARNING: printf(): Too few arguments in wp-content/plugins/wporg-learn/views/locale-notice.php:24
```
<img width="663" alt="Screen Shot 2021-08-25 at 12 34 01 pm" src="https://user-images.githubusercontent.com/767313/130717083-0d4436e4-1f3b-47bb-bccd-6beae14bab41.png">

When a translator translates it to that, they get a Translation warning, but upon correcting it to `%%` they also get a translation warning, it's a loose:loose situation for the translators.

Since the string doesn't make much difference in English, translating it to be `100%` seems like it'll solve a few issues here.