### PR TITLE
Add a quick script to sync to production svn.

### DIFF
--- a/bin/sync-to-production.sh
+++ b/bin/sync-to-production.sh
@@ -19,15 +19,11 @@ composer install
 yarn workspaces run build
 
 # Sync git to SVN
-rm -rf meta-theme/*
+rm -rf meta-theme/* meta-plugin/*
 cp -r wp-content/themes/pub/wporg-learn-2020/* meta-theme
-svn st meta-theme/ | grep ^? | cut -c2- | xargs -I% svn add %
-svn st meta-theme/ | grep ^! | cut -c2- | xargs -I% svn rm %
-
-rm -rf meta-plugin/*
 cp -r wp-content/plugins/wporg-learn/* meta-plugin
-svn st meta-plugin/ | grep ^? | cut -c2- | xargs -I% svn add %
-svn st meta-plugin/ | grep ^! | cut -c2- | xargs -I% svn rm %
+svn st meta-*/ | grep ^? | cut -c2- | xargs -I% svn add %
+svn st meta-*/ | grep ^! | cut -c2- | xargs -I% svn rm %
 
 # Print diff.
 svn st meta-*

--- a/bin/sync-to-production.sh
+++ b/bin/sync-to-production.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+rm -rf /tmp/learn
+
+git clone https://github.com/WordPress/learn.git /tmp/learn
+
+svn co https://meta.svn.wordpress.org/sites/trunk/wordpress.org/public_html/wp-content/themes/pub/wporg-learn-2020 /tmp/learn/meta-theme
+svn co https://meta.svn.wordpress.org/sites/trunk/wordpress.org/public_html/wp-content/plugins/wporg-learn /tmp/learn/meta-plugin
+
+cd /tmp/learn
+
+# Install
+yarn
+
+# Install v2
+composer install
+
+# Build
+yarn workspaces run build
+
+# Sync git to SVN
+rm -rf meta-theme/*
+cp -r wp-content/themes/pub/wporg-learn-2020/* meta-theme
+svn st meta-theme/ | grep ^? | cut -c2- | xargs -I% svn add %
+svn st meta-theme/ | grep ^! | cut -c2- | xargs -I% svn rm %
+
+rm -rf meta-plugin/*
+cp -r wp-content/plugins/wporg-learn/* meta-plugin
+svn st meta-plugin/ | grep ^? | cut -c2- | xargs -I% svn add %
+svn st meta-plugin/ | grep ^! | cut -c2- | xargs -I% svn rm %
+
+# Print diff.
+svn st meta-*
+
+echo "svn diff /tmp/learn/meta-* to view diff."
+
+# pause
+echo "Press any key to commit"
+read
+
+COMMIT=`git log | head -1 | cut -d' ' -f2`
+MSG="Learn: Sync with git WordPress/learn@$COMMIT"
+
+svn ci meta-plugin meta-theme -m "$MSG"

--- a/bin/sync-to-production.sh
+++ b/bin/sync-to-production.sh
@@ -34,11 +34,11 @@ svn st meta-*
 
 echo "svn diff /tmp/learn/meta-* to view diff."
 
-# pause
-echo "Press any key to commit"
-read
-
 COMMIT=`git log | head -1 | cut -d' ' -f2`
 MSG="Learn: Sync with git WordPress/learn@$COMMIT"
+
+# pause
+echo "Control+C to abort, or Press any key to commit as: '$MSG'"
+read
 
 svn ci meta-plugin meta-theme -m "$MSG"


### PR DESCRIPTION
I wanted a single script I could run outside of SVN/Git and have it sync current trunk from Git to the WordPress.org SVNs. That's what this is.

This might be better living in https://github.com/WordPress/wporg-repo-tools technically but this seems like an obvious place for a sync script.