### PR TITLE
Accessibility fixes for social learning spaces on front page

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2020/template-parts/component-discussion-event-short-item.php
+++ b/wp-content/themes/pub/wporg-learn-2020/template-parts/component-discussion-event-short-item.php
@@ -9,6 +9,9 @@ $timestamp = strtotime( $args['date_utc'] ) - (int) $args['date_utc_offset'];
 
 <li class="discussion-event">
 	<div>
+		<a class="discussion-event-link" href="<?php echo esc_attr( $args['url'] ); ?>">
+			<h3><?php echo esc_html( $args['title'] ); ?></h3>
+		</a>
 		<abbr
 			class="discussion-event-date"
 			title="<?php echo esc_attr( gmdate( 'c', $timestamp ) ); ?>"
@@ -16,13 +19,10 @@ $timestamp = strtotime( $args['date_utc'] ) - (int) $args['date_utc_offset'];
 		>
 			<?php echo esc_html( gmdate( 'l, F jS, Y', $timestamp ) ); ?>
 		</abbr>
-		<a class="discussion-event-link" href="<?php echo esc_attr( $args['url'] ); ?>">
-			<?php echo esc_html( $args['title'] ); ?>
-		</a>
 	</div>
 	<div class="wp-block-button is-style-primary">
 		<a class="wp-block-button__link" href="<?php echo esc_attr( $args['url'] ); ?>" style="border-radius:5px">
-			<?php esc_html_e( 'Join this space', 'wporg-learn' ); ?>
+			<?php esc_html_e( 'Join this space', 'wporg-learn' ); ?><span class="screen-reader-text"><?php echo sprintf( ': %s', esc_html( $args['title'] ) ); ?></span>
 		</a>
 	</div>
 </li>


### PR DESCRIPTION
* Add heading 3 structure.
* Move timestamp after initial title.
* Improve link text.