### PR TITLE
Update content-translation.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/content-translation.md
+++ b/.github/ISSUE_TEMPLATE/content-translation.md
@@ -2,7 +2,7 @@
 name: Content Translation Template
 about: Tracking content translation for the learn.wordpress.org website
 title: LANGUAGE translation for CONTENT TYPE "CONTENT TITLE" 
-labels: Awaiting Triage, Translation
+labels: Awaiting Triage, Translation, Needs Translation Reviewer
 assignees: ''
 ---
 


### PR DESCRIPTION
This adds a `Needs Translation Reviewer` label by default to the content translation issue template.