### PR TITLE
Switching the order of courses within their categories

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2020/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2020/functions.php
@@ -341,6 +341,14 @@ function wporg_archive_modify_query( WP_Query $query ) {
 	// Possibly temporary until more of the courses are filled out.
 	if ( $query->is_main_query() && $query->is_post_type_archive( 'course' ) ) {
 		$query->set(
+			'orderby',
+			array(
+				'post_date' => 'ASC',
+				'ID'        => 'DESC',
+			)
+		);
+
+		$query->set(
 			'meta_query',
 			array(
 				array(


### PR DESCRIPTION
This links to the work done in #309 and just updated the courses to appear oldest to newest inside each category.