### PR TITLE
Term Translations: Include the URL to where the translation is used

### DIFF
--- a/bin/i18n.php
+++ b/bin/i18n.php
@@ -115,8 +115,11 @@ function main() {
 		$label = addcslashes( $tax_label, "'" );
 
 		foreach ( $terms as $term ) {
+
 			$name = addcslashes( $term['name'], "'" );
-			$file_content .= "_x( '{$name}', '$label term name', 'wporg-learn' );\n";
+			$link = addcslashes( $term['link'], '*' );
+
+			$file_content .= "/* translators: {$link} */\n_x( '{$name}', '$label term name', 'wporg-learn' );\n";
 
 			if ( 'cli' === php_sapi_name() ) {
 				echo "$name\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
@@ -124,7 +127,7 @@ function main() {
 
 			if ( $term['description'] ) {
 				$description = addcslashes( $term['description'], "'" );
-				$file_content .= "_x( '{$description}', '$label term description', 'wporg-learn' );\n";
+				$file_content .= "/* translators: {$link} */\n_x( '{$description}', '$label term description', 'wporg-learn' );\n";
 			}
 		}
 	}

--- a/extra/translation-strings.php
+++ b/extra/translation-strings.php
@@ -8,220 +8,438 @@
  * ⚠️ Do not require or include this file anywhere.
  */
 
+/* translators: https://learn.wordpress.org/audience/all/ */
 _x( 'All', 'Audiences term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/audience/contributors/ */
 _x( 'Contributors', 'Audiences term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/audience/designers/ */
 _x( 'Designers', 'Audiences term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/audience/developers/ */
 _x( 'Developers', 'Audiences term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/audience/speakers/ */
 _x( 'Speakers', 'Audiences term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/audience/users/ */
 _x( 'Users', 'Audiences term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/lesson-plans/builder/ */
 _x( 'Builder', 'Lesson Categories term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/lesson-plans/builder/ */
 _x( 'Developing or Customizing with code.', 'Lesson Categories term description', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/lesson-plans/espanol/ */
 _x( 'Español', 'Lesson Categories term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/lesson-plans/general/ */
 _x( 'General', 'Lesson Categories term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/lesson-plans/general/ */
 _x( 'History of WordPress, About the Community, Open Source, or other broad overview lessons', 'Lesson Categories term description', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/lesson-plans/admin/ */
 _x( 'General Admin', 'Lesson Categories term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/lesson-plans/admin/ */
 _x( 'Using admin settings, the dashboard, posts, pages,', 'Lesson Categories term description', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/lesson-plans/group-block/ */
 _x( 'group block', 'Lesson Categories term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/lesson-plans/plugin/ */
 _x( 'Plugin', 'Lesson Categories term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/lesson-plans/plugin-development/ */
 _x( 'Plugin Dev', 'Lesson Categories term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/lesson-plans/portugues/ */
 _x( 'Português', 'Lesson Categories term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/lesson-plans/speaker/ */
 _x( 'Speaker', 'Lesson Categories term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/lesson-plans/templates/ */
 _x( 'Templates', 'Lesson Categories term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/lesson-plans/templates/ */
 _x( 'How to get started writing lesson plans, templates for lessons, guidelines for Learn', 'Lesson Categories term description', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/lesson-plans/theme/ */
 _x( 'Theme', 'Lesson Categories term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/lesson-plans/theme-dev/ */
 _x( 'Theme Dev', 'Lesson Categories term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/lesson-plans/user/ */
 _x( 'User', 'Lesson Categories term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/duration/15/ */
 _x( '15m', 'Duration term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/duration/30/ */
 _x( '30m', 'Duration term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/duration/45/ */
 _x( '45m', 'Duration term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/duration/60/ */
 _x( '60m', 'Duration term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/duration/90/ */
 _x( '90m', 'Duration term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/lesson_group/get-started/ */
 _x( 'Get Started', 'Lesson Groups term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/lesson_group/polyglots-training/ */
 _x( 'Polyglots Training', 'Lesson Groups term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/lesson_group/speaker-training/ */
 _x( 'Speaker Training', 'Lesson Groups term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/instruction_type/demonstration/ */
 _x( 'Demonstration', 'Instruction Types term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/instruction_type/discussion/ */
 _x( 'Discussion', 'Instruction Types term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/instruction_type/exercises/ */
 _x( 'Exercises', 'Instruction Types term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/instruction_type/feedback/ */
 _x( 'Feedback', 'Instruction Types term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/instruction_type/lecture/ */
 _x( 'Lecture', 'Instruction Types term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/instruction_type/show-tell/ */
 _x( 'Show &amp; Tell', 'Instruction Types term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/instruction_type/tutorial/ */
 _x( 'Tutorial', 'Instruction Types term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/level/advanced/ */
 _x( 'Advanced', 'Experience Levels term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/level/any/ */
 _x( 'Any', 'Experience Levels term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/level/beginner/ */
 _x( 'Beginner', 'Experience Levels term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/level/intermediate/ */
 _x( 'Intermediate', 'Experience Levels term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/workshops/como-contribuir-a-wordpress/ */
 _x( 'Cómo contribuir a WordPress', 'Workshop Series term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/workshops/como-usar-wordpress/ */
 _x( 'Cómo usar WordPress', 'Workshop Series term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/workshops/contributing-to-wordpress/ */
 _x( 'Contributing to WordPress', 'Workshop Series term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/workshops/contributing-to-wordpress/ */
 _x( 'Get involved in contributing to WordPress - no matter you do with WordPress there\'s a way that you can be a part of building the project and community. You will need to <a href="https://learn.wordpress.org/workshop/set-up-a-wordpress-org-account">set up a WordPress.org profile</a> in order to contribute.', 'Workshop Series term description', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/workshops/developing-for-block-editor/ */
 _x( 'Developing for the Block Editor', 'Workshop Series term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/workshops/developing-for-block-editor/ */
 _x( 'This series is aimed at WordPress developers interested in developing for the block editor.', 'Workshop Series term description', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/workshops/diverse-speaker-training/ */
 _x( 'Diverse Speaker Training', 'Workshop Series term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/workshops/diverse-speaker-training/ */
 _x( 'This series is for people from marginalized or underrepresented groups who are thinking about speaking at WordPress events. You do not need to have any experience in public speaking, and this series is for all levels of experience. Topics include finding a talk topic, writing a pitch, creating the talk, becoming a better speaker, creating great slides, handling tough questions, and more!', 'Workshop Series term description', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/workshops/editor-de-bloques-tutorial-basico/ */
 _x( 'Editor de Bloques - Tutorial básico', 'Workshop Series term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/workshops/editor-de-bloques-tutorial-basico/ */
 _x( 'En esta serio de tutoriales, o WorkShops, se abordan los conceptos básico, y no tanto, para poder adentrarnos en el fascinante mundo del desarrollo en el editor de bloques de WordPress, también conocido como Gutenberg.
 Partiendo de lo indispensable, iremos viendo sección tras sección, video tras video, cómo poder implementar nuestras propias ideas, necesidades, requerimientos, etc. de una manera simple y al alcance de todo el mundo.', 'Workshop Series term description', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/workshops/full-site-editing/ */
 _x( 'Full Site Editing', 'Workshop Series term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/workshops/managing-settings/ */
 _x( 'Managing Settings', 'Workshop Series term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/workshops/managing-settings/ */
 _x( 'Guides on how to manage the various settings pages in your WordPress dashboard.', 'Workshop Series term description', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/workshops/organizing-wordpress-meetups/ */
 _x( 'Organizing WordPress Meetups', 'Workshop Series term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/workshops/organizing-wordpress-meetups/ */
 _x( 'This series aimed at all WordPress Community members across the world that are interested in organizing WordPress meetups. You will learn how to organize a local WordPress Meetup, the important things to keep in mind while organizing a meetup, and how to keep your local meetup group active.', 'Workshop Series term description', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/workshops/seguridad-en-wordpress/ */
 _x( 'Seguridad en WordPress', 'Workshop Series term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/workshops/site-management/ */
 _x( 'Site Management', 'Workshop Series term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/workshops/using-the-block-editor/ */
 _x( 'Using the Block Editor', 'Workshop Series term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/workshops/using-the-block-editor/ */
 _x( 'Learn how to get the most out of the WordPress block editor when publishing your content.', 'Workshop Series term description', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/workshops/wordpress-%e3%81%ae%e5%9f%ba%e6%9c%ac/ */
 _x( 'WordPress の基本', 'Workshop Series term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/workshops/wp-troubleshooting/ */
 _x( 'WordPress Troubleshooting', 'Workshop Series term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/workshops/wp-troubleshooting/ */
 _x( 'Learn how to troubleshoot WordPress issues.', 'Workshop Series term description', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/topic/block-development/ */
 _x( 'Block Development', 'Topics term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/topic/block-editor/ */
 _x( 'Block Editor', 'Topics term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/topic/community-team/ */
 _x( 'Community Team', 'Topics term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/topic/contributing/ */
 _x( 'Contributing', 'Topics term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/topic/core/ */
 _x( 'Core', 'Topics term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/topic/css/ */
 _x( 'CSS', 'Topics term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/topic/dashboard/ */
 _x( 'Dashboard', 'Topics term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/topic/diversity/ */
 _x( 'Diversity', 'Topics term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/topic/ecommerce/ */
 _x( 'eCommerce', 'Topics term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/topic/full-site-editing/ */
 _x( 'Full Site Editing', 'Topics term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/topic/getting-started/ */
 _x( 'Getting Started', 'Topics term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/topic/gutenberg/ */
 _x( 'Gutenberg', 'Topics term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/topic/hosting/ */
 _x( 'Hosting', 'Topics term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/topic/media/ */
 _x( 'Media', 'Topics term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/topic/meetups/ */
 _x( 'Meetups', 'Topics term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/topic/open-source/ */
 _x( 'Open-Source', 'Topics term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/topic/openverse/ */
 _x( 'Openverse', 'Topics term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/topic/plugins/ */
 _x( 'Plugins', 'Topics term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/topic/publishing/ */
 _x( 'Publishing', 'Topics term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/topic/rss/ */
 _x( 'RSS', 'Topics term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/topic/security/ */
 _x( 'Security', 'Topics term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/topic/site-management/ */
 _x( 'Site Management', 'Topics term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/topic/training-team/ */
 _x( 'Training Team', 'Topics term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/topic/translation/ */
 _x( 'Translation', 'Topics term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/topic/troubleshooting/ */
 _x( 'Troubleshooting', 'Topics term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/topic/troubleshooting/ */
 _x( 'Sessions on WordPress Troubleshooting.', 'Topics term description', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/topic/tv-team/ */
 _x( 'TV Team', 'Topics term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/topic/ui/ */
 _x( 'UI', 'Topics term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/topic/wordpress/ */
 _x( 'WordPress', 'Topics term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_workshop_type/community/ */
 _x( 'Community', 'Types term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_workshop_type/faculty/ */
 _x( 'Faculty', 'Types term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_wp_version/4-1/ */
 _x( '4.1', 'WordPress Version term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_wp_version/4-3/ */
 _x( '4.3', 'WordPress Version term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_wp_version/4-7/ */
 _x( '4.7', 'WordPress Version term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_wp_version/5-0/ */
 _x( '5.0', 'WordPress Version term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_wp_version/5-4/ */
 _x( '5.4', 'WordPress Version term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_wp_version/5-5/ */
 _x( '5.5', 'WordPress Version term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_wp_version/5-6/ */
 _x( '5.6', 'WordPress Version term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_wp_version/5-7/ */
 _x( '5.7', 'WordPress Version term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_wp_version/5-8/ */
 _x( '5.8', 'WordPress Version term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_wp_version/5-9/ */
 _x( '5.9', 'WordPress Version term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_wp_version/6-0/ */
 _x( '6.0', 'WordPress Version term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/accessibility/ */
 _x( 'accessibility', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/add-new-plugin/ */
 _x( 'add new plugin', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/add-new-user/ */
 _x( 'add new user', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/admin-navigation/ */
 _x( 'admin navigation', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/admin-toolbar/ */
 _x( 'admin toolbar', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/all-pages/ */
 _x( 'all pages', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/all-plugins/ */
 _x( 'all plugins', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/all-posts-posts/ */
 _x( 'all posts', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/appearance/ */
 _x( 'appearance', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/appearance-template/ */
 _x( 'appearance template', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/appearance-template-editor/ */
 _x( 'appearance template editor', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/appearance-template-parts/ */
 _x( 'appearance template parts', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/available-tools/ */
 _x( 'available tools', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/block-directory/ */
 _x( 'block directory', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/block-inserter/ */
 _x( 'block inserter', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/block-inserter/ */
 _x( 'https://cloudup.com/cOg0Hd96tJx ', 'Included Content term description', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/block-inserter-block/ */
 _x( 'block inserter block', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/block-inserter-pattern/ */
 _x( 'block inserter pattern', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/block-inserter-reusable/ */
 _x( 'block inserter reusable', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/block-locking/ */
 _x( 'block locking', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/block-pattern/ */
 _x( 'block pattern', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/block-template/ */
 _x( 'block template', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/block-template-parts/ */
 _x( 'block template parts', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/block-toolbar/ */
 _x( 'block toolbar', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/block-type/ */
 _x( 'block type', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/block-categories/ */
 _x( 'block-categories', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/brand/ */
 _x( 'brand', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/categories/ */
 _x( 'categories', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/classic-block/ */
 _x( 'classic block', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/classic-editor/ */
 _x( 'classic editor', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/classic-theme/ */
 _x( 'classic theme', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/comments/ */
 _x( 'comments', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/custom-post-type/ */
 _x( 'custom post type', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/customizer/ */
 _x( 'Customizer', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/dashboard/ */
 _x( 'dashboard', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/discussion/ */
 _x( 'discussion', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/duotone/ */
 _x( 'duotone', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/dynamic-block/ */
 _x( 'dynamic block', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/edit/ */
 _x( 'Edit', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/edit-media/ */
 _x( 'edit media', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/export/ */
 _x( 'export', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/file/ */
 _x( 'file', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/full-site-editing/ */
 _x( 'full site editing', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/group-block/ */
 _x( 'group block', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/image/ */
 _x( 'image', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/import/ */
 _x( 'import', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/install/ */
 _x( 'install', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/list-view/ */
 _x( 'list view', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/login/ */
 _x( 'login', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/maintenance-mode/ */
 _x( 'maintenance mode', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/media/ */
 _x( 'media', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/media-library/ */
 _x( 'media library', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/menu/ */
 _x( 'menu', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/migration/ */
 _x( 'migration', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/multisite/ */
 _x( 'multisite', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/navigation-block/ */
 _x( 'navigation block', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/navigation-block-menu/ */
 _x( 'Navigation Block Menu', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/page-attributes/ */
 _x( 'page attributes', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/pages/ */
 _x( 'pages', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/performance/ */
 _x( 'performance', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/permalinks/ */
 _x( 'permalinks', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/plugin-editor/ */
 _x( 'plugin editor', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/plugins/ */
 _x( 'plugins', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/polyglots/ */
 _x( 'polyglots', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/post-editor/ */
 _x( 'post editor', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/post-formats/ */
 _x( 'post formats', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/post-type-options/ */
 _x( 'post type options', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/post-type-settings/ */
 _x( 'post type settings', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/posts/ */
 _x( 'posts', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/privacy/ */
 _x( 'privacy', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/profile/ */
 _x( 'profile', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/query-block/ */
 _x( 'query block', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/query-loop/ */
 _x( 'query loop', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/quick-edit/ */
 _x( 'quick edit', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/reading/ */
 _x( 'reading', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/reusable-block/ */
 _x( 'reusable block', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/rich-text/ */
 _x( 'rich text', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/rss/ */
 _x( 'RSS', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/rtl/ */
 _x( 'RTL', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/screen-options/ */
 _x( 'screen options', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/search/ */
 _x( 'search', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/security/ */
 _x( 'security', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/settings/ */
 _x( 'settings', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/settings-general/ */
 _x( 'settings general', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/settings-media/ */
 _x( 'settings media', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/settings-sidebar/ */
 _x( 'settings sidebar', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/site-editor/ */
 _x( 'site editor', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/site-health/ */
 _x( 'site health', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/static-block/ */
 _x( 'static block', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/sticky-posts/ */
 _x( 'sticky posts', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/styles/ */
 _x( 'styles', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/tags/ */
 _x( 'tags', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/template-editing-mode/ */
 _x( 'template editing mode', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/theme-editor/ */
 _x( 'theme editor', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/themes/ */
 _x( 'themes', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/tools/ */
 _x( 'tools', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/updates/ */
 _x( 'updates', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/users/ */
 _x( 'users', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/video-block/ */
 _x( 'video block', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/widgets/ */
 _x( 'widgets', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/wordpress-org/ */
 _x( 'WordPress.org', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/wporg_included_content/writing/ */
+_x( 'writing', 'Included Content term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/course-category/contributing-to-wordpress/ */
 _x( 'Contributing to WordPress', 'Course Categories term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/course-category/contributing-to-wordpress/ */
 _x( 'WordPress is built and managed by a wide community of individuals from all over the world. These courses will help you find your feet in the project and help you get involved in the mission to democratize publishing.', 'Course Categories term description', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/course-category/full-site-editing/ */
 _x( 'Full Site Editing', 'Course Categories term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/course-category/full-site-editing/ */
 _x( 'If you\'ve ever wanted to edit all parts of your site easily, full site editing (FSE) makes that possible. First launched in WordPress 5.9, FSE includes features like the site editor, templates, template parts, theme blocks, and more. The courses below will teach you all about full site editing and its features to help you build your perfect site.', 'Course Categories term description', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/course-category/introduction-to-wordpress/ */
 _x( 'Introduction to WordPress', 'Course Categories term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/course-category/introduction-to-wordpress/ */
 _x( 'WordPress is a powerful content management system with a range of innovative features. In the following courses, you\'ll get an introduction to WordPress and learn everything you need to know to get going with your website. So whether you\'re a novice or simply want to know how to set up a new site, we have you covered.', 'Course Categories term description', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/lesson-tag/deputies/ */
 _x( 'deputies', 'Lesson Tags term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/lesson-tag/gpl/ */
 _x( 'GPL', 'Lesson Tags term name', 'wporg-learn' );
+/* translators: https://learn.wordpress.org/lesson-tag/licensing/ */
 _x( 'licensing', 'Lesson Tags term name', 'wporg-learn' );


### PR DESCRIPTION
Currently Term names & descriptions specify that it's a term description, and the kind of string it is, but they don't link to where the translation is actually used

For example:
<img width="629" alt="Screen Shot 2022-03-23 at 5 42 38 pm" src="https://user-images.githubusercontent.com/767313/159648162-994c9e87-fd29-47f9-8dcf-14db2a87f38a.png">

It seems reasonable to include the URL to the term in a comment here, so that translators can backtrack to where it's actually used.