### PR TITLE
Adding links to workshop & lesson plan meta data

### DIFF
--- a/wp-content/plugins/wporg-learn/inc/blocks.php
+++ b/wp-content/plugins/wporg-learn/inc/blocks.php
@@ -77,7 +77,7 @@ function workshop_details_render_callback( $attributes, $content ) {
 	$captions  = get_post_meta( $post->ID, 'video_caption_language' );
 
 	$topic_names = array();
-	foreach( $topic_ids as $id ) {
+	foreach ( $topic_ids as $id ) {
 		$topic_names[] = get_term( $id )->name;
 	}
 

--- a/wp-content/plugins/wporg-learn/views/block-workshop-details.php
+++ b/wp-content/plugins/wporg-learn/views/block-workshop-details.php
@@ -20,26 +20,28 @@ $has_transcript = false !== strpos( $post->post_content, 'id="transcript"' );
 			<?php foreach ( $fields as $key => $field ) : ?>
 				<li>
 					<b><?php echo esc_html( $field['label'] ); ?></b>
-					<?php
-					$display = '';
-					foreach ( $field['value'] as $field_key => $value ) {
-						$url = '';
-						if ( ! empty( $field['param'] ) ) {
-							$url = trailingslashit( site_url() ) . 'workshops/?' . $key . '=' . $field['param'][ $field_key ];
-						}
+					<span>
+						<?php
+						$i = 0;
+						foreach ( $field['value'] as $field_key => $value ) {
+							$url = '';
+							if ( ! empty( $field['param'] ) ) {
+								$url = trailingslashit( site_url() ) . 'workshops/?' . $key . '=' . $field['param'][ $field_key ];
+							}
 
-						if ( $display ) {
-							$display .= ', ';
-						}
+							if ( 0 < $i ) {
+								echo ', ';
+							}
 
-						if ( $url ) {
-							$display .= '<a href=" ' . esc_url( $url ) . '">' . esc_html( $value ) . '</a>';
-						} else {
-							$display .= esc_html( $value );
+							if ( $url ) {
+								echo sprintf( '%1$s' . esc_url( $url ) . '%2$s' . esc_html( $value ) . '%3$s', '<a href="', '">', '</a>' );
+							} else {
+								echo esc_html( $value );
+							}
+							$i++;
 						}
-					}
-					?>
-					<span><?php echo $display; ?></span>
+						?>
+					</span>
 				</li>
 			<?php endforeach; ?>
 

--- a/wp-content/plugins/wporg-learn/views/block-workshop-details.php
+++ b/wp-content/plugins/wporg-learn/views/block-workshop-details.php
@@ -34,7 +34,7 @@ $has_transcript = false !== strpos( $post->post_content, 'id="transcript"' );
 							}
 
 							if ( $url ) {
-								echo sprintf( '%1$s' . esc_url( $url ) . '%2$s' . esc_html( $value ) . '%3$s', '<a href="', '">', '</a>' );
+								echo '<a href="' . esc_url( $url ) . '">' . esc_html( $value ) . '</a>';
 							} else {
 								echo esc_html( $value );
 							}

--- a/wp-content/plugins/wporg-learn/views/block-workshop-details.php
+++ b/wp-content/plugins/wporg-learn/views/block-workshop-details.php
@@ -22,7 +22,7 @@ $has_transcript = false !== strpos( $post->post_content, 'id="transcript"' );
 					<b><?php echo esc_html( $field['label'] ); ?></b>
 					<?php
 					$display = '';
-					foreach( $field['value'] as $field_key => $value ) {
+					foreach ( $field['value'] as $field_key => $value ) {
 						$url = '';
 						if ( ! empty( $field['param'] ) ) {
 							$url = trailingslashit( site_url() ) . 'workshops/?' . $key . '=' . $field['param'][ $field_key ];
@@ -32,7 +32,7 @@ $has_transcript = false !== strpos( $post->post_content, 'id="transcript"' );
 							$display .= ', ';
 						}
 
-						if( $url ) {
+						if ( $url ) {
 							$display .= '<a href=" ' . esc_url( $url ) . '">' . esc_html( $value ) . '</a>';
 						} else {
 							$display .= esc_html( $value );

--- a/wp-content/plugins/wporg-learn/views/block-workshop-details.php
+++ b/wp-content/plugins/wporg-learn/views/block-workshop-details.php
@@ -17,10 +17,29 @@ $has_transcript = false !== strpos( $post->post_content, 'id="transcript"' );
 <div class="wp-block-wporg-learn-workshop-details">
 	<?php if ( ! empty( $fields ) ) : ?>
 		<ul class="workshop-details-list">
-			<?php foreach ( $fields as $key => $value ) : ?>
+			<?php foreach ( $fields as $key => $field ) : ?>
 				<li>
-					<b><?php echo esc_html( $key ); ?></b>
-					<span><?php echo esc_html( $value ); ?></span>
+					<b><?php echo esc_html( $field['label'] ); ?></b>
+					<?php
+					$display = '';
+					foreach( $field['value'] as $field_key => $value ) {
+						$url = '';
+						if ( ! empty( $field['param'] ) ) {
+							$url = trailingslashit( site_url() ) . 'workshops/?' . $key . '=' . $field['param'][ $field_key ];
+						}
+
+						if ( $display ) {
+							$display .= ', ';
+						}
+
+						if( $url ) {
+							$display .= '<a href=" ' . esc_url( $url ) . '">' . esc_html( $value ) . '</a>';
+						} else {
+							$display .= esc_html( $value );
+						}
+					}
+					?>
+					<span><?php echo $display; ?></span>
 				</li>
 			<?php endforeach; ?>
 

--- a/wp-content/themes/pub/wporg-learn-2020/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2020/functions.php
@@ -165,7 +165,7 @@ function wporg_get_cat_or_default_slug() {
 }
 
 /**
- * Get the values associated to the page/post
+ * Get the values associated to the page/post formatted as a string
  *
  * @param string $post_id Id of the post.
  * @param string $tax_slug The slug for the custom taxonomy.
@@ -197,10 +197,22 @@ function wporg_learn_get_taxonomy_terms_array( $post_id, $tax_slug ) {
 	return $terms;
 }
 
+/**
+ * Get the values associated to the page/post according to the context
+ * @param  int    $post_id  ID of the post
+ * @param  string $tax_slug The slug for the custom taxonomy
+ * @param  string $context  The context for display
+ *
+ * @return array|string
+ */
 function wporg_learn_get_taxonomy_terms( $post_id, $tax_slug, $context ) {
 	switch ( $context ) {
-		case 'archive': return wporg_learn_get_taxonomy_terms_string( $post_id, $tax_slug ); break;
-		case 'single': return wporg_learn_get_taxonomy_terms_array( $post_id, $tax_slug ); break;
+		case 'archive':
+			return wporg_learn_get_taxonomy_terms_string( $post_id, $tax_slug );
+			break;
+		case 'single':
+			return wporg_learn_get_taxonomy_terms_array( $post_id, $tax_slug );
+			break;
 	}
 }
 

--- a/wp-content/themes/pub/wporg-learn-2020/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2020/functions.php
@@ -179,33 +179,63 @@ function wporg_learn_get_taxonomy_terms_string( $post_id, $tax_slug ) {
 }
 
 /**
+ * Get the values associated to the page/post formatted as an array
+ *
+ * @param string $post_id Id of the post.
+ * @param string $tax_slug The slug for the custom taxonomy.
+ *
+ * @return array
+ */
+function wporg_learn_get_taxonomy_terms_array( $post_id, $tax_slug ) {
+	$term_ids = wp_get_post_terms( $post_id, $tax_slug, array( 'fields' => 'ids' ) );
+
+	$terms = array();
+	foreach ( $term_ids as $id ) {
+		$terms[ $id ] = get_term( $id )->name;
+	}
+
+	return $terms;
+}
+
+function wporg_learn_get_taxonomy_terms( $post_id, $tax_slug, $context ) {
+	switch ( $context ) {
+		case 'archive': return wporg_learn_get_taxonomy_terms_string( $post_id, $tax_slug ); break;
+		case 'single': return wporg_learn_get_taxonomy_terms_array( $post_id, $tax_slug ); break;
+	}
+}
+
+/**
  * Returns the taxonomies associated to a lesson or workshop
  *
  * @param int $post_id Id of the post.
  *
  * @return array
  */
-function wporg_learn_get_lesson_plan_taxonomy_data( $post_id ) {
+function wporg_learn_get_lesson_plan_taxonomy_data( $post_id, $context ) {
 	return array(
 		array(
 			'icon'  => 'clock',
+			'slug'  => 'duration',
 			'label' => wporg_label_with_colon( get_taxonomy_labels( get_taxonomy( 'duration' ) )->singular_name ),
-			'value' => wporg_learn_get_taxonomy_terms_string( $post_id, 'duration' ),
+			'value' => wporg_learn_get_taxonomy_terms( $post_id, 'duration', $context ),
 		),
 		array(
 			'icon'  => 'admin-users',
+			'slug'  => 'audience',
 			'label' => wporg_label_with_colon( get_taxonomy_labels( get_taxonomy( 'audience' ) )->singular_name ),
-			'value' => wporg_learn_get_taxonomy_terms_string( $post_id, 'audience' ),
+			'value' => wporg_learn_get_taxonomy_terms( $post_id, 'audience', $context ),
 		),
 		array(
 			'icon'  => 'dashboard',
+			'slug'  => 'level',
 			'label' => wporg_label_with_colon( get_taxonomy_labels( get_taxonomy( 'level' ) )->singular_name ),
-			'value' => wporg_learn_get_taxonomy_terms_string( $post_id, 'level' ),
+			'value' => wporg_learn_get_taxonomy_terms( $post_id, 'level', $context ),
 		),
 		array(
 			'icon'  => 'welcome-learn-more',
+			'slug'  => 'type',
 			'label' => wporg_label_with_colon( get_taxonomy_labels( get_taxonomy( 'instruction_type' ) )->singular_name ),
-			'value' => wporg_learn_get_taxonomy_terms_string( $post_id, 'instruction_type' ),
+			'value' => wporg_learn_get_taxonomy_terms( $post_id, 'instruction_type', $context ),
 		),
 	);
 }
@@ -579,7 +609,7 @@ function wporg_learn_get_card_template_args( $post_id ) {
 			break;
 
 		case 'lesson-plan':
-			$args['meta'] = wporg_learn_get_lesson_plan_taxonomy_data( $post_id );
+			$args['meta'] = wporg_learn_get_lesson_plan_taxonomy_data( $post_id, 'archive' );
 			break;
 
 		case 'wporg_workshop':

--- a/wp-content/themes/pub/wporg-learn-2020/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2020/functions.php
@@ -199,9 +199,10 @@ function wporg_learn_get_taxonomy_terms_array( $post_id, $tax_slug ) {
 
 /**
  * Get the values associated to the page/post according to the context
- * @param  int    $post_id  ID of the post
- * @param  string $tax_slug The slug for the custom taxonomy
- * @param  string $context  The context for display
+ *
+ * @param  int    $post_id  ID of the post.
+ * @param  string $tax_slug The slug for the custom taxonomy.
+ * @param  string $context  The context for display.
  *
  * @return array|string
  */

--- a/wp-content/themes/pub/wporg-learn-2020/sidebar-lesson-plan.php
+++ b/wp-content/themes/pub/wporg-learn-2020/sidebar-lesson-plan.php
@@ -14,7 +14,7 @@ namespace WordPressdotorg\Theme;
 	<div class="lp-details">
 		<ul>
 			<?php
-			foreach ( wporg_learn_get_lesson_plan_taxonomy_data( get_the_ID() ) as $detail ) {
+			foreach ( wporg_learn_get_lesson_plan_taxonomy_data( get_the_ID(), 'single' ) as $detail ) {
 				if ( ! empty( $detail['value'] ) ) {
 					include locate_template( 'template-parts/component-taxonomy-item.php' );
 				}

--- a/wp-content/themes/pub/wporg-learn-2020/template-parts/component-taxonomy-item.php
+++ b/wp-content/themes/pub/wporg-learn-2020/template-parts/component-taxonomy-item.php
@@ -18,8 +18,8 @@
 
 			<?php
 			$i = 0;
-			foreach ( $detail['value'] as $id => $value ) {
-				$url = trailingslashit( site_url() ) . 'lesson-plans/?' . $detail['slug'] . '[]=' . $id;
+			foreach ( $detail['value'] as $key => $value ) {
+				$url = trailingslashit( site_url() ) . 'lesson-plans/?' . $detail['slug'] . '[]=' . $key;
 
 				if ( 0 < $i ) {
 					echo ', ';

--- a/wp-content/themes/pub/wporg-learn-2020/template-parts/component-taxonomy-item.php
+++ b/wp-content/themes/pub/wporg-learn-2020/template-parts/component-taxonomy-item.php
@@ -25,7 +25,7 @@
 					echo ', ';
 				}
 
-				echo sprintf( '%1$s' . esc_attr( $url ) . '%2$s' . esc_html( $value ) . '%3$s', '<a href="', '">', '</a>' );
+				echo '<a href="' . esc_attr( $url ) . '">' . esc_html( $value ) . '</a>';
 				$i++;
 			}
 			?>

--- a/wp-content/themes/pub/wporg-learn-2020/template-parts/component-taxonomy-item.php
+++ b/wp-content/themes/pub/wporg-learn-2020/template-parts/component-taxonomy-item.php
@@ -13,6 +13,22 @@
 	<span class="dashicons dashicons-<?php echo esc_attr( $detail['icon'] ); ?>"></span>
 	<span><?php echo esc_html( $detail['label'] ); ?></span>
 	<strong>
-		<span><?php echo esc_html( $detail['value'] ); ?></span>
+		<span>
+			<?php //echo esc_html( $detail['value'] ); ?>
+
+			<?php
+			$i = 0;
+			foreach ( $detail['value'] as $id => $value ) {
+				$url = trailingslashit( site_url() ) . 'lesson-plans/?' . $detail['slug'] . '[]=' . $id;
+
+				if ( 0 < $i ) {
+					echo ', ';
+				}
+
+				echo sprintf( '%1$s' . esc_attr( $url ) . '%2$s' . esc_html( $value ) . '%3$s', '<a href="', '">', '</a>' );
+				$i++;
+			}
+			?>
+		</span>
 	</strong>
 </li>


### PR DESCRIPTION
This commit enhances the function that generates the workshop meta data block to fetch the IDs as well, and then link each meta item to its filtered archive page.

Closes #192 