### PR TITLE
Adds a print button to Workshops and Lesson plans

### DIFF
--- a/wp-content/plugins/wporg-learn/views/block-workshop-details.php
+++ b/wp-content/plugins/wporg-learn/views/block-workshop-details.php
@@ -34,14 +34,14 @@ $has_transcript = false !== strpos( $post->post_content, 'id="transcript"' );
 					</span>
 				</li>
 			<?php endif; ?>
-            <li>
-                <b><?php esc_html_e( 'Print View', 'wporg-learn' ); ?></b>
-                <span>
+			<li>
+				<b><?php esc_html_e( 'Print View', 'wporg-learn' ); ?></b>
+				<span>
 						<a class="components-button is-secondary is-small" href="#" onclick="window.print();">
 							<?php esc_html_e( 'View', 'wporg-learn' ); ?>
 						</a>
 					</span>
-            </li>
+			</li>
 		</ul>
 	<?php endif; ?>
 

--- a/wp-content/plugins/wporg-learn/views/block-workshop-details.php
+++ b/wp-content/plugins/wporg-learn/views/block-workshop-details.php
@@ -34,6 +34,14 @@ $has_transcript = false !== strpos( $post->post_content, 'id="transcript"' );
 					</span>
 				</li>
 			<?php endif; ?>
+            <li>
+                <b><?php esc_html_e( 'Print View', 'wporg-learn' ); ?></b>
+                <span>
+						<a class="components-button is-secondary is-small" href="#" onclick="window.print();">
+							<?php esc_html_e( 'View', 'wporg-learn' ); ?>
+						</a>
+					</span>
+            </li>
 		</ul>
 	<?php endif; ?>
 

--- a/wp-content/themes/pub/wporg-learn-2020/css/print.css
+++ b/wp-content/themes/pub/wporg-learn-2020/css/print.css
@@ -149,7 +149,8 @@ p a {
   padding: 0;
 }
 
-.single-wporg_workshop .wp-block-column, .single-wporg_workshop .wp-block-columns:not(.is-not-stacked-on-mobile) > .wp-block-column[style*="flex-basis"] {
+.single-wporg_workshop .wp-block-column,
+.single-wporg_workshop .wp-block-columns:not(.is-not-stacked-on-mobile) > .wp-block-column[style*="flex-basis"] {
   flex-grow: 1;
 }
 

--- a/wp-content/themes/pub/wporg-learn-2020/template-parts/content-single.php
+++ b/wp-content/themes/pub/wporg-learn-2020/template-parts/content-single.php
@@ -64,7 +64,9 @@
 							</a>
 						</li> -->
 					</ul>
-
+					<div class="lp-print">
+						<a href="#" onclick="window.print();"><?php esc_html_e( 'Print view', 'wporg-learn' ); ?></a>
+					</div>
 					<div class="lp-suggestion">
 						<h2 class="lp-suggestion_title h4"><?php esc_html_e( 'Suggestions', 'wporg-learn' ); ?></h2>
 						<p><?php esc_html_e( 'Found a typo, grammar error,or outdated screenshot?', 'wporg-learn' ); ?></p>

--- a/wp-content/themes/pub/wporg-learn-2020/template-parts/content-single.php
+++ b/wp-content/themes/pub/wporg-learn-2020/template-parts/content-single.php
@@ -65,7 +65,7 @@
 						</li> -->
 					</ul>
 					<div class="lp-print">
-						<a href="#" onclick="window.print();"><?php esc_html_e( 'Print view', 'wporg-learn' ); ?></a>
+						<p><a href="#" onclick="window.print();"><?php esc_html_e( 'Print view', 'wporg-learn' ); ?></a></p>
 					</div>
 					<div class="lp-suggestion">
 						<h2 class="lp-suggestion_title h4"><?php esc_html_e( 'Suggestions', 'wporg-learn' ); ?></h2>


### PR DESCRIPTION
Adds a Print View item and button to Workshops, under the Transcript item

![post_type-workshop-p-5-preview-true](https://user-images.githubusercontent.com/180629/138566267-1c27b97b-3709-4688-9524-e4bac2d8fa07.png)

Adds a Print View link to Lesson plans, below the details but above the Suggestions in the sidebar

![post_type-lesson-plan-p-7-preview-true](https://user-images.githubusercontent.com/180629/138566281-c661b652-ad3d-4828-8044-77738d957001.png)

Closes #251 

