### PR TITLE
Improved copy button styling

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2020/css/objects/_prism.scss
+++ b/wp-content/themes/pub/wporg-learn-2020/css/objects/_prism.scss
@@ -217,7 +217,7 @@ pre.line-numbers > code {
 .wp-code-block-button-container {
 	display: flex;
 	justify-content: right;
-	padding: 0.5rem;
+	padding: 1rem;
 	background: $color-white;
 	border-width: 1px 1px 0;
 	border-style: solid;
@@ -226,7 +226,7 @@ pre.line-numbers > code {
 	border-top-right-radius: 0.3em;
 
 	button {
-		font-size: 0.8rem !important;
+		font-size: 1.2rem !important;
 	}
 
 	button + button {
@@ -235,7 +235,6 @@ pre.line-numbers > code {
 
 	+ pre {
 		margin-top: 0;
-		padding: 1em;
 		border-width: 0 1px 1px;
 		border-style: solid;
 		border-color: get-color(gray-5);
@@ -249,4 +248,16 @@ pre.line-numbers > code {
  */
 .github-markdown pre.wp-block-code {
 	margin-top: 0;
+}
+
+.wp-code-block-button-container {
+	padding: 0.5rem;
+
+	button {
+		font-size: 0.8rem !important;
+	}
+
+	+ pre {
+		padding: 1em;
+	}
 }

--- a/wp-content/themes/pub/wporg-learn-2020/css/objects/_prism.scss
+++ b/wp-content/themes/pub/wporg-learn-2020/css/objects/_prism.scss
@@ -217,7 +217,7 @@ pre.line-numbers > code {
 .wp-code-block-button-container {
 	display: flex;
 	justify-content: right;
-	padding: 1rem;
+	padding: 0.5rem;
 	background: $color-white;
 	border-width: 1px 1px 0;
 	border-style: solid;
@@ -226,7 +226,7 @@ pre.line-numbers > code {
 	border-top-right-radius: 0.3em;
 
 	button {
-		font-size: 1.2rem !important;
+		font-size: 0.8rem !important;
 	}
 
 	button + button {
@@ -235,6 +235,7 @@ pre.line-numbers > code {
 
 	+ pre {
 		margin-top: 0;
+		padding: 1em;
 		border-width: 0 1px 1px;
 		border-style: solid;
 		border-color: get-color(gray-5);


### PR DESCRIPTION
Improves the new Copy button styling for the Code block

Before:

![before](https://user-images.githubusercontent.com/180629/189607407-61e02ba8-015c-43f2-8a5a-ddfe619fe9e2.png)

After:

![after](https://user-images.githubusercontent.com/180629/189607428-4832e949-f315-43a5-900e-be3455e73074.png)
