### PR TITLE
Fix RSS feed for workshops

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2020/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2020/functions.php
@@ -315,7 +315,9 @@ function wporg_archive_modify_query( WP_Query $query ) {
 
 			if ( ! empty( $featured ) ) {
 				$featured = reset( $featured );
-				$query->set( 'post__not_in', array( $featured->ID ) );
+				if ( ! is_feed() ) {
+					$query->set( 'post__not_in', array( $featured->ID ) );
+				}
 			}
 		}
 	}

--- a/wp-content/themes/pub/wporg-learn-2020/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2020/functions.php
@@ -315,7 +315,7 @@ function wporg_archive_modify_query( WP_Query $query ) {
 
 			if ( ! empty( $featured ) ) {
 				$featured = reset( $featured );
-				if ( ! is_feed() ) {
+				if ( ! $query->is_feed() ) {
 					$query->set( 'post__not_in', array( $featured->ID ) );
 				}
 			}


### PR DESCRIPTION
Ensures that the latest workshop actually shows up in the RSS feed.

Fixes #679