### PR TITLE
Use the child theme's navigation.js file

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2020/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2020/functions.php
@@ -43,7 +43,7 @@ function wporg_learn_scripts() {
 	);
 	wp_enqueue_script(
 		'wporg-navigation',
-		get_template_directory_uri() . '/js/navigation.js',
+		get_theme_file_uri() . '/js/navigation.js',
 		array(),
 		filemtime( __DIR__ . '/js/navigation.js' ),
 		true


### PR DESCRIPTION
Resolves #204 

Load `navigation.js` from the `wporg-learn-2020` child theme, not the parent theme.