### PR TITLE
Add WordPress version to filters & display on Lesson Plans and Workshops

### DIFF
--- a/wp-content/plugins/wporg-learn/inc/blocks.php
+++ b/wp-content/plugins/wporg-learn/inc/blocks.php
@@ -75,7 +75,9 @@ function workshop_details_render_callback( $attributes, $content ) {
 	$topic_ids = wp_get_post_terms( $post->ID, 'topic', array( 'fields' => 'ids' ) );
 	$level     = wp_get_post_terms( $post->ID, 'level', array( 'fields' => 'names' ) );
 	$captions  = get_post_meta( $post->ID, 'video_caption_language' );
-	$versions  = wp_get_post_terms( $post->ID, 'wporg_wp_version', array( 'fields' => 'names' ) );
+
+	$version_ids    = wp_get_post_terms( $post->ID, 'wporg_wp_version', array( 'fields' => 'ids' ) );
+	$version_names  = wp_get_post_terms( $post->ID, 'wporg_wp_version', array( 'fields' => 'names' ) );
 
 	$topic_names = array();
 	foreach ( $topic_ids as $id ) {
@@ -95,8 +97,8 @@ function workshop_details_render_callback( $attributes, $content ) {
 		),
 		'wp_version' => array(
 			'label' => __( 'Related Version', 'wporg-learn' ),
-			'param' => array(),
-			'value' => $versions,
+			'param' => $version_ids,
+			'value' => $version_names,
 		),
 		'level' => array(
 			'label' => __( 'Level', 'wporg-learn' ),

--- a/wp-content/plugins/wporg-learn/inc/blocks.php
+++ b/wp-content/plugins/wporg-learn/inc/blocks.php
@@ -75,6 +75,7 @@ function workshop_details_render_callback( $attributes, $content ) {
 	$topic_ids = wp_get_post_terms( $post->ID, 'topic', array( 'fields' => 'ids' ) );
 	$level     = wp_get_post_terms( $post->ID, 'level', array( 'fields' => 'names' ) );
 	$captions  = get_post_meta( $post->ID, 'video_caption_language' );
+	$versions  = wp_get_post_terms( $post->ID, 'wporg_wp_version', array( 'fields' => 'names' ) );
 
 	$topic_names = array();
 	foreach ( $topic_ids as $id ) {
@@ -91,6 +92,11 @@ function workshop_details_render_callback( $attributes, $content ) {
 			'label' => __( 'Topic', 'wporg-learn' ),
 			'param' => $topic_ids,
 			'value' => $topic_names,
+		),
+		'wp_version' => array(
+			'label' => __( 'Related Version', 'wporg-learn' ),
+			'param' => array(),
+			'value' => $versions,
 		),
 		'level' => array(
 			'label' => __( 'Level', 'wporg-learn' ),

--- a/wp-content/themes/pub/wporg-learn-2020/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2020/functions.php
@@ -477,7 +477,7 @@ function wporg_archive_maybe_apply_query_filters( WP_Query &$query ) {
 			),
 			'wp_version' => array(
 				'filter' => FILTER_VALIDATE_INT,
-				'flags'  => FILTER_REQUIRE_ARRAY,
+				'flags'  => FILTER_FORCE_ARRAY,
 			),
 		),
 		false

--- a/wp-content/themes/pub/wporg-learn-2020/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2020/functions.php
@@ -448,24 +448,28 @@ function wporg_archive_maybe_apply_query_filters( WP_Query &$query ) {
 	$filters = filter_input_array(
 		INPUT_GET,
 		array(
-			'search'   => FILTER_SANITIZE_STRING,
-			'captions' => FILTER_SANITIZE_STRING,
-			'language' => FILTER_SANITIZE_STRING,
-			'audience' => array(
+			'search'     => FILTER_SANITIZE_STRING,
+			'captions'   => FILTER_SANITIZE_STRING,
+			'language'   => FILTER_SANITIZE_STRING,
+			'audience'   => array(
 				'filter' => FILTER_VALIDATE_INT,
 				'flags'  => FILTER_REQUIRE_ARRAY,
 			),
-			'duration' => array(
+			'duration'   => array(
 				'filter' => FILTER_VALIDATE_INT,
 				'flags'  => FILTER_REQUIRE_ARRAY,
 			),
-			'level'    => array(
+			'level'      => array(
 				'filter' => FILTER_VALIDATE_INT,
 				'flags'  => FILTER_REQUIRE_ARRAY,
 			),
-			'series'   => FILTER_VALIDATE_INT,
-			'topic'    => FILTER_VALIDATE_INT,
-			'type'     => array(
+			'series'     => FILTER_VALIDATE_INT,
+			'topic'      => FILTER_VALIDATE_INT,
+			'type'       => array(
+				'filter' => FILTER_VALIDATE_INT,
+				'flags'  => FILTER_REQUIRE_ARRAY,
+			),
+			'wp_version' => array(
 				'filter' => FILTER_VALIDATE_INT,
 				'flags'  => FILTER_REQUIRE_ARRAY,
 			),
@@ -474,13 +478,14 @@ function wporg_archive_maybe_apply_query_filters( WP_Query &$query ) {
 	);
 
 	$entity_map = array(
-		'captions' => 'video_caption_language',
-		'language' => 'video_language',
-		'audience' => 'audience',
-		'duration' => 'duration',
-		'level'    => 'level',
-		'topic'    => 'topic',
-		'type'     => 'instruction_type',
+		'captions'   => 'video_caption_language',
+		'language'   => 'video_language',
+		'audience'   => 'audience',
+		'duration'   => 'duration',
+		'level'      => 'level',
+		'topic'      => 'topic',
+		'type'       => 'instruction_type',
+		'wp_version' => 'wporg_wp_version',
 	);
 
 	$series_slug = wporg_learn_get_series_taxonomy_slug( $query->get( 'post_type' ) );
@@ -535,6 +540,7 @@ function wporg_archive_maybe_apply_query_filters( WP_Query &$query ) {
 				case 'series':
 				case 'topic':
 				case 'type':
+				case 'wp_version':
 					if ( ! empty( $tax_query ) ) {
 						$tax_query['relation'] = 'AND';
 					}

--- a/wp-content/themes/pub/wporg-learn-2020/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2020/functions.php
@@ -225,7 +225,7 @@ function wporg_learn_get_taxonomy_terms( $post_id, $tax_slug, $context ) {
  * @return array
  */
 function wporg_learn_get_lesson_plan_taxonomy_data( $post_id, $context ) {
-	return array(
+	$data = array(
 		array(
 			'icon'  => 'clock',
 			'slug'  => 'duration',
@@ -250,13 +250,19 @@ function wporg_learn_get_lesson_plan_taxonomy_data( $post_id, $context ) {
 			'label' => wporg_label_with_colon( get_taxonomy_labels( get_taxonomy( 'instruction_type' ) )->singular_name ),
 			'value' => wporg_learn_get_taxonomy_terms( $post_id, 'instruction_type', $context ),
 		),
-		array(
+	);
+
+	$versions = wporg_learn_get_taxonomy_terms( $post_id, 'wporg_wp_version', $context );
+	if ( $versions ) {
+		$data[] = array(
 			'icon'  => 'wordpress',
 			'slug'  => 'wp_version',
 			'label' => wporg_label_with_colon( get_taxonomy_labels( get_taxonomy( 'wporg_wp_version' ) )->singular_name ),
-			'value' => wporg_learn_get_taxonomy_terms( $post_id, 'wporg_wp_version', $context ),
-		),
-	);
+			'value' => $versions,
+		);
+	}
+
+	return $data;
 }
 
 /**

--- a/wp-content/themes/pub/wporg-learn-2020/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2020/functions.php
@@ -250,6 +250,12 @@ function wporg_learn_get_lesson_plan_taxonomy_data( $post_id, $context ) {
 			'label' => wporg_label_with_colon( get_taxonomy_labels( get_taxonomy( 'instruction_type' ) )->singular_name ),
 			'value' => wporg_learn_get_taxonomy_terms( $post_id, 'instruction_type', $context ),
 		),
+		array(
+			'icon'  => 'wordpress',
+			'slug'  => 'wp_version',
+			'label' => wporg_label_with_colon( get_taxonomy_labels( get_taxonomy( 'wporg_wp_version' ) )->singular_name ),
+			'value' => wporg_learn_get_taxonomy_terms( $post_id, 'wporg_wp_version', $context ),
+		),
 	);
 }
 

--- a/wp-content/themes/pub/wporg-learn-2020/template-parts/component-lesson-filters.php
+++ b/wp-content/themes/pub/wporg-learn-2020/template-parts/component-lesson-filters.php
@@ -24,6 +24,12 @@ $taxonomies = array(
 		'name'    => 'type',
 		'current' => filter_input( INPUT_GET, 'type', FILTER_VALIDATE_INT, FILTER_REQUIRE_ARRAY ) ?? array(),
 	),
+	array(
+		'label'   => get_taxonomy_labels( get_taxonomy( 'wporg_wp_version' ) )->singular_name,
+		'terms'   => get_terms( array( 'taxonomy' => 'wporg_wp_version' ) ),
+		'name'    => 'wp_version',
+		'current' => filter_input( INPUT_GET, 'wp_version', FILTER_VALIDATE_INT, FILTER_REQUIRE_ARRAY ) ?? array(),
+	),
 );
 ?>
 

--- a/wp-content/themes/pub/wporg-learn-2020/template-parts/component-workshop-filters.php
+++ b/wp-content/themes/pub/wporg-learn-2020/template-parts/component-workshop-filters.php
@@ -30,6 +30,14 @@ $buckets = array(
 		'name'  => 'captions',
 		'items' => \WPOrg_Learn\Post_Meta\get_available_workshop_locales( 'video_caption_language', 'native' ),
 	),
+	array(
+		'label' => __( 'WordPress Version', 'wporg-learn' ),
+		'name'  => 'wp_version',
+		'items' => get_terms( array(
+			'taxonomy' => 'wporg_wp_version',
+			'fields'   => 'id=>name',
+		) ),
+	),
 );
 ?>
 


### PR DESCRIPTION
Fixes #289 — This adds the WP version to Lesson Plans and Workshops, and adds filtering on that value.

Display on lesson plan
<img width="999" alt="Screen Shot 2021-12-16 at 5 04 51 PM" src="https://user-images.githubusercontent.com/541093/146455971-1ff8245d-f83e-4c6c-baaa-5fa8825779f3.png">

Display on lesson plan list
<img width="693" alt="Screen Shot 2021-12-16 at 5 03 32 PM" src="https://user-images.githubusercontent.com/541093/146456071-57416904-492e-4561-9662-3728fa416314.png">

Display on workshop
<img width="349" alt="Screen Shot 2021-12-16 at 5 04 20 PM" src="https://user-images.githubusercontent.com/541093/146456003-40ac1d48-63c0-4b15-aaaa-35cf2f04104f.png">

Filter in lesson plan sidebar
<img width="323" alt="Screen Shot 2021-12-16 at 5 03 54 PM" src="https://user-images.githubusercontent.com/541093/146456025-28a4e913-0c0e-4f47-aebb-8cd1e03ab818.png">

Filter in workshop header
<img width="983" alt="Screen Shot 2021-12-16 at 5 04 13 PM" src="https://user-images.githubusercontent.com/541093/146456046-150eaa44-3753-41c8-8b7f-3456c2474e50.png">

