### PR TITLE
Interim fix for the order of the Topic tiles on the Lesson Plan landing page

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2020/archive-lesson-plan.php
+++ b/wp-content/themes/pub/wporg-learn-2020/archive-lesson-plan.php
@@ -40,9 +40,11 @@ if ( '' === get_query_var( 'search' ) && empty( $_GET ) && is_post_type_archive(
 
 		<hr>
 		<?php
-		$categories = get_terms( 'wporg_lesson_category', array(
+		$categories = get_terms( array(
+			'taxonomy'   => 'wporg_lesson_category',
 			'hide_empty' => false,
 			'orderby'    => 'id',
+			'order'      => 'DESC',
 		) );
 		?>
 		<div class="row lp-taxonomy categories">


### PR DESCRIPTION
See #942 

The 'Topic' tiles on the Lesson Plan landing page are currently ordered by `id ASC` and this results in the 'General' tile being last. @hlashbrooke's [suggestion for a quick fix](https://wordpress.slack.com/archives/C02RW657Q/p1663278070703839) was to simply reverse the order.

Before:
![Screen Shot 2022-09-28 at 8 44 56 PM](https://user-images.githubusercontent.com/1017872/192719611-ea66ce99-ca1b-4321-a207-7a149beb4293.jpg)

After:
![Screen Shot 2022-09-28 at 8 44 31 PM](https://user-images.githubusercontent.com/1017872/192719675-3310a883-d391-4d7d-b370-0927243e5b33.jpg)

 A more robust custom ordering solution will be developed later.