### PR TITLE
Remove non-featured courses from search results

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2020/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2020/functions.php
@@ -300,22 +300,22 @@ function wporg_archive_modify_query( WP_Query $query ) {
 	// Omit some post types from search results.
 	if ( $query->is_main_query() && $query->is_search() ) {
 		$public_post_types = array_keys( get_post_types( array( 'public' => true ) ) );
-		$omit_from_search = array( 'attachment','page', 'lesson', 'quiz', 'sensei_message', 'meeting' );
+		$omit_from_search = array( 'attachment', 'page', 'lesson', 'quiz', 'sensei_message', 'meeting' );
 		$searchable_post_types = array_diff( $public_post_types, $omit_from_search );
 
 		// Only show featured courses, but don't limit other post types
 		$query->set(
 			'meta_query',
-			array(
-				'relation' => 'OR',
 				array(
-					'key'   => '_course_featured',
-					'value' => 'featured',
+					'relation' => 'OR',
+					array(
+						'key'   => '_course_featured',
+						'value' => 'featured',
+					),
+					array(
+						'key'      => '_course_featured',
+						'compare'  => 'NOT EXISTS',
 				),
-				array(
-		          'key'      => '_course_featured',
-		          'compare'  => 'NOT EXISTS'
-		        ),
 			)
 		);
 

--- a/wp-content/themes/pub/wporg-learn-2020/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2020/functions.php
@@ -300,8 +300,24 @@ function wporg_archive_modify_query( WP_Query $query ) {
 	// Omit some post types from search results.
 	if ( $query->is_main_query() && $query->is_search() ) {
 		$public_post_types = array_keys( get_post_types( array( 'public' => true ) ) );
-		$omit_from_search = array( 'attachment', 'lesson', 'quiz', 'sensei_message', 'meeting' );
+		$omit_from_search = array( 'attachment','page', 'lesson', 'quiz', 'sensei_message', 'meeting' );
 		$searchable_post_types = array_diff( $public_post_types, $omit_from_search );
+
+		// Only show featured courses, but don't limit other post types
+		$query->set(
+			'meta_query',
+			array(
+				'relation' => 'OR',
+				array(
+					'key'   => '_course_featured',
+					'value' => 'featured',
+				),
+				array(
+		          'key'      => '_course_featured',
+		          'compare'  => 'NOT EXISTS'
+		        ),
+			)
+		);
 
 		$query->set( 'post_type', $searchable_post_types );
 	}

--- a/wp-content/themes/pub/wporg-learn-2020/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2020/functions.php
@@ -306,15 +306,15 @@ function wporg_archive_modify_query( WP_Query $query ) {
 		// Only show featured courses, but don't limit other post types
 		$query->set(
 			'meta_query',
+			array(
+				'relation' => 'OR',
 				array(
-					'relation' => 'OR',
-					array(
-						'key'   => '_course_featured',
-						'value' => 'featured',
-					),
-					array(
-						'key'      => '_course_featured',
-						'compare'  => 'NOT EXISTS',
+					'key'   => '_course_featured',
+					'value' => 'featured',
+				),
+				array(
+					'key'      => '_course_featured',
+					'compare'  => 'NOT EXISTS',
 				),
 			)
 		);


### PR DESCRIPTION
This PR removes non-featured courses from search results without affecting other post types. It also removes pages from search results.

Fixes #286 