### PR TITLE
Updating page titles to match other post types

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2020/header.php
+++ b/wp-content/themes/pub/wporg-learn-2020/header.php
@@ -49,8 +49,6 @@ $menu_items = array(
 				<div class="search-form--is-inline search-form--is-constrained search-form--is-centered">
 					<?php get_search_form(); ?>
 				</div>
-				<?php elseif ( is_page() ) : ?>
-				<h1 class="site-title"><a href="<?php echo esc_url( get_the_permalink() ); ?>" rel="home"><?php the_title(); ?></a></h1>
 				<?php else : ?>
 				<p class="site-title">
 					<a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home">

--- a/wp-content/themes/pub/wporg-learn-2020/page.php
+++ b/wp-content/themes/pub/wporg-learn-2020/page.php
@@ -20,6 +20,11 @@ get_header();
 	<main id="main" class="site-main" role="main">
 		<?php get_template_part( 'template-parts/component', 'breadcrumbs' ); ?>
 
+		<div class="row align-middle between section-heading section-heading--with-space">
+			<?php the_title( '<h1 class="section-heading_title h2">', '</h1>' ); ?>
+		</div>
+		<hr>
+
 		<div id="main-content">
 			<?php
 			while ( have_posts() ) :


### PR DESCRIPTION
This commit ensures that the header section looks mostly the same on all post types - including site title, navigation menu, and page title below. This goes some of the way to completing #245 and fixes #264.

Closes #264 