### PR TITLE
The second parameter to `get_terms` filter can be null.

### DIFF
--- a/wp-content/plugins/wporg-learn/inc/i18n.php
+++ b/wp-content/plugins/wporg-learn/inc/i18n.php
@@ -74,7 +74,7 @@ function translate_term( $term, $taxonomy_slug ) {
  *
  * @return WP_Term[]
  */
-function translate_terms( array $terms, array $taxonomies ) {
+function translate_terms( array $terms, ?array $taxonomies ) {
 	if ( 'en_US' === get_locale() ) {
 		return $terms;
 	}
@@ -89,8 +89,8 @@ function translate_terms( array $terms, array $taxonomies ) {
 		return $terms;
 	}
 
-	// If the terms query has multiple taxonomies, we don't know which one a term will belong to.
-	if ( count( $taxonomies ) > 1 ) {
+	// If the terms query has multiple (or no) taxonomies, we don't know which one a term will belong to.
+	if ( ! $taxonomies || count( $taxonomies ) > 1 ) {
 		return $terms;
 	}
 


### PR DESCRIPTION
The second parameter can be null, although it's not documented as such.

This happens when terms are queried by `term_taxonomy_id` and so no specific taxonomy is provided to the filter.

The taxonomy could be inferred from the WP_Term instance if available, but for the purposes of translation this isn't needed here.

This avoids a Fatal error when `get_terms( [ 'term_taxonomy_id' => ?? ] );` is made by Jetpack Sync.