### PR TITLE
updated the link to "Workshop Captions and Transcripts" page

### DIFF
--- a/.github/ISSUE_TEMPLATE/workshop-template.md
+++ b/.github/ISSUE_TEMPLATE/workshop-template.md
@@ -30,7 +30,7 @@ Review the [team guidelines] (https://make.wordpress.org/training/handbook/guide
 - [ ] Workshop submitted to the team for Q/A review https://blog.wordpress.tv/submission-guidelines/ & https://make.wordpress.org/training/2021/08/17/proposal-brand-guidelines-for-learn-wordpress-content/
 - [ ] Workshop submitted to WPTV https://wordpress.tv/submit-video/
 - [ ] Workshop published on WPTV
-- [ ] Workshop is captioned https://learn.wordpress.org/handbook/handbook/workshop-captions-and-transcripts/
+- [ ] Workshop is captioned https://make.wordpress.org/training/handbook/workshops/workshop-subtitles-and-transcripts/
 - [ ] Workshop created on Learn.WordPress.org
 - [ ] Workshop post is reviewed for grammar, spelling, etc.
 - [ ] Workshop published on Learn.WordPress.org


### PR DESCRIPTION
The Workshop Captions and Transcripts link in the Workshop Template was outdated, so I updated it.