### PR TITLE
Make tutorial length label translatable

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2020/template-parts/component-featured-workshop.php
+++ b/wp-content/themes/pub/wporg-learn-2020/template-parts/component-featured-workshop.php
@@ -33,7 +33,9 @@ $featured_workshop = reset( $featured_workshop );
 					<a href="<?php echo esc_url( get_the_permalink() ); ?>"><?php the_title(); ?></a>
 				</h2>
 				<?php if ( isset( $duration ) ) { ?>
-					<p class="featured-workshop_content_duration">Length: <?php echo esc_html( $duration ); ?></p>
+					<p class="featured-workshop_content_duration">
+						<?php esc_html_e( 'Length:', 'wporg-learn' ); ?> <?php echo esc_html( $duration ); ?>
+					</p>
 				<?php } ?>
 				<div class="row">
 					<div class="col-8">

--- a/wp-content/themes/pub/wporg-learn-2020/template-parts/component-video-grid-item.php
+++ b/wp-content/themes/pub/wporg-learn-2020/template-parts/component-video-grid-item.php
@@ -20,7 +20,9 @@ $duration = get_workshop_duration( $post, 'string' );
 		?>
 		<h3><?php the_title(); ?></h3>
 		<?php if ( isset( $duration ) ) { ?>
-			<p class="video-grid_item_duration">Length: <?php echo esc_html( $duration ); ?></p>
+			<p class="video-grid_item_duration">
+				<?php esc_html_e( 'Length:', 'wporg-learn' ); ?> <?php echo esc_html( $duration ); ?>
+			</p>
 		<?php } ?>
 	</a>
 </li>


### PR DESCRIPTION
See #1006 

I missed translation of the labelling text 'Length:'