### PR TITLE
Breadcrumbs: Separators should be commas for screen readers, not icons

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2020/template-parts/component-breadcrumbs.php
+++ b/wp-content/themes/pub/wporg-learn-2020/template-parts/component-breadcrumbs.php
@@ -55,7 +55,7 @@ if ( is_post_type_archive() ) {
 		}
 
 		if ( $x < $crumb_length - 1 ) {
-			echo '<span class="screen-reader-text">,</span> <span aria-hidden="true" class="bbp-breadcrumb-sep">»</span> ';
+			echo '<span class="screen-reader-text">, </span><span aria-hidden="true" class="bbp-breadcrumb-sep"> » </span>';
 		}
 	}
 	?>

--- a/wp-content/themes/pub/wporg-learn-2020/template-parts/component-breadcrumbs.php
+++ b/wp-content/themes/pub/wporg-learn-2020/template-parts/component-breadcrumbs.php
@@ -55,7 +55,7 @@ if ( is_post_type_archive() ) {
 		}
 
 		if ( $x < $crumb_length - 1 ) {
-			echo ' <span class="bbp-breadcrumb-sep">»</span> ';
+			echo '<span class="screen-reader-text">,</span> <span aria-hidden="true" class="bbp-breadcrumb-sep">»</span> ';
 		}
 	}
 	?>


### PR DESCRIPTION
Fixes #977 