### PR TITLE
Fix up link text on front page for screen readers.

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2020/front-page.php
+++ b/wp-content/themes/pub/wporg-learn-2020/front-page.php
@@ -48,7 +48,7 @@ get_header(); ?>
 		<section>
 			<div class="row align-middle between section-heading">
 				<h2 class="h4 section-heading_title"><?php esc_html_e( 'Recent Workshops', 'wporg-learn' ); ?></h2>
-				<a class="section-heading_link" href="/workshops"><?php esc_html_e( 'View All »', 'wporg-learn' ); ?></a>
+				<a class="section-heading_link" href="/workshops"><span aria-hidden="true"><?php esc_html_e( 'View All »', 'wporg-learn' ); ?></span><span class="screen-reader-text"><?php esc_html_e( 'View All Workshops', 'wporg-learn' ); ?></span></a>
 			</div>
 
 			<?php

--- a/wp-content/themes/pub/wporg-learn-2020/template-parts/component-submit-idea-cta.php
+++ b/wp-content/themes/pub/wporg-learn-2020/template-parts/component-submit-idea-cta.php
@@ -13,8 +13,8 @@ $args = wp_parse_args( $args );
 
 <section class="submit-idea-cta">
 	<?php if ( isset( $args['icon'] ) ) : ?>
-		<div class="content-icon"><span class="dashicons dashicons-<?php echo esc_attr( $args['icon'] ); ?>"></span></div>
+		<div aria-hidden="true" class="content-icon"><span class="dashicons dashicons-<?php echo esc_attr( $args['icon'] ); ?>"></span></div>
 	<?php endif; ?>
 	<h2><?php esc_html_e( 'Have an Idea for a Workshop? Let us know!', 'wporg-learn' ); ?></h2>
-	<a class="button button-primary button-large" href="https://learn.wordpress.org/workshop-presenter-application/"><?php esc_html_e( 'Submit an Idea', 'wporg-learn' ); ?></a>
+	<a class="button button-primary button-large" href="https://learn.wordpress.org/workshop-presenter-application/"><span aria-hidden="true"><?php esc_html_e( 'Submit an Idea', 'wporg-learn' ); ?></span><span class="screen-reader-text"><?php esc_html_e( 'Submit Workshop Idea', 'wporg-learn' ); ?></span></a>
 </section>


### PR DESCRIPTION
Make link text more descriptive. Eliminate those icons that just don't read well with screen readers.