### PR TITLE
Accessibility fixes for single Workshops Part 2

### DIFF
--- a/wp-content/plugins/wporg-learn/views/block-workshop-details.php
+++ b/wp-content/plugins/wporg-learn/views/block-workshop-details.php
@@ -50,9 +50,8 @@ $has_transcript = false !== strpos( $post->post_content, 'id="transcript"' );
 				<li>
 					<b><?php esc_html_e( 'Transcript', 'wporg-learn' ); ?></b>
 					<span>
-						<a class="components-button is-secondary is-small" href="#transcript">
-							<?php esc_html_e( 'View ', 'wporg-learn' ); ?>
-							<span class="screen-reader-text"><?php esc_html_e( 'Transcript', 'wporg-learn' ); ?></span>
+						<a class="components-button is-secondary is-small" href="#transcript" aria-label="<?php esc_attr_e( 'View Transcript', 'wporg-learn' ); ?>">
+							<?php esc_html_e( 'View', 'wporg-learn' ); ?>
 						</a>
 					</span>
 				</li>
@@ -60,8 +59,7 @@ $has_transcript = false !== strpos( $post->post_content, 'id="transcript"' );
 			<li>
 				<b><?php esc_html_e( 'Print View', 'wporg-learn' ); ?></b>
 				<span>
-						<a class="components-button is-secondary is-small" href="#" onclick="window.print();">
-							<span class="screen-reader-text"><?php esc_html_e( 'Print ', 'wporg-learn' ); ?></span>
+						<a class="components-button is-secondary is-small" href="#" onclick="window.print();" aria-label="<?php esc_attr_e( 'Print View', 'wporg-learn' ); ?>">
 							<?php esc_html_e( 'View', 'wporg-learn' ); ?>
 						</a>
 					</span>

--- a/wp-content/plugins/wporg-learn/views/block-workshop-details.php
+++ b/wp-content/plugins/wporg-learn/views/block-workshop-details.php
@@ -51,7 +51,8 @@ $has_transcript = false !== strpos( $post->post_content, 'id="transcript"' );
 					<b><?php esc_html_e( 'Transcript', 'wporg-learn' ); ?></b>
 					<span>
 						<a class="components-button is-secondary is-small" href="#transcript">
-							<?php esc_html_e( 'View', 'wporg-learn' ); ?>
+							<?php esc_html_e( 'View ', 'wporg-learn' ); ?>
+							<span class="screen-reader-text"><?php esc_html_e( 'Transcript', 'wporg-learn' ); ?></span>
 						</a>
 					</span>
 				</li>
@@ -60,6 +61,7 @@ $has_transcript = false !== strpos( $post->post_content, 'id="transcript"' );
 				<b><?php esc_html_e( 'Print View', 'wporg-learn' ); ?></b>
 				<span>
 						<a class="components-button is-secondary is-small" href="#" onclick="window.print();">
+							<span class="screen-reader-text"><?php esc_html_e( 'Print ', 'wporg-learn' ); ?></span>
 							<?php esc_html_e( 'View', 'wporg-learn' ); ?>
 						</a>
 					</span>

--- a/wp-content/themes/pub/wporg-learn-2020/template-parts/component-featured-workshop.php
+++ b/wp-content/themes/pub/wporg-learn-2020/template-parts/component-featured-workshop.php
@@ -17,7 +17,7 @@ $featured_workshop = reset( $featured_workshop );
 		$post = $featured_workshop; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		setup_postdata( $post );
 		?>
-			<div class="featured-workshop_video">
+			<div aria-hidden="true" tabindex="-1" class="featured-workshop_video">
 				<a href="<?php echo esc_url( get_the_permalink() ); ?>">
 					<?php
 					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
@@ -26,7 +26,10 @@ $featured_workshop = reset( $featured_workshop );
 				</a>
 			</div>
 			<div class="featured-workshop_content">
-				<a class="featured-workshop_title" href="<?php echo esc_url( get_the_permalink() ); ?>"><?php the_title(); ?></a>
+				<a class="featured-workshop_title" href="<?php echo esc_url( get_the_permalink() ); ?>">
+					<span aria-hidden="true"><?php the_title(); ?></span>
+					<h3 class="screen-reader-text"><?php the_title(); ?></h3>
+				</a>
 				<div class="row">
 					<div class="col-8">
 						<p><?php the_excerpt(); ?></p>

--- a/wp-content/themes/pub/wporg-learn-2020/template-parts/component-video-grid-item.php
+++ b/wp-content/themes/pub/wporg-learn-2020/template-parts/component-video-grid-item.php
@@ -15,6 +15,7 @@
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		echo wporg_get_post_thumbnail( $post, 'medium' );
 		?>
-		<h3><?php the_title(); ?></h3>
+		<span aria-hidden="true"><?php the_title(); ?></span>
+		<h3 class="screen-reader-text"><?php the_title(); ?></h3>
 	</a>
 </li>

--- a/wp-content/themes/pub/wporg-learn-2020/template-parts/component-video-grid-item.php
+++ b/wp-content/themes/pub/wporg-learn-2020/template-parts/component-video-grid-item.php
@@ -15,6 +15,6 @@
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		echo wporg_get_post_thumbnail( $post, 'medium' );
 		?>
-		<?php the_title(); ?>
+		<h3><?php the_title(); ?></h3>
 	</a>
 </li>


### PR DESCRIPTION
- Add better link screen reader text to Transcript/Print View links.
- Make title on list item heading 3.