### PR TITLE
Adds author support to lesson plans and tutorials

### DIFF
--- a/wp-content/plugins/wporg-learn/inc/post-type.php
+++ b/wp-content/plugins/wporg-learn/inc/post-type.php
@@ -60,7 +60,7 @@ function register_lesson_plan() {
 		'label'               => __( 'Lesson Plan', 'wporg_learn' ),
 		'description'         => __( 'WordPress.org Training Lesson Plan', 'wporg_learn' ),
 		'labels'              => $labels,
-		'supports'            => array( 'title', 'editor', 'comments', 'revisions', 'custom-fields' ),
+		'supports'            => array( 'title', 'editor', 'comments', 'revisions', 'custom-fields', 'author' ),
 		'taxonomies'          => array( 'duration', 'level', 'audience', 'instruction_type' ),
 		'hierarchical'        => true,
 		'public'              => true,
@@ -125,6 +125,7 @@ function register_workshop() {
 		'thumbnail',
 		'title',
 		'wporg-internal-notes',
+		'author',
 	);
 
 	$args = array(


### PR DESCRIPTION
This PR simply adds `author` support to lesson plans and tutorials so that the post author will be visible in the dashboard. This will help us track number of contributors more easily.