### PR TITLE
Adding local bio check first, then .org bio.

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2020/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2020/functions.php
@@ -631,16 +631,18 @@ function wporg_get_workshop_presenters( $workshop = null ) {
  * This relies on the availability of the `bpmain_bp_xprofile_data` table, so for local environments
  * it falls back on values in `usermeta`.
  *
- * @param WP_User $user
+ * @param WP_User $user The user to retrieve a bio for.
  *
  * @return string
  */
 function wporg_get_workshop_presenter_bio( WP_User $user ) {
 	global $wpdb;
 
-	$bio = '';
+	// Retrieve bio from user data.
+	$bio = $user->description;
 
-	if ( 'local' !== wp_get_environment_type() ) {
+	// If bio is empty, retrieve from .org.
+	if ( ! $bio && 'local' !== wp_get_environment_type() ) {
 		$xprofile_field_id = 3;
 
 		$sql = $wpdb->prepare(
@@ -655,10 +657,6 @@ function wporg_get_workshop_presenter_bio( WP_User $user ) {
 		);
 
 		$bio = $wpdb->get_var( $sql ) ?: ''; // phpcs:ignore WordPress.DB.PreparedSQL -- prepare called above.
-	}
-
-	if ( ! $bio ) {
-		$bio = $user->description;
 	}
 
 	return apply_filters( 'the_content', wp_unslash( $bio ) );

--- a/wp-content/themes/pub/wporg-learn-2020/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2020/functions.php
@@ -626,10 +626,11 @@ function wporg_get_workshop_presenters( $workshop = null ) {
 }
 
 /**
- * Get the bio of a user, either from profiles.wordpress.org or usermeta.
+ * Get the bio of a user, first trying usermeta and then profiles.wordpress.org.
  *
- * This relies on the availability of the `bpmain_bp_xprofile_data` table, so for local environments
- * it falls back on values in `usermeta`.
+ * The `usermeta` bio (description) field will be pulled. If there is no bio, profiles.wordpress.org is tried.
+ * The bio at profiles.wordpress.org relies on the availability of the `bpmain_bp_xprofile_data` table.
+ * For local environments the bio will only pull from `usermeta`.
  *
  * @param WP_User $user The user to retrieve a bio for.
  *


### PR DESCRIPTION
Resolves #237

Reverses the current logic to:

1. Check for the existence of a local bio.
2. If no local bio found, tries to find .org bio.

No UI pieces were added to this PR.