### PR TITLE
Add icon and sticky fields to Topic taxonomy

### DIFF
--- a/wp-content/plugins/wporg-learn/inc/admin.php
+++ b/wp-content/plugins/wporg-learn/inc/admin.php
@@ -192,7 +192,7 @@ function render_topics_list_table_columns( $content, $column_name, $term_id ) {
 		case 'sticky':
 			$sticky = get_term_meta( $term_id, 'sticky', true );
 
-			echo $sticky ? 'Yes' : '';
+			echo $sticky ? '<span class="dashicons dashicons-sticky"></span>' : '';
 			break;
 	}
 }

--- a/wp-content/plugins/wporg-learn/inc/admin.php
+++ b/wp-content/plugins/wporg-learn/inc/admin.php
@@ -14,10 +14,12 @@ defined( 'WPINC' ) || die();
  */
 add_action( 'admin_notices', __NAMESPACE__ . '\show_term_translation_notice' );
 add_filter( 'manage_wporg_workshop_posts_columns', __NAMESPACE__ . '\add_workshop_list_table_columns' );
+add_filter( 'manage_edit-topic_columns', __NAMESPACE__ . '\add_topic_list_table_column' );
 foreach ( array( 'lesson-plan', 'meeting', 'course', 'lesson' ) as $pt ) {
 	add_filter( 'manage_' . $pt . '_posts_columns', __NAMESPACE__ . '\add_list_table_language_column' );
 }
 add_action( 'manage_wporg_workshop_posts_custom_column', __NAMESPACE__ . '\render_workshop_list_table_columns', 10, 2 );
+add_action( 'manage_topic_custom_column', __NAMESPACE__ . '\render_topics_list_table_columns', 10, 3 );
 foreach ( array( 'lesson-plan', 'meeting', 'course', 'lesson' ) as $pt ) {
 	add_filter( 'manage_' . $pt . '_posts_custom_column', __NAMESPACE__ . '\render_list_table_language_column', 10, 2 );
 }
@@ -97,6 +99,22 @@ function add_workshop_list_table_columns( $columns ) {
 }
 
 /**
+ * Add additional columns to the terms list table for topics.
+ *
+ * @param array $columns
+ *
+ * @return array
+ */
+function add_topic_list_table_column( $columns ) {
+	$columns = array_slice( $columns, 0, -1, true )
+				+ array( 'icon' => __( 'Icon', 'wporg-learn' ) )
+				+ array( 'sticky' => __( 'Sticky', 'wporg-learn' ) )
+				+ array_slice( $columns, -1, 1, true );
+
+	return $columns;
+}
+
+/**
  * Add a language column to the post list table.
  *
  * @param array $columns
@@ -151,6 +169,30 @@ function render_workshop_list_table_columns( $column_name, $post_id ) {
 					$captions
 				)
 			) );
+			break;
+	}
+}
+
+/**
+ * Render the cell contents for the additional columns in the terms list table for topics.
+ *
+ * @param string $content
+ * @param string $column_name
+ * @param int    $term_id
+ *
+ * @return void
+ */
+function render_topics_list_table_columns( $content, $column_name, $term_id ) {
+	switch ( $column_name ) {
+		case 'icon':
+			$icon = get_term_meta( $term_id, 'dashicon-class', true );
+
+			echo esc_html( $icon );
+			break;
+		case 'sticky':
+			$sticky = get_term_meta( $term_id, 'sticky', true );
+
+			echo $sticky ? 'Yes' : '';
 			break;
 	}
 }

--- a/wp-content/plugins/wporg-learn/inc/taxonomy.php
+++ b/wp-content/plugins/wporg-learn/inc/taxonomy.php
@@ -10,12 +10,16 @@ defined( 'WPINC' ) || die();
 add_action( 'init', __NAMESPACE__ . '\register' );
 add_action( 'audience_add_form_fields', __NAMESPACE__ . '\register_custom_fields' );
 add_action( 'wporg_lesson_category_add_form_fields', __NAMESPACE__ . '\register_custom_fields' );
+add_action( 'topic_add_form_fields', __NAMESPACE__ . '\register_custom_fields' );
 add_action( 'audience_edit_form_fields', __NAMESPACE__ . '\tax_edit_term_fields', 10, 2 );
 add_action( 'wporg_lesson_category_edit_form_fields', __NAMESPACE__ . '\tax_edit_term_fields', 10, 2 );
+add_action( 'topic_edit_form_fields', __NAMESPACE__ . '\tax_edit_term_fields', 10, 2 );
 add_action( 'created_audience', __NAMESPACE__ . '\tax_save_term_fields' );
 add_action( 'edited_audience', __NAMESPACE__ . '\tax_save_term_fields' );
 add_action( 'created_wporg_lesson_category', __NAMESPACE__ . '\tax_save_term_fields' );
 add_action( 'edited_wporg_lesson_category', __NAMESPACE__ . '\tax_save_term_fields' );
+add_action( 'created_topic', __NAMESPACE__ . '\tax_save_term_fields' );
+add_action( 'edited_topic', __NAMESPACE__ . '\tax_save_term_fields' );
 
 /**
  * Register all the taxonomies.
@@ -598,7 +602,7 @@ function register_custom_fields( $taxonomy ) {
  * @param array  $taxonomy the taxonomy array.
  */
 function tax_edit_term_fields( $term, $taxonomy ) {
-	$value = get_term_meta( $term->term_id, 'dashicon-class', true );
+	$value  = get_term_meta( $term->term_id, 'dashicon-class', true );
 	$sticky = get_term_meta( $term->term_id, 'sticky', true );
 
 	echo '<tr class="form-field">

--- a/wp-content/plugins/wporg-learn/inc/taxonomy.php
+++ b/wp-content/plugins/wporg-learn/inc/taxonomy.php
@@ -8,6 +8,14 @@ defined( 'WPINC' ) || die();
  * Actions and filters.
  */
 add_action( 'init', __NAMESPACE__ . '\register' );
+add_action( 'audience_add_form_fields', __NAMESPACE__ . '\register_custom_fields' );
+add_action( 'wporg_lesson_category_add_form_fields', __NAMESPACE__ . '\register_custom_fields' );
+add_action( 'audience_edit_form_fields', __NAMESPACE__ . '\tax_edit_term_fields', 10, 2 );
+add_action( 'wporg_lesson_category_edit_form_fields', __NAMESPACE__ . '\tax_edit_term_fields', 10, 2 );
+add_action( 'created_audience', __NAMESPACE__ . '\tax_save_term_fields' );
+add_action( 'edited_audience', __NAMESPACE__ . '\tax_save_term_fields' );
+add_action( 'created_wporg_lesson_category', __NAMESPACE__ . '\tax_save_term_fields' );
+add_action( 'edited_wporg_lesson_category', __NAMESPACE__ . '\tax_save_term_fields' );
 
 /**
  * Register all the taxonomies.
@@ -583,9 +591,6 @@ function register_custom_fields( $taxonomy ) {
 	';
 }
 
-add_action( 'audience_add_form_fields', __NAMESPACE__ . '\register_custom_fields' );
-add_action( 'wporg_lesson_category_add_form_fields', __NAMESPACE__ . '\register_custom_fields' );
-
 /**
  * Icon field on edit screen.
  *
@@ -617,9 +622,6 @@ function tax_edit_term_fields( $term, $taxonomy ) {
 	';
 }
 
-add_action( 'audience_edit_form_fields', __NAMESPACE__ . '\tax_edit_term_fields', 10, 2 );
-add_action( 'wporg_lesson_category_edit_form_fields', __NAMESPACE__ . '\tax_edit_term_fields', 10, 2 );
-
 /**
  * Save icon field.
  *
@@ -647,8 +649,3 @@ function tax_save_term_fields( $term_id ) {
 		rest_sanitize_boolean( $is_sticky )
 	);
 }
-
-add_action( 'created_audience', __NAMESPACE__ . '\tax_save_term_fields' );
-add_action( 'edited_audience', __NAMESPACE__ . '\tax_save_term_fields' );
-add_action( 'created_wporg_lesson_category', __NAMESPACE__ . '\tax_save_term_fields' );
-add_action( 'edited_wporg_lesson_category', __NAMESPACE__ . '\tax_save_term_fields' );


### PR DESCRIPTION
See #1037 

Precursor to https://github.com/WordPress/Learn/pull/1072 where we will actually deprecate the `wporg_lesson_category` taxonomy.

This PR just adds the fields required for setting up the Topics to be displayed on the Lesson Plan landing page, **and does not actually update the tiles**.

![Screen Shot 2022-11-04 at 2 21 54 PM](https://user-images.githubusercontent.com/1017872/199864864-0ab99f20-93fc-4e2b-93be-72801c0998c3.jpg)

![Screen Shot 2022-11-04 at 1 05 36 PM](https://user-images.githubusercontent.com/1017872/199864873-e99ff225-1e38-4d96-bcbd-649818d7f017.jpg)

