### PR TITLE
Fix breadcrumbs not always shown

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2020/archive-course.php
+++ b/wp-content/themes/pub/wporg-learn-2020/archive-course.php
@@ -16,6 +16,8 @@ $category_description = '';
 get_header(); ?>
 
 <main id="main" class="site-main">
+	<?php get_template_part( 'template-parts/component', 'breadcrumbs' ); ?>
+
 	<section>
 		<div class="row align-middle between section-heading section-heading--with-space">
 			<?php the_archive_title( '<h1 class="section-heading_title h2">', '</h1>' ); ?>

--- a/wp-content/themes/pub/wporg-learn-2020/archive-lesson-plan.php
+++ b/wp-content/themes/pub/wporg-learn-2020/archive-lesson-plan.php
@@ -12,6 +12,8 @@ namespace WordPressdotorg\Theme;
 get_header(); ?>
 
 <main id="main" class="site-main">
+	<?php get_template_part( 'template-parts/component', 'breadcrumbs' ); ?>
+
 	<section>
 		<div class="row align-middle between section-heading section-heading--with-space">
 			<?php the_archive_title( '<h1 class="section-heading_title h2">', '</h1>' ); ?>

--- a/wp-content/themes/pub/wporg-learn-2020/archive-wporg_workshop.php
+++ b/wp-content/themes/pub/wporg-learn-2020/archive-wporg_workshop.php
@@ -19,6 +19,8 @@ $is_filtered = $wp_query->get( 'wporg_archive_filters' );
 get_header(); ?>
 
 <main id="main" class="site-main">
+	<?php get_template_part( 'template-parts/component', 'breadcrumbs' ); ?>
+
 	<section>
 		<div class="row align-middle between section-heading section-heading--with-space">
 			<?php the_archive_title( '<h1 class="section-heading_title h2">', '</h1>' ); ?>

--- a/wp-content/themes/pub/wporg-learn-2020/search.php
+++ b/wp-content/themes/pub/wporg-learn-2020/search.php
@@ -18,6 +18,8 @@ $search_query = sprintf(
 get_header(); ?>
 
 	<main id="main" class="site-main type-page" role="main">
+		<?php get_template_part( 'template-parts/component', 'breadcrumbs' ); ?>
+
 		<section>
 			<div class="row align-middle between section-heading section-heading--with-space">
 				<h1 class="section-heading_title h2"><?php echo esc_html( $search_query ); ?></h1>

--- a/wp-content/themes/pub/wporg-learn-2020/single-wporg_workshop.php
+++ b/wp-content/themes/pub/wporg-learn-2020/single-wporg_workshop.php
@@ -9,6 +9,8 @@ get_header();
 ?>
 
 	<main id="main" class="site-main page-full-width" role="main">
+		<?php get_template_part( 'template-parts/component', 'breadcrumbs' ); ?>
+
 		<?php
 		while ( have_posts() ) {
 			the_post();

--- a/wp-content/themes/pub/wporg-learn-2020/template-parts/component-breadcrumbs.php
+++ b/wp-content/themes/pub/wporg-learn-2020/template-parts/component-breadcrumbs.php
@@ -14,20 +14,30 @@ $crumbs = array(
 	),
 );
 
-// Get information about the post title.
-$cpt_object = get_post_type_object( get_post_type( get_queried_object() ) );
-
-if ( 'lesson-plan' === get_post_type() ) {
+if ( is_post_type_archive() ) {
 	array_push( $crumbs, array(
-		'label' => ucfirst( $cpt_object->labels->name ),
-		'url'   => home_url( $cpt_object->has_archive ),
-	) );
-}
+		'label' => post_type_archive_title( '', false ),
+		'url' => '',
+	));
+} elseif ( is_singular() ) {
+	if ( is_single() ) {
+		$cpt_object = get_post_type_object( get_post_type() );
 
-array_push( $crumbs, array(
-	'label' => get_the_title(),
-	'url'   => '',
-) );
+		array_push($crumbs, array(
+			'label' => $cpt_object->label,
+			'url'   => home_url( $cpt_object->has_archive ),
+		));
+	}
+	array_push( $crumbs, array(
+		'label' => get_the_title(),
+		'url'   => '',
+	) );
+} elseif ( is_search() ) {
+	array_push( $crumbs, array(
+		'label' => get_search_query(),
+		'url' => '',
+	));
+}
 ?>
 
 <div class="clearfix">


### PR DESCRIPTION
**Ref**: #84 

**Description:**
Adjust crumbs trail based on the type of current page.
Archive pages, Lesson Plan, Workshop, Course post type pages, and search pages are now identified explicitly.

**Screencast of Results:**
https://user-images.githubusercontent.com/18050944/156573078-4ccda801-463b-4478-9416-5b92b0bdf279.mp4

**TODO:**
Test in the remote sandbox - I haven't had access permission to it yet.
You can see that in the screencast starting at time 1:10, there's a weird behavior happening when clicking into `Courses`. That's probably caused by the local env provision or testing data.