### PR TITLE
Add an "Expiration" field to the block editor for some post types

### DIFF
--- a/wp-content/plugins/wporg-learn/js/expiration-date/index.js
+++ b/wp-content/plugins/wporg-learn/js/expiration-date/index.js
@@ -1,0 +1,87 @@
+/**
+ * WordPress dependencies
+ */
+import { Button, DateTimePicker, Dropdown, PanelRow } from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { format, __experimentalGetSettings } from '@wordpress/date';
+import { PluginPostStatusInfo } from '@wordpress/edit-post';
+import { useState, useRef } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { registerPlugin } from '@wordpress/plugins';
+
+function ExpirationLabel( { date } ) {
+	const settings = __experimentalGetSettings();
+	return date
+		? format(
+			`${ settings.formats.date } ${ settings.formats.time }`,
+			date
+		)
+		: __( 'No expiration date', 'wporg-learn' );
+}
+
+const ExpirationDate = () => {
+	const postMetaData = useSelect( ( select ) => select( 'core/editor' ).getEditedPostAttribute( 'meta' ) || {} );
+	const { editPost } = useDispatch( 'core/editor' );
+	const [ expDate, setExpDate ] = useState( postMetaData?.expiration_date );
+	const anchorRef = useRef();
+	const pickerRef = useRef();
+
+	return (
+		<PluginPostStatusInfo>
+			<PanelRow className="edit-post-post-schedule" ref={ anchorRef }>
+				<span>{ __( 'Expiration', 'wporg-learn' ) }</span>
+				<Dropdown
+					popoverProps={ { anchorRef: anchorRef.current } }
+					position="bottom left"
+					contentClassName="edit-post-post-schedule__dialog"
+					renderToggle={ ( { onToggle, isOpen } ) => (
+						<>
+							<Button
+								className="edit-post-post-schedule__toggle"
+								onClick={ onToggle }
+								aria-expanded={ isOpen }
+								variant="tertiary"
+							>
+								<ExpirationLabel date={ expDate } />
+							</Button>
+						</>
+					) }
+					renderContent={ () => {
+						return (
+							<>
+								<p className="help-text" style={ { padding: '0 16px' } }>
+									{ __( 'A date when the content in this post might become obsolete.', 'wporg-learn' ) }
+								</p>
+								<DateTimePicker
+									ref={ pickerRef }
+									currentDate={ expDate }
+									onChange={ ( newDate ) => {
+										setExpDate( newDate );
+
+										editPost( {
+											meta: {
+												...postMetaData,
+												expiration_date: newDate,
+											},
+										} );
+
+										const { ownerDocument } = pickerRef.current;
+										ownerDocument.activeElement.blur();
+									} }
+								/>
+							</>
+						);
+					} }
+				/>
+			</PanelRow>
+		</PluginPostStatusInfo>
+	);
+};
+
+const PluginWrapper = () => {
+	return <ExpirationDate />;
+};
+
+registerPlugin( 'wporg-learn-expiration-date', {
+	render: PluginWrapper,
+} );

--- a/wp-content/plugins/wporg-learn/js/expiration-date/index.js
+++ b/wp-content/plugins/wporg-learn/js/expiration-date/index.js
@@ -1,7 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { Button, DateTimePicker, Dropdown, PanelRow } from '@wordpress/components';
+import {
+	Button,
+	DateTimePicker,
+	Dropdown,
+	PanelRow,
+} from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { format, __experimentalGetSettings } from '@wordpress/date';
 import { PluginPostStatusInfo } from '@wordpress/edit-post';
@@ -13,14 +18,17 @@ function ExpirationLabel( { date } ) {
 	const settings = __experimentalGetSettings();
 	return date
 		? format(
-			`${ settings.formats.date } ${ settings.formats.time }`,
-			date
-		)
+				`${ settings.formats.date } ${ settings.formats.time }`,
+				date
+		  )
 		: __( 'No expiration date', 'wporg-learn' );
 }
 
 const ExpirationDate = () => {
-	const postMetaData = useSelect( ( select ) => select( 'core/editor' ).getEditedPostAttribute( 'meta' ) || {} );
+	const postMetaData = useSelect(
+		( select ) =>
+			select( 'core/editor' ).getEditedPostAttribute( 'meta' ) || {}
+	);
 	const { editPost } = useDispatch( 'core/editor' );
 	const [ expDate, setExpDate ] = useState( postMetaData?.expiration_date );
 	const anchorRef = useRef();
@@ -49,8 +57,11 @@ const ExpirationDate = () => {
 					renderContent={ () => {
 						return (
 							<>
-								<p className="help-text" style={ { padding: '0 16px' } }>
-									{ __( 'A date when the content in this post might become obsolete.', 'wporg-learn' ) }
+								<p style={ { padding: '0 16px' } }>
+									{ __(
+										'A date when the content in this post might become obsolete.',
+										'wporg-learn'
+									) }
 								</p>
 								<DateTimePicker
 									ref={ pickerRef }
@@ -65,7 +76,9 @@ const ExpirationDate = () => {
 											},
 										} );
 
-										const { ownerDocument } = pickerRef.current;
+										const {
+											ownerDocument,
+										} = pickerRef.current;
 										ownerDocument.activeElement.blur();
 									} }
 								/>

--- a/wp-content/plugins/wporg-learn/webpack.config.js
+++ b/wp-content/plugins/wporg-learn/webpack.config.js
@@ -5,6 +5,7 @@ const config = require( '@wordpress/scripts/config/webpack.config' );
  */
 config.entry = {
 	'block-styles': './js/block-styles/index.js',
+	'expiration-date': './js/expiration-date/index.js',
 	'workshop-application-form': './js/workshop-application-form/src/index.js',
 	'workshop-details': './js/workshop-details/src/index.js',
 	'event': './js/event.js',


### PR DESCRIPTION
Adds a control to the "Status & Visibility" panel, just below the Publish date, for adding an expiration date. It functions the same way as setting the publish date: Click the label that either says "No expiration date" or has the current expiration date, which reveals a dropdown with a date picker.

Fixes #225 


## Screenshots

No expiration date set:
![expire-1](https://user-images.githubusercontent.com/916023/132419147-9066d4c5-cbef-4b99-a214-33c119fa53e4.jpg)

Choosing an expiration date:
![expire-2](https://user-images.githubusercontent.com/916023/132419166-48c57ebf-3bd4-4af1-8978-271c701a3af5.jpg)

With an expiration date set:
![expire-3](https://user-images.githubusercontent.com/916023/132419190-a2809944-6e8b-443f-a887-ba979b007136.jpg)

Filtering the list table for expired posts:
![expire-4](https://user-images.githubusercontent.com/916023/132419213-66f654cb-8a66-420c-a275-506257a51459.jpg)


## To test

1. Create some posts of one of the supported post types: lesson plans, workshops, courses, or lessons
2. Edit a post and set an expiration date for it that is in the future
3. Go to the list table for that post type and see the "post state" shows how long until it expires
4. Go back and change the expiration date to some time in the past
5. Now the "post state" should be red and say "Expired"
6. Try clicking the "Expired" view link at the top of the list table