### PR TITLE
Accessibility fixes for single Workshops

### DIFF
--- a/wp-content/plugins/wporg-learn/views/block-workshop-details.php
+++ b/wp-content/plugins/wporg-learn/views/block-workshop-details.php
@@ -15,6 +15,7 @@ $has_transcript = false !== strpos( $post->post_content, 'id="transcript"' );
 ?>
 
 <div class="wp-block-wporg-learn-workshop-details">
+	<h3 class="screen-reader-text">Workshop Details</h3>
 	<?php if ( ! empty( $fields ) ) : ?>
 		<ul class="workshop-details-list">
 			<?php foreach ( $fields as $key => $field ) : ?>

--- a/wp-content/themes/pub/wporg-learn-2020/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2020/functions.php
@@ -1036,8 +1036,8 @@ function wporg_learn_register_sidebars() {
 		array(
 			'name'          => __( 'Workshops', 'wporg-learn' ),
 			'id'            => 'wporg-learn-workshops',
-			'before_widget' => '<aside id="%1$s" class="widget %2$s">',
-			'after_widget'  => '</aside>',
+			'before_widget' => '<div id="%1$s" class="widget %2$s">',
+			'after_widget'  => '</div>',
 			'before_title'  => '<h4 class="widget-title">',
 			'after_title'   => '</h4>',
 		)


### PR DESCRIPTION
- Add heading 3 for screen readers to Workshop Details block.
- Make sure complementary doesn't get appended to every widget.

Let's hold off on merging. I can't test these yet due to not having a mirror image of live. Hard to say if it will help or make the problems worse.