### PR TITLE
Fixing course display in the dashboard

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2020/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2020/functions.php
@@ -408,6 +408,10 @@ add_action( 'pre_get_posts', 'wporg_archive_modify_query' );
 function wporg_archive_orderby( $orderby, $query ) {
 	global $wpdb;
 
+	if ( is_admin() ) {
+		return $orderby;
+	}
+
 	// Group courses by their category
 	if ( $query->is_main_query() && $query->is_post_type_archive( 'course' ) ) {
 		$orderby = $wpdb->term_relationships . '.term_taxonomy_id DESC, ' . $orderby;


### PR DESCRIPTION
The recent update to the frontend course ordering broke the course list table in the dashboard - this PR fixes that issue by adding an `is_admin()` check to the `orderby` filter.