### PR TITLE
Adding a default bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report-template.md
+++ b/.github/ISSUE_TEMPLATE/bug-report-template.md
@@ -1,0 +1,41 @@
+---
+name: Bug Report Template
+about: Reporting bugs on the learn.wordpress.org website
+title: Bug report
+labels: Awaiting Triage, [Type] Bug
+assignees: ''
+
+---
+<!--
+Please fill out ALL required sections. Bug reports with missing information will be closed.
+
+Before submitting a bug report please check if the bug has already been reported by searching https://github.com/WordPress/gutenberg/issues.
+
+-->
+
+## Description
+<!-- Please write a brief description of the bug. -->
+
+## Step-by-step reproduction instructions
+<!--
+Please list the steps needed to reproduce the bug. For example:
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+-->
+
+## Expected behaviour
+<!-- Please describe what you expected to happen. -->
+
+## Actual behaviour
+<!-- Please describe what actually happened. -->
+
+## Screenshots or screen recording (optional)
+<!--
+If possible, please upload a screenshot or screen recording which demonstrates
+the bug. 
+-->
+
+## Environment information
+- Browser(s) are you seeing the problem on.
+- Device you are using and operating system (e.g. "Desktop with Windows 10", "iPhone with iOS 14", etc.).


### PR DESCRIPTION
Adds a bug report template for reporting bugs on the learn.wordpress.org website