### PR TITLE
Remove the `github-markdown` class from lesson content

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2020/template-parts/content-single.php
+++ b/wp-content/themes/pub/wporg-learn-2020/template-parts/content-single.php
@@ -17,7 +17,7 @@
 		</header>
 
 		<div class="lp-content">
-			<div class="lp-content-inner github-markdown">
+			<div class="lp-content-inner">
 				<?php
 				the_content();
 				wp_link_pages(


### PR DESCRIPTION
Removing the `github-markdown` class brings back 16px font sizing on lesson content, which is far more accessible than 14px. Right now Lessons are harder to read than necessary because the body is using 14px. It also feels visually different from other parts of public-facing WordPress documentation.

Right now, removing that class also removes the borders underneath subheadings. If this is a style we should be keeping, please let me know so I can update this PR with an additional commit. :)

Before:
<img width="1028" alt="Screen Shot 2022-01-14 at 11 27 30 AM" src="https://user-images.githubusercontent.com/6925260/149566550-74db6e04-1327-4e50-956a-862c9ed22bd1.png">

After:

<img width="1055" alt="Screen Shot 2022-01-14 at 11 27 47 AM" src="https://user-images.githubusercontent.com/6925260/149566628-3fe37c9f-c216-4dd9-9d24-05556205ae1a.png">


