### PR TITLE
Fixed Spacing issue in course category page

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2020/css/vendor/_sensei.scss
+++ b/wp-content/themes/pub/wporg-learn-2020/css/vendor/_sensei.scss
@@ -1,5 +1,5 @@
 .sensei {
-	&:not(.post-type-archive-course) {
+	&:not(.post-type-archive-course):not(.tax-course-category) {
 		section {
 			padding: 0;
 		}


### PR DESCRIPTION
See #889

The PR adds a **:not** pseudo class in the existing style to check if the page is the course category page (.tax-course-category) class, and in that case the padding 0 won't be applied, that is it will load the default padding. 

Here is a screenshot of the fix -

<img width="1438" alt="fixed_spacing" src="https://user-images.githubusercontent.com/15308261/185219269-07f2f9ca-8cc1-4b38-94a3-c0d77f17ba60.png">