### PR TITLE
fix print area not spanning entire width of the workshops page

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2020/css/print.css
+++ b/wp-content/themes/pub/wporg-learn-2020/css/print.css
@@ -149,7 +149,7 @@ p a {
   padding: 0;
 }
 
-.single-wporg_workshop .wp-block-column {
+.single-wporg_workshop .wp-block-column, .single-wporg_workshop .wp-block-columns:not(.is-not-stacked-on-mobile) > .wp-block-column[style*="flex-basis"] {
   flex-grow: 1;
 }
 

--- a/wp-content/themes/pub/wporg-learn-2020/css/print.scss
+++ b/wp-content/themes/pub/wporg-learn-2020/css/print.scss
@@ -163,7 +163,8 @@ p a {
 		padding: 0;
 	}
 
-	.wp-block-column {
+	.wp-block-column,
+	.wp-block-columns:not(.is-not-stacked-on-mobile) > .wp-block-column[style*="flex-basis"] {
 		flex-grow: 1;
 	}
 


### PR DESCRIPTION
Based on discussion https://github.com/WordPress/learn/pull/247#pullrequestreview-775372869

Handling a gutenberg class that only shows up on live, limiting width of workshops detail page when printing.