### PR TITLE
Updating homepage events

### DIFF
--- a/wp-content/plugins/wporg-learn/inc/events.php
+++ b/wp-content/plugins/wporg-learn/inc/events.php
@@ -69,7 +69,7 @@ function get_discussion_events_from_db( DateTime $start_date, DateTime $end_date
 	$sql = "
 		SELECT *
 		FROM wporg_events
-		WHERE meetup_url = 'https://www.meetup.com/learn-wordpress-discussions/'
+		WHERE meetup_url = 'https://www.meetup.com/wordpress-social-learning/'
 		AND status = 'scheduled'
 		AND date_utc BETWEEN %s AND %s
 		ORDER BY date_utc

--- a/wp-content/themes/pub/wporg-learn-2020/front-page.php
+++ b/wp-content/themes/pub/wporg-learn-2020/front-page.php
@@ -71,9 +71,9 @@ get_header(); ?>
 			<section class="wporg-learn-workshop-discussion-events">
 				<div class="row align-middle between section-heading">
 					<h2 class="h4 section-heading_title">
-						<?php esc_html_e( 'Upcoming Discussion Groups', 'wporg-learn' ); ?>
+						<?php esc_html_e( 'Upcoming Social Learning Spaces', 'wporg-learn' ); ?>
 					</h2>
-					<a class="section-heading_link" href="https://www.meetup.com/learn-wordpress-discussions/">
+					<a class="section-heading_link" href="/social-learning/">
 						<?php esc_html_e( 'View All »', 'wporg-learn' ); ?>
 					</a>
 				</div>


### PR DESCRIPTION
Fixing events on homepage and renaming to social learning spaces.

Fixes #278 