### PR TITLE
Create content-translation-template

### DIFF
--- a/.github/ISSUE_TEMPLATE/content-translation-template
+++ b/.github/ISSUE_TEMPLATE/content-translation-template
@@ -7,17 +7,16 @@ assignees: ''
 
 ---
 
-<!-- The steps to translating content on Learn WordPress can be found in this [Online Workshop Hhandbook page](MISSING-LINK). -->
+<!-- The steps to translating content on Learn WordPress can be found in the handbook: [Content Localization](https://make.wordpress.org/training/handbook/content-localization/). -->
 
-<!-- Remember to update the title of this issue. Example: "Greek translation for Lesson Plan "Introduction To Common Plugins" -->
+<!-- Remember to update the title of this issue. Example: Greek translation for Lesson Plan "Introduction To Common Plugins" -->
 
 # Details
 - Link to original content:
 - Language you'll be translating to: 
 - Have you arranged for someone to review this translation?: Yes or No
-- If you have, please list their GitHub username:
+- Reviewer's GitHub username:
 - Other info: 
 
-# Translated Resource
-- If you have translated a Lesson Plan or a Tutorial, please link your translation here:
-- If you have translated an Online Workshop's caption file, please attach the translated file to this GitHub issue.
+# Next Steps
+Once translated, please link or upload your translated files in a comment on this issue, and request a [translation review](https://make.wordpress.org/training/handbook/content-localization/#translation-review).

--- a/.github/ISSUE_TEMPLATE/content-translation-template
+++ b/.github/ISSUE_TEMPLATE/content-translation-template
@@ -1,0 +1,23 @@
+---
+name: Content Translation Template
+about: Content Translation template
+title: LANGUAGE translation for CONTENT TYPE "CONTENT TITLE" 
+labels: Translation, Awaiting Triage
+assignees: ''
+
+---
+
+<!-- The steps to translating content on Learn WordPress can be found in this [Online Workshop Hhandbook page](MISSING-LINK). -->
+
+<!-- Remember to update the title of this issue. Example: "Greek translation for Lesson Plan "Introduction To Common Plugins" -->
+
+# Details
+- Link to original content:
+- Language you'll be translating to: 
+- Have you arranged for someone to review this translation?: Yes or No
+- If you have, please list their GitHub username:
+- Other info: 
+
+# Translated Resource
+- If you have translated a Lesson Plan or a Tutorial, please link your translation here:
+- If you have translated an Online Workshop's caption file, please attach the translated file to this GitHub issue.

--- a/.github/ISSUE_TEMPLATE/content-translation-template
+++ b/.github/ISSUE_TEMPLATE/content-translation-template
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-<!-- The steps to translating content on Learn WordPress can be found in the handbook: [Content Localization](https://make.wordpress.org/training/handbook/content-localization/). -->
+<!-- The steps to translating content on Learn WordPress can be found in the handbook: https://make.wordpress.org/training/handbook/content-localization/. -->
 
 <!-- Remember to update the title of this issue. Example: Greek translation for Lesson Plan "Introduction To Common Plugins" -->
 


### PR DESCRIPTION
I'm creating a new issue type to be used for those wanting to translate content that already exists on Learn WordPress.

An accompanying Handbook draft can be found here: https://docs.google.com/document/d/1wuPlPVjVypxCzajrsnLWvQKqsyM3jf-x3WWcv2BFgvw/edit?usp=sharing