### PR TITLE
Filters: Strip out empty `wp_version` to fix filtering results with no version

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2020/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2020/functions.php
@@ -511,6 +511,10 @@ function wporg_archive_maybe_apply_query_filters( WP_Query &$query ) {
 
 	if ( is_array( $filters ) ) {
 		$filters = array_filter( $filters );
+		// Strip out `wp_version` if it's empty (converted to `array( false )`, due to FILTER_FORCE_ARRAY).
+		if ( isset( $filters['wp_version'] ) && 0 === count( array_filter( $filters['wp_version'] ) ) ) {
+			unset( $filters['wp_version'] );
+		}
 
 		// If both language and captions filters are set, we assume an "OR" relationship.
 		if ( isset( $filters['captions'], $filters['language'] ) ) {


### PR DESCRIPTION
Fixes #302.

The fix for an issue in #292 caused this value to always be an array, so `array_filter` does not clear it out. This causes the query to try looking for a version that doesn't exist, returning no posts. The fix adds an extra step in the filter-to-query processing, to remove this value if it's actually meant to be empty.