### PR TITLE
Create content-error-report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/content-error-report
+++ b/.github/ISSUE_TEMPLATE/content-error-report
@@ -4,13 +4,24 @@ about: Learn WordPress Content Error Report template
 title: Learn WordPress Content Error Report: Ticket #
 labels: Help Scout, Error Report
 assignees: ''
-
 ---
 
+<!--
+
+Thank you for taking the time to report a content error. Please include the title and the URL to the content in question in the Error Description, and a description of the error.
+
+This can be done either using the markdown format, for example, (Creating Custom Post Types Without Code)[https://learn.wordpress.org/workshop/creating-custom-post-types-without-code/], or by use the **Add a link** icon in the issue editor toolbar. 
+
+Alternatively you can share the link to the page as is.
+-->
+
 # Error Description
-Write a description of the topic here.
+- Content URL: 
+
+Write a description of the error here.
 
 # Error Report Checklist:
 - [ ] Error Validated
 - [ ] Error fix proposed
+- [ ] Error fix reviewed
 - [ ] Error fix published

--- a/.github/ISSUE_TEMPLATE/content-error-report
+++ b/.github/ISSUE_TEMPLATE/content-error-report
@@ -1,0 +1,16 @@
+---
+name: Learn WordPress Content Error Report template
+about: Learn WordPress Content Error Report template
+title: Learn WordPress Content Error Report: Ticket #
+labels: Help Scout, Error Report
+assignees: ''
+
+---
+
+# Error Description
+Write a description of the topic here.
+
+# Error Report Checklist:
+- [ ] Error Validated
+- [ ] Error fix proposed
+- [ ] Error fix published


### PR DESCRIPTION
This is an issue template for adding Learn WordPress Content Error Reports from Help Scout to GitHub.