### PR TITLE
Add custom roles, capability types for lesson plans / workshops

### DIFF
--- a/wp-content/plugins/wporg-learn/inc/capabilities.php
+++ b/wp-content/plugins/wporg-learn/inc/capabilities.php
@@ -87,7 +87,7 @@ function map_meta_caps( $required_caps, $current_cap, $user_id, $args ) {
 				$object = get_post_type_object( $post_type );
 				if ( user_can( $user_id, $object->cap->edit_posts ) ) {
 					$required_caps[] = $object->cap->edit_posts;
-					break 2;
+					break 2; // Breaks out of the foreach and the switch.
 				}
 			}
 
@@ -97,6 +97,7 @@ function map_meta_caps( $required_caps, $current_cap, $user_id, $args ) {
 		case 'read-internal-notes':
 		case 'create-internal-note':
 		case 'delete-internal-note':
+			// Override the meta caps set up in the Internal Notes plugin, specifically for the workshop post type.
 			$parent = get_post( $args[0] ?? 'none' );
 			if ( $parent && 'wporg_workshop' === get_post_type( $parent ) ) {
 				$required_caps = array( 'manage_workshop_internal_notes' );

--- a/wp-content/plugins/wporg-learn/inc/capabilities.php
+++ b/wp-content/plugins/wporg-learn/inc/capabilities.php
@@ -150,6 +150,9 @@ function add_or_update_lesson_plan_editor_role() {
 /**
  * Generate a list of capabilities for the Lesson Plan Editor role.
  *
+ * The Lesson Plan Editor should have full editing caps for the Lesson Plan post type, but no other post types.
+ * They can assign/unassign terms from the various taxonomies to lesson plans, but they can't add/edit/delete terms.
+ *
  * @return bool[]
  */
 function get_lesson_plan_editor_role_caps() {
@@ -217,6 +220,11 @@ function add_or_update_workshop_reviewer_role() {
 
 /**
  * Generate a list of capabilities for the Workshop Reviewer role.
+ *
+ * The Workshop Reviewer should have all the same caps as the Editor role, with the addition of `promote_users`
+ * (normally reserved for the Admin role), so that they can add workshop presenters as new users on the site.
+ *
+ * This also gives them the cap to manage internal notes on workshop posts. (See `set_caps_for_internal_notes` above.)
  *
  * @return bool[]
  */

--- a/wp-content/plugins/wporg-learn/inc/capabilities.php
+++ b/wp-content/plugins/wporg-learn/inc/capabilities.php
@@ -16,6 +16,9 @@ add_action( 'init', __NAMESPACE__ . '\add_or_update_workshop_reviewer_role' );
 /**
  * Assign custom post type caps to roles based on their equivalents for the 'post' post type.
  *
+ * Example: If a user has the `edit_others_posts` cap (from Editor role), this will also give them
+ * the equivalent `edit_others_lesson_plans` and `edit_others_workshops` caps.
+ *
  * @param bool[] $user_caps A list of primitive caps (keys) and whether user has them (boolean values).
  *
  * @return array
@@ -27,7 +30,7 @@ function set_post_type_caps( $user_caps ) {
 	);
 
 	foreach ( $capability_types as $capability_type ) {
-		// Set corresponding caps for all roles.
+		// Generate the caps for a capability type.
 		$cap_args = array(
 			'capability_type' => $capability_type,
 			'capabilities'    => array(),
@@ -48,13 +51,14 @@ function set_post_type_caps( $user_caps ) {
 /**
  * Enable a cap for managing internal notes on workshop posts.
  *
+ * The `promote_users` cap is shared by admin and workshop reviewer roles, which are the two roles
+ * that should also have access to internal notes.
+ *
  * @param bool[] $user_caps
  *
  * @return mixed
  */
 function set_caps_for_internal_notes( $user_caps ) {
-	// The promote_users cap is shared by admin and workshop reviewer roles, which are the two roles
-	// that should have access to internal notes.
 	if ( isset( $user_caps['promote_users'] ) && true === $user_caps['promote_users'] ) {
 		$user_caps['manage_workshop_internal_notes'] = true;
 	}
@@ -149,6 +153,7 @@ function add_or_update_lesson_plan_editor_role() {
  * @return bool[]
  */
 function get_lesson_plan_editor_role_caps() {
+	// Generate the caps for a capability type.
 	$cap_args = array(
 		'capability_type' => array( 'lesson_plan', 'lesson_plans' ),
 		'capabilities'    => array(),

--- a/wp-content/plugins/wporg-learn/inc/capabilities.php
+++ b/wp-content/plugins/wporg-learn/inc/capabilities.php
@@ -91,7 +91,7 @@ function map_meta_caps( $required_caps, $current_cap, $user_id, $args ) {
 				}
 			}
 
-			$required_caps[] = 'edit_posts';
+			$required_caps[] = 'do_not_allow';
 			break;
 
 		case 'read-internal-notes':

--- a/wp-content/plugins/wporg-learn/inc/capabilities.php
+++ b/wp-content/plugins/wporg-learn/inc/capabilities.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace WPOrg_Learn\Capabilities;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Actions and filters.
+ */
+add_filter( 'user_has_cap', __NAMESPACE__ . '\set_post_type_caps' );
+
+/**
+ *
+ *
+ * @param array $user_caps A list of primitive caps (keys) and whether user has them (boolean values).
+ *
+ * @return array
+ */
+function set_post_type_caps( $user_caps ) {
+	$capability_types = array(
+		array( 'lesson_plan', 'lesson_plans' ),
+		array( 'workshop', 'workshops' ),
+	);
+
+	foreach ( $capability_types as $capability_type ) {
+		// Set corresponding caps for all roles.
+		$cap_args = array(
+			'capability_type' => $capability_type,
+			'capabilities'    => array(),
+			'map_meta_cap'    => true,
+		);
+		$cap_map = (array) get_post_type_capabilities( (object) $cap_args );
+
+		foreach ( $user_caps as $cap => $bool ) {
+			if ( $bool && isset( $cap_map[ $cap ] ) ) {
+				$user_caps[ $cap_map[ $cap ] ] = true;
+			}
+		}
+	}
+
+	return $user_caps;
+}

--- a/wp-content/plugins/wporg-learn/inc/capabilities.php
+++ b/wp-content/plugins/wporg-learn/inc/capabilities.php
@@ -82,6 +82,7 @@ function map_meta_caps( $required_caps, $current_cap, $user_id, $args ) {
 			$required_caps       = array();
 			$learn_content_types = array( 'lesson-plan', 'wporg_workshop', 'course', 'lesson' );
 
+			// Grant `edit_any_learn_content` when the user has `edit_posts` for any of our custom post types.
 			foreach ( $learn_content_types as $post_type ) {
 				$object = get_post_type_object( $post_type );
 				if ( user_can( $user_id, $object->cap->edit_posts ) ) {

--- a/wp-content/plugins/wporg-learn/inc/capabilities.php
+++ b/wp-content/plugins/wporg-learn/inc/capabilities.php
@@ -98,7 +98,7 @@ function map_meta_caps( $required_caps, $current_cap, $user_id, $args ) {
 		case 'create-internal-note':
 		case 'delete-internal-note':
 			// Override the meta caps set up in the Internal Notes plugin, specifically for the workshop post type.
-			$parent = get_post( $args[0] ?? 'none' );
+			$parent = ! empty( $args[0] ) ? get_post( $args[0] ) : false;
 			if ( $parent && 'wporg_workshop' === get_post_type( $parent ) ) {
 				$required_caps = array( 'manage_workshop_internal_notes' );
 			}

--- a/wp-content/plugins/wporg-learn/inc/capabilities.php
+++ b/wp-content/plugins/wporg-learn/inc/capabilities.php
@@ -38,9 +38,9 @@ function set_post_type_caps( $user_caps ) {
 		);
 		$cap_map = (array) get_post_type_capabilities( (object) $cap_args );
 
-		foreach ( $user_caps as $cap => $bool ) {
-			if ( $bool && isset( $cap_map[ $cap ] ) ) {
-				$user_caps[ $cap_map[ $cap ] ] = true;
+		foreach ( $user_caps as $cap_slug => $granted ) {
+			if ( $granted && isset( $cap_map[ $cap_slug ] ) ) {
+				$user_caps[ $cap_map[ $cap_slug ] ] = true;
 			}
 		}
 	}

--- a/wp-content/plugins/wporg-learn/inc/capabilities.php
+++ b/wp-content/plugins/wporg-learn/inc/capabilities.php
@@ -8,6 +8,7 @@ defined( 'WPINC' ) || die();
  * Actions and filters.
  */
 add_filter( 'user_has_cap', __NAMESPACE__ . '\set_post_type_caps' );
+add_filter( 'map_meta_cap', __NAMESPACE__ . '\map_meta_caps', 10, 4 );
 add_action( 'init', __NAMESPACE__ . '\add_or_update_lesson_plan_editor_role' );
 
 /**
@@ -40,6 +41,37 @@ function set_post_type_caps( $user_caps ) {
 	}
 
 	return $user_caps;
+}
+
+/**
+ * Map primitive caps to our custom caps.
+ *
+ * @param array  $required_caps
+ * @param string $current_cap
+ * @param int    $user_id
+ * @param mixed  $args
+ *
+ * @return mixed
+ */
+function map_meta_caps( $required_caps, $current_cap, $user_id, $args ) {
+	switch ( $current_cap ) {
+		case 'edit_any_learn_content':
+			$required_caps       = array();
+			$learn_content_types = array( 'lesson-plan', 'wporg_workshop', 'course', 'lesson' );
+
+			foreach ( $learn_content_types as $post_type ) {
+				$object = get_post_type_object( $post_type );
+				if ( user_can( $user_id, $object->cap->edit_posts ) ) {
+					$required_caps[] = $object->cap->edit_posts;
+					break 2;
+				}
+			}
+
+			$required_caps[] = 'edit_posts';
+			break;
+	}
+
+	return $required_caps;
 }
 
 /**

--- a/wp-content/plugins/wporg-learn/inc/post-type.php
+++ b/wp-content/plugins/wporg-learn/inc/post-type.php
@@ -74,7 +74,8 @@ function register_lesson_plan() {
 		'has_archive'         => 'lesson-plans',
 		'exclude_from_search' => false,
 		'publicly_queryable'  => true,
-		'capability_type'     => 'page',
+		'capability_type'     => array( 'lesson_plan', 'lesson_plans' ),
+		'map_meta_cap'        => true,
 		'show_in_rest'        => true,
 	);
 
@@ -144,7 +145,8 @@ function register_workshop() {
 		'can_export'          => true,
 		'exclude_from_search' => false,
 		'publicly_queryable'  => true,
-		'capability_type'     => 'page',
+		'capability_type'     => array( 'workshop', 'workshops' ),
+		'map_meta_cap'        => true,
 		'show_in_rest'        => true,
 		'rewrite'             => array( 'slug' => 'workshop' ),
 		'template'            => generate_workshop_template_structure(),

--- a/wp-content/plugins/wporg-learn/inc/taxonomy.php
+++ b/wp-content/plugins/wporg-learn/inc/taxonomy.php
@@ -62,6 +62,10 @@ function register_lesson_audience() {
 		'show_in_nav_menus' => true,
 		'show_tagcloud'     => false,
 		'show_in_rest'      => true,
+		'capabilities'      => array(
+			'manage_terms' => 'edit_lesson_plans',
+			'assign_terms' => 'edit_lesson_plans',
+		),
 	);
 
 	register_taxonomy( 'audience', array( 'lesson-plan' ), $args );
@@ -104,6 +108,10 @@ function register_lesson_category() {
 		'show_in_nav_menus' => false,
 		'show_tagcloud'     => false,
 		'show_in_rest'      => true,
+		'capabilities'      => array(
+			'manage_terms' => 'edit_lesson_plans',
+			'assign_terms' => 'edit_lesson_plans',
+		),
 	);
 
 	register_taxonomy( 'wporg_lesson_category', array( 'lesson-plan' ), $args );
@@ -146,6 +154,10 @@ function register_lesson_duration() {
 		'show_in_nav_menus' => false,
 		'show_tagcloud'     => false,
 		'show_in_rest'      => true,
+		'capabilities'      => array(
+			'manage_terms' => 'edit_lesson_plans',
+			'assign_terms' => 'edit_lesson_plans',
+		),
 	);
 
 	register_taxonomy( 'duration', array( 'lesson-plan' ), $args );
@@ -187,6 +199,10 @@ function register_lesson_group() {
 		'show_in_nav_menus' => true,
 		'show_tagcloud'     => false,
 		'show_in_rest'      => true,
+		'capabilities'      => array(
+			'manage_terms' => 'edit_lesson_plans',
+			'assign_terms' => 'edit_lesson_plans',
+		),
 	);
 
 	register_taxonomy( 'lesson_group', array( 'lesson-plan' ), $args );
@@ -229,6 +245,10 @@ function register_lesson_instruction_type() {
 		'show_in_nav_menus' => true,
 		'show_tagcloud'     => false,
 		'show_in_rest'      => true,
+		'capabilities'      => array(
+			'manage_terms' => 'edit_lesson_plans',
+			'assign_terms' => 'edit_lesson_plans',
+		),
 	);
 
 	register_taxonomy( 'instruction_type', array( 'lesson-plan' ), $args );
@@ -271,6 +291,10 @@ function register_lesson_level() {
 		'show_in_nav_menus' => true,
 		'show_tagcloud'     => false,
 		'show_in_rest'      => true,
+		'capabilities'      => array(
+			'manage_terms' => 'edit_lesson_plans',
+			'assign_terms' => 'edit_lesson_plans',
+		),
 	);
 
 	register_taxonomy( 'level', array( 'lesson-plan' ), $args );
@@ -314,6 +338,10 @@ function register_workshop_series() {
 		'show_in_nav_menus' => true,
 		'show_tagcloud'     => false,
 		'show_in_rest'      => true,
+		'capabilities'      => array(
+			'manage_terms' => 'edit_workshops',
+			'assign_terms' => 'edit_workshops',
+		),
 	);
 
 	register_taxonomy( 'wporg_workshop_series', array( 'wporg_workshop' ), $args );
@@ -356,6 +384,10 @@ function register_workshop_topic() {
 		'show_in_nav_menus' => true,
 		'show_tagcloud'     => false,
 		'show_in_rest'      => true,
+		'capabilities'      => array(
+			'manage_terms' => 'edit_workshops',
+			'assign_terms' => 'edit_workshops',
+		),
 	);
 
 	register_taxonomy( 'topic', array( 'wporg_workshop' ), $args );

--- a/wp-content/plugins/wporg-learn/inc/taxonomy.php
+++ b/wp-content/plugins/wporg-learn/inc/taxonomy.php
@@ -421,7 +421,7 @@ function register_wp_version() {
 		'show_tagcloud'     => false,
 		'show_in_rest'      => true,
 		'capabilities'      => array(
-			'assign_terms' => 'edit_any_learn_content',
+			'assign_terms' => 'edit_any_learn_content', // See \WPOrg_Learn\Capabilities\map_meta_caps.
 		),
 	);
 
@@ -466,7 +466,7 @@ function register_included_content() {
 		'show_tagcloud'     => false,
 		'show_in_rest'      => true,
 		'capabilities'      => array(
-			'assign_terms' => 'edit_any_learn_content',
+			'assign_terms' => 'edit_any_learn_content', // See \WPOrg_Learn\Capabilities\map_meta_caps.
 		),
 	);
 

--- a/wp-content/plugins/wporg-learn/inc/taxonomy.php
+++ b/wp-content/plugins/wporg-learn/inc/taxonomy.php
@@ -63,7 +63,6 @@ function register_lesson_audience() {
 		'show_tagcloud'     => false,
 		'show_in_rest'      => true,
 		'capabilities'      => array(
-			'manage_terms' => 'edit_lesson_plans',
 			'assign_terms' => 'edit_lesson_plans',
 		),
 	);
@@ -109,7 +108,6 @@ function register_lesson_category() {
 		'show_tagcloud'     => false,
 		'show_in_rest'      => true,
 		'capabilities'      => array(
-			'manage_terms' => 'edit_lesson_plans',
 			'assign_terms' => 'edit_lesson_plans',
 		),
 	);
@@ -155,7 +153,6 @@ function register_lesson_duration() {
 		'show_tagcloud'     => false,
 		'show_in_rest'      => true,
 		'capabilities'      => array(
-			'manage_terms' => 'edit_lesson_plans',
 			'assign_terms' => 'edit_lesson_plans',
 		),
 	);
@@ -200,7 +197,6 @@ function register_lesson_group() {
 		'show_tagcloud'     => false,
 		'show_in_rest'      => true,
 		'capabilities'      => array(
-			'manage_terms' => 'edit_lesson_plans',
 			'assign_terms' => 'edit_lesson_plans',
 		),
 	);
@@ -246,7 +242,6 @@ function register_lesson_instruction_type() {
 		'show_tagcloud'     => false,
 		'show_in_rest'      => true,
 		'capabilities'      => array(
-			'manage_terms' => 'edit_lesson_plans',
 			'assign_terms' => 'edit_lesson_plans',
 		),
 	);
@@ -292,7 +287,6 @@ function register_lesson_level() {
 		'show_tagcloud'     => false,
 		'show_in_rest'      => true,
 		'capabilities'      => array(
-			'manage_terms' => 'edit_lesson_plans',
 			'assign_terms' => 'edit_lesson_plans',
 		),
 	);
@@ -339,7 +333,6 @@ function register_workshop_series() {
 		'show_tagcloud'     => false,
 		'show_in_rest'      => true,
 		'capabilities'      => array(
-			'manage_terms' => 'edit_workshops',
 			'assign_terms' => 'edit_workshops',
 		),
 	);
@@ -385,7 +378,6 @@ function register_workshop_topic() {
 		'show_tagcloud'     => false,
 		'show_in_rest'      => true,
 		'capabilities'      => array(
-			'manage_terms' => 'edit_workshops',
 			'assign_terms' => 'edit_workshops',
 		),
 	);
@@ -428,6 +420,9 @@ function register_wp_version() {
 		'show_in_nav_menus' => true,
 		'show_tagcloud'     => false,
 		'show_in_rest'      => true,
+		'capabilities'      => array(
+			'assign_terms' => 'edit_any_learn_content',
+		),
 	);
 
 	$post_types = array( 'lesson-plan', 'wporg_workshop', 'course', 'lesson' );
@@ -470,6 +465,9 @@ function register_included_content() {
 		'show_in_nav_menus' => true,
 		'show_tagcloud'     => false,
 		'show_in_rest'      => true,
+		'capabilities'      => array(
+			'assign_terms' => 'edit_any_learn_content',
+		),
 	);
 
 	$post_types = array( 'lesson-plan', 'wporg_workshop', 'course', 'lesson' );

--- a/wp-content/plugins/wporg-learn/wporg-learn.php
+++ b/wp-content/plugins/wporg-learn/wporg-learn.php
@@ -66,6 +66,7 @@ function get_views_path() {
 function load_files() {
 	require_once get_includes_path() . 'admin.php';
 	require_once get_includes_path() . 'blocks.php';
+	require_once get_includes_path() . 'capabilities.php';
 	require_once get_includes_path() . 'class-markdown-import.php';
 	require_once get_includes_path() . 'events.php';
 	require_once get_includes_path() . 'form.php';


### PR DESCRIPTION
Adds two new custom roles, Lesson Plan Editor and Workshop Reviewer, to the Learn site, which necessitates using custom capability types for the Lesson Plan and Workshop post types. Also introduces a custom capability for viewing/managing internal notes on the Workshop post type (enabled by the Internal Notes plugin), because only Admins/Workshop Reviewers should be able to see the notes, not Editors.

Fixes #220 
Fixes #223 

## To test

Lesson Plan Editor role

1. Create a new user on your test site and assign the Lesson Plan Editor role.
2. Log into WP Admin on the site with that user.
3. You should have access to the Lesson Plans menu in the left column, but no other post types.
4. You should be able to add new lesson plans as well as edit and delete existing ones.
5. You should be able to assign terms to lesson plans from any of the associated taxonomites. However, you should not be able to access the screens for adding/deleting/editing terms within those taxonomies.

Workshop Reviewer role

1. You'll need to temporarily install the Internal Notes plugin on your test site for this. You can check it out via [dotorg svn](https://dotorg.svn.wordpress.org/wordpress/website/wp-content/plugins/wporg-internal-notes) if you have access, or get it from [GitHub](https://github.com/WordPress/wporg-internal-notes), but then you'll have to run the build script.
1. Create two new users on your test site: one with the Workshop Reviewer role and one with the normal Editor role.
2. Log into WP Admin as the Workshop Reviewer.
3. You should be able to manage/edit all post types.
4. You should be able to change roles of other users on the test site (on the production multisite this [will allow](https://wordpress.org/support/article/roles-and-capabilities/#promote_users) "Add Existing User")
5. When you edit a workshop post, you should see the icon in the upper right to toggle the Internal Notes sidebar.
6. Now log out and log back in as the Editor user.
7. When editing a workshop post, you should no longer see the icon for the Internal Notes sidebar.