### PR TITLE
Migrate Tutorials `video_language` -> `language` meta field

### DIFF
--- a/wp-content/plugins/wporg-learn/inc/admin.php
+++ b/wp-content/plugins/wporg-learn/inc/admin.php
@@ -90,9 +90,8 @@ function show_term_translation_notice() {
  */
 function add_workshop_list_table_columns( $columns ) {
 	$columns = array_slice( $columns, 0, -2, true )
-				+ array( 'video_language' => __( 'Video Language', 'wporg-learn' ) )
-				+ array( 'video_caption_language' => __( 'Subtitles', 'wporg-learn' ) )
 				+ array( 'language' => __( 'Language', 'wporg-learn' ) )
+				+ array( 'video_caption_language' => __( 'Subtitles', 'wporg-learn' ) )
 				+ array_slice( $columns, -2, 2, true );
 
 	return $columns;
@@ -148,13 +147,6 @@ function render_workshop_list_table_columns( $column_name, $post_id ) {
 				'%s [%s]',
 				esc_html( get_locale_name_from_code( $language, 'english' ) ),
 				esc_html( $language )
-			);
-			break;
-		case 'video_language':
-			printf(
-				'%s [%s]',
-				esc_html( get_locale_name_from_code( $post->video_language, 'english' ) ),
-				esc_html( $post->video_language )
 			);
 			break;
 		case 'video_caption_language':
@@ -225,7 +217,7 @@ function render_list_table_language_column( $column_name, $post_id ) {
  * @return array
  */
 function add_workshop_list_table_sortable_columns( $sortable_columns ) {
-	$sortable_columns['video_language'] = 'video_language';
+	$sortable_columns['language'] = 'language';
 
 	return $sortable_columns;
 }
@@ -243,7 +235,7 @@ function add_workshop_list_table_filters( $post_type, $which ) {
 		return;
 	}
 
-	$available_locales = get_available_workshop_locales( 'video_language', 'english', false );
+	$available_locales = get_available_workshop_locales( 'language', 'english', false );
 	$language          = filter_input( INPUT_GET, 'language', FILTER_SANITIZE_STRING );
 
 	?>
@@ -251,7 +243,7 @@ function add_workshop_list_table_filters( $post_type, $which ) {
 		<?php esc_html_e( 'Filter by language', 'wporg-learn' ); ?>
 	</label>
 	<select id="filter-by-language" name="language">
-		<option value=""<?php selected( ! $language ); ?>><?php esc_html_e( 'Any video language', 'wporg-learn' ); ?></option>
+		<option value=""<?php selected( ! $language ); ?>><?php esc_html_e( 'Any language', 'wporg-learn' ); ?></option>
 		<?php foreach ( $available_locales as $code => $name ) : ?>
 			<option value="<?php echo esc_attr( $code ); ?>"<?php selected( $code, $language ); ?>>
 				<?php
@@ -299,15 +291,15 @@ function handle_workshop_list_table_filters( WP_Query $query ) {
 			}
 
 			$meta_query[] = array(
-				'key'   => 'video_language',
+				'key'   => 'language',
 				'value' => $language,
 			);
 
 			$query->set( 'meta_query', $meta_query );
 		}
 
-		if ( 'video_language' === $query->get( 'orderby' ) ) {
-			$query->set( 'meta_key', 'video_language' );
+		if ( 'language' === $query->get( 'orderby' ) ) {
+			$query->set( 'meta_key', 'language' );
 			$query->set( 'orderby', 'meta_value' );
 		}
 	}

--- a/wp-content/plugins/wporg-learn/inc/blocks.php
+++ b/wp-content/plugins/wporg-learn/inc/blocks.php
@@ -226,8 +226,8 @@ function workshop_details_render_callback( $attributes, $content ) {
 		),
 		'language' => array(
 			'label' => __( 'Language', 'wporg-learn' ),
-			'param' => array( $post->video_language ),
-			'value' => array( esc_html( get_locale_name_from_code( $post->video_language, 'native' ) ) ),
+			'param' => array( $post->language ),
+			'value' => array( esc_html( get_locale_name_from_code( $post->language, 'native' ) ) ),
 		),
 		'captions' => array(
 			'label' => __( 'Subtitles', 'wporg-learn' ),

--- a/wp-content/plugins/wporg-learn/inc/form.php
+++ b/wp-content/plugins/wporg-learn/inc/form.php
@@ -264,7 +264,7 @@ function process_workshop_application_form_submission( $submission ) {
 		'post_excerpt' => $validated['description-short'],
 		'post_content' => $content,
 		'meta_input'   => array(
-			'video_language'       => $validated['language'],
+			'language'             => $validated['language'],
 			'original_application' => $validated,
 		),
 	);

--- a/wp-content/plugins/wporg-learn/inc/post-meta.php
+++ b/wp-content/plugins/wporg-learn/inc/post-meta.php
@@ -119,19 +119,6 @@ function register_workshop_meta() {
 
 	register_post_meta(
 		$post_type,
-		'video_language',
-		array(
-			'description'       => __( 'The language that the workshop is presented in.', 'wporg_learn' ),
-			'type'              => 'string',
-			'single'            => true,
-			'default'           => 'en_US',
-			'sanitize_callback' => __NAMESPACE__ . '\sanitize_locale',
-			'show_in_rest'      => true,
-		)
-	);
-
-	register_post_meta(
-		$post_type,
 		'video_caption_language',
 		array(
 			'description'       => __( 'A language for which subtitles are available for the workshop video.', 'wporg_learn' ),

--- a/wp-content/plugins/wporg-learn/inc/post-meta.php
+++ b/wp-content/plugins/wporg-learn/inc/post-meta.php
@@ -479,9 +479,6 @@ function save_workshop_metabox_fields( $post_id ) {
 		update_post_meta( $post_id, 'duration', $duration );
 	}
 
-	$video_language = filter_input( INPUT_POST, 'video-language' );
-	update_post_meta( $post_id, 'video_language', $video_language );
-
 	$captions = filter_input( INPUT_POST, 'video-caption-language', FILTER_DEFAULT, FILTER_REQUIRE_ARRAY );
 	delete_post_meta( $post_id, 'video_caption_language' );
 	if ( is_array( $captions ) ) {

--- a/wp-content/plugins/wporg-learn/views/metabox-workshop-details.php
+++ b/wp-content/plugins/wporg-learn/views/metabox-workshop-details.php
@@ -66,17 +66,6 @@
 <?php wp_nonce_field( 'workshop-metaboxes', 'workshop-metabox-nonce' ); ?>
 
 <p>
-	<label for="workshop-video-language"><?php esc_html_e( 'Video Language', 'wporg_learn' ); ?></label>
-	<select id="workshop-video-language" name="video-language" style="width: 100%;">
-		<?php foreach ( $locales as $code => $label ) : ?>
-			<option value="<?php echo esc_attr( $code ); ?>" <?php selected( $code, $post->video_language ); ?>>
-				<?php echo esc_html( $label ); ?>
-			</option>
-		<?php endforeach; ?>
-	</select>
-</p>
-
-<p>
 	<label for="workshop-video-caption-language"><?php esc_html_e( 'Subtitles', 'wporg_learn' ); ?></label>
 	<select id="workshop-video-caption-language" name="video-caption-language[]" style="width: 100%;" multiple>
 		<?php foreach ( $locales as $code => $label ) : ?>

--- a/wp-content/themes/pub/wporg-learn-2020/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2020/functions.php
@@ -460,7 +460,7 @@ add_filter( 'posts_orderby', 'wporg_archive_orderby', 10, 2 );
  *
  * After:
  * SELECT SQL_CALC_FOUND_ROWS wp_posts.*,
- *   MAX( IF( pmeta.meta_key = 'video_language' AND pmeta.meta_value LIKE 'art_%', 1, 0 ) ) AS has_language,
+ *   MAX( IF( pmeta.meta_key = 'language' AND pmeta.meta_value LIKE 'art_%', 1, 0 ) ) AS has_language,
  *   MAX( IF( pmeta.meta_key = 'video_caption_language' AND pmeta.meta_value LIKE 'art_%', 1, 0 ) ) AS has_caption
  * FROM wp_posts
  * INNER JOIN wp_postmeta pmeta ON ( wp_posts.ID = pmeta.post_id )
@@ -494,7 +494,7 @@ function wporg_archive_query_prioritize_locale( $clauses, $query ) {
 		 * grouping, there would be a separate row for each postmeta value for each workshop post.
 		 */
 		$clauses['fields'] .= ",
-			MAX( IF( pmeta.meta_key = 'video_language' AND pmeta.meta_value LIKE '{$locale_root}%', 1, 0 ) ) AS has_language
+			MAX( IF( pmeta.meta_key = 'language' AND pmeta.meta_value LIKE '{$locale_root}%', 1, 0 ) ) AS has_language
 		";
 		$clauses['fields'] .= ",
 			MAX( IF( pmeta.meta_key = 'video_caption_language' AND pmeta.meta_value LIKE '{$locale_root}%', 1, 0 ) ) AS has_caption
@@ -554,7 +554,7 @@ function wporg_archive_maybe_apply_query_filters( WP_Query &$query ) {
 
 	$entity_map = array(
 		'captions'   => 'video_caption_language',
-		'language'   => 'video_language',
+		'language'   => 'language',
 		'audience'   => 'audience',
 		'duration'   => 'duration',
 		'level'      => 'level',
@@ -725,7 +725,7 @@ function wporg_learn_get_card_template_args( $post_id ) {
 				array(
 					'icon'  => 'admin-site-alt3',
 					'label' => __( 'Language:', 'wporg-learn' ),
-					'value' => \WordPressdotorg\Locales\get_locale_name_from_code( $post->video_language, 'native' ),
+					'value' => \WordPressdotorg\Locales\get_locale_name_from_code( $post->language, 'native' ),
 				),
 			);
 			break;

--- a/wp-content/themes/pub/wporg-learn-2020/template-parts/component-workshop-filters.php
+++ b/wp-content/themes/pub/wporg-learn-2020/template-parts/component-workshop-filters.php
@@ -23,7 +23,7 @@ $buckets = array(
 	array(
 		'label' => __( 'Language', 'wporg-learn' ),
 		'name'  => 'language',
-		'items' => \WPOrg_Learn\Post_Meta\get_available_workshop_locales( 'video_language', 'native' ),
+		'items' => \WPOrg_Learn\Post_Meta\get_available_workshop_locales( 'language', 'native' ),
 	),
 	array(
 		'label' => __( 'Subtitles', 'wporg-learn' ),


### PR DESCRIPTION
See #1038 

All post meta data for the `video_language` field has been copied to the new `language` field so we can now remove `video_language`.

### Areas affected

1. Column displaying `video_language` removed from admin table
3. Filter on admin table switched from `video_language` to `language`
4. Metabox field for `video_language` on edit screen removed (and saving of field)
5. Frontend filtering switched from `video_language` to `language`
6. Language on frontend single Tutorial details switched from `video_language` to `language`
7. Custom query to prioritize content in the user's locale switched from `video_language` to `language`
8. Tutorial application form schema switched from `video_language` to `language`
9. The `video_language` field is no longer registered

### How to test

1. **Before** switching to this branch (ie. on trunk), ensure that some tutorials in your local instance have both `video_language` and `language` meta set (either set a few manually, or trash existing/destroy env and re-import from prod). These should have columns for 'Language' and 'Video Language' displayed in the admin table with matching values. When editing the Language field is the topmost document setting, and the video language is in the Workshop Details meta box:
![Screen Shot 2022-11-04 at 1 23 54 PM](https://user-images.githubusercontent.com/1017872/199859323-aa2b6d6a-1e18-44c3-9e5a-2964f6db0e19.jpg)

2. Switch to this branch and check all of the above affected areas
4. For 7, try changing locale when viewing the tutorials page on the frontend, and observe any tutorials with `language` matching your locale being displayed first