### PR TITLE
Adding average learner data to course sidebar

### DIFF
--- a/wp-content/plugins/wporg-learn/inc/blocks.php
+++ b/wp-content/plugins/wporg-learn/inc/blocks.php
@@ -206,20 +206,6 @@ function course_data_render_callback( $attributes, $content ) {
 		)
 	);
 
-	/**
-	// Get the total number of learners who have completed the course
-	$completions = Sensei_Utils::sensei_check_for_activity(
-		array(
-			'type'     => 'sensei_course_status',
-			'status'   => 'complete',
-			'post__in' => $course_id,
-		)
-	);
-
-	// Calculate the percentage of learners who have completed the course, rounded off to 1 decimal point
-	$percent_complete = round( ( $completions / $learners * 100 ), 1 );
-	**/
-
 	// Get the average grade scross all learners
 	$average_grade = $course_service->get_courses_average_grade( array( $course_id ) );
 
@@ -232,12 +218,6 @@ function course_data_render_callback( $attributes, $content ) {
 			'label' => __( 'Number of learners', 'wporg-learn' ),
 			'value' => $learners,
 		),
-		/**
-		'completions' => array(
-			'label' => __( 'Completion rate', 'wporg-learn' ),
-			'value' => $percent_complete . '%',
-		),
-		**/
 		'grade' => array(
 			'label' => __( 'Average grade', 'wporg-learn' ),
 			'value' => $average_grade,

--- a/wp-content/plugins/wporg-learn/inc/blocks.php
+++ b/wp-content/plugins/wporg-learn/inc/blocks.php
@@ -4,6 +4,8 @@ namespace WPOrg_Learn\Blocks;
 
 use Error;
 use Sensei_Lesson;
+use Sensei_Utils;
+use Sensei_Reports_Overview_Service_Courses;
 use function WordPressdotorg\Locales\get_locale_name_from_code;
 use function WPOrg_Learn\{get_build_path, get_build_url, get_views_path};
 use function WPOrg_Learn\Form\render_workshop_application_form;
@@ -26,6 +28,7 @@ add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_block_style_assets' 
 function register_types() {
 	register_lesson_plan_actions();
 	register_lesson_plan_details();
+	register_course_data();
 	register_workshop_details();
 	register_workshop_application_form();
 }
@@ -138,6 +141,111 @@ function lesson_plan_details_render_callback( $attributes, $content ) {
 
 	ob_start();
 	require get_views_path() . 'block-lesson-plan-details.php';
+
+	return ob_get_clean();
+}
+
+/**
+ * Register Course Data block type and related assets.
+ *
+ * @throws Error If the build files are not found.
+ */
+function register_course_data() {
+	$script_asset_path = get_build_path() . 'course-data.asset.php';
+	if ( ! is_readable( $script_asset_path ) ) {
+		throw new Error(
+			'You need to run `npm start` or `npm run build` for the "wporg-learn/course-data" block first.'
+		);
+	}
+
+	$script_asset = require $script_asset_path;
+	wp_register_script(
+		'course-data-editor-script',
+		get_build_url() . 'course-data.js',
+		$script_asset['dependencies'],
+		$script_asset['version'],
+		true,
+	);
+
+	wp_register_style(
+		'course-data-style',
+		get_build_url() . 'style-course-data.css',
+		array(),
+		filemtime( get_build_path() . 'style-course-data.css' )
+	);
+
+	register_block_type( 'wporg-learn/course-data', array(
+		'editor_script'   => 'course-data-editor-script',
+		'style'           => 'course-data-style',
+		'render_callback' => __NAMESPACE__ . '\course_data_render_callback',
+	) );
+}
+
+/**
+ * Render the block content (html) on the frontend of the site.
+ *
+ * @param array  $attributes
+ * @param string $content
+ * @return string HTML output used by the block
+ */
+function course_data_render_callback( $attributes, $content ) {
+	if ( get_post_type() !== 'course' ) {
+		return;
+	}
+
+	$course_service = new Sensei_Reports_Overview_Service_Courses();
+	$post           = get_post();
+	$course_id      = $post->ID;
+
+	// Get the total number of learners enrolled in the course
+	$learners = Sensei_Utils::sensei_check_for_activity(
+		array(
+			'type'     => 'sensei_course_status',
+			'status'   => 'in-progress',
+			'post__in' => $course_id,
+		)
+	);
+
+	// Get the total number of learners who have completed the course
+	$completions = Sensei_Utils::sensei_check_for_activity(
+		array(
+			'type'     => 'sensei_course_status',
+			'status'   => 'complete',
+			'post__in' => $course_id,
+		)
+	);
+
+	// Calculate the percentage of learners who have completed the course, rounded off to 1 decimal point
+	$percent_complete = round( ( $completions / $learners * 100 ), 1 );
+
+	// Get the average grade scross all learners
+	$average_grade = $course_service->get_courses_average_grade( array( $course_id ) );
+
+	// Get the average number of days it takes to complete a course
+	$avergage_days = $course_service->get_average_days_to_completion( array( $course_id ) );
+
+	// Set up array of data to be used
+	$data = array(
+		'learners' => array(
+			'label' => __( 'Number of learners', 'wporg-learn' ),
+			'value' => $learners,
+		),
+		'completions' => array(
+			'label' => __( 'Completion rate', 'wporg-learn' ),
+			'value' => $percent_complete . '%',
+		),
+		'grade' => array(
+			'label' => __( 'Average grade', 'wporg-learn' ),
+			'value' => $average_grade,
+		),
+		'days' => array(
+			'label' => __( 'Average days to complete', 'wporg-learn' ),
+			'value' => $avergage_days,
+		),
+	);
+
+	ob_start();
+	require get_views_path() . 'block-course-data.php';
 
 	return ob_get_clean();
 }

--- a/wp-content/plugins/wporg-learn/inc/blocks.php
+++ b/wp-content/plugins/wporg-learn/inc/blocks.php
@@ -206,17 +206,17 @@ function course_data_render_callback( $attributes, $content ) {
 		)
 	);
 
-	// Get the total number of learners who have completed the course
-	$completions = Sensei_Utils::sensei_check_for_activity(
-		array(
-			'type'     => 'sensei_course_status',
-			'status'   => 'complete',
-			'post__in' => $course_id,
-		)
-	);
+	// // Get the total number of learners who have completed the course
+	// $completions = Sensei_Utils::sensei_check_for_activity(
+	// 	array(
+	// 		'type'     => 'sensei_course_status',
+	// 		'status'   => 'complete',
+	// 		'post__in' => $course_id,
+	// 	)
+	// );
 
-	// Calculate the percentage of learners who have completed the course, rounded off to 1 decimal point
-	$percent_complete = round( ( $completions / $learners * 100 ), 1 );
+	// // Calculate the percentage of learners who have completed the course, rounded off to 1 decimal point
+	// $percent_complete = round( ( $completions / $learners * 100 ), 1 );
 
 	// Get the average grade scross all learners
 	$average_grade = $course_service->get_courses_average_grade( array( $course_id ) );
@@ -230,10 +230,10 @@ function course_data_render_callback( $attributes, $content ) {
 			'label' => __( 'Number of learners', 'wporg-learn' ),
 			'value' => $learners,
 		),
-		'completions' => array(
-			'label' => __( 'Completion rate', 'wporg-learn' ),
-			'value' => $percent_complete . '%',
-		),
+		// 'completions' => array(
+		// 	'label' => __( 'Completion rate', 'wporg-learn' ),
+		// 	'value' => $percent_complete . '%',
+		// ),
 		'grade' => array(
 			'label' => __( 'Average grade', 'wporg-learn' ),
 			'value' => $average_grade,

--- a/wp-content/plugins/wporg-learn/inc/blocks.php
+++ b/wp-content/plugins/wporg-learn/inc/blocks.php
@@ -206,17 +206,19 @@ function course_data_render_callback( $attributes, $content ) {
 		)
 	);
 
-	// // Get the total number of learners who have completed the course
-	// $completions = Sensei_Utils::sensei_check_for_activity(
-	// 	array(
-	// 		'type'     => 'sensei_course_status',
-	// 		'status'   => 'complete',
-	// 		'post__in' => $course_id,
-	// 	)
-	// );
+	/**
+	// Get the total number of learners who have completed the course
+	$completions = Sensei_Utils::sensei_check_for_activity(
+		array(
+			'type'     => 'sensei_course_status',
+			'status'   => 'complete',
+			'post__in' => $course_id,
+		)
+	);
 
-	// // Calculate the percentage of learners who have completed the course, rounded off to 1 decimal point
-	// $percent_complete = round( ( $completions / $learners * 100 ), 1 );
+	// Calculate the percentage of learners who have completed the course, rounded off to 1 decimal point
+	$percent_complete = round( ( $completions / $learners * 100 ), 1 );
+	**/
 
 	// Get the average grade scross all learners
 	$average_grade = $course_service->get_courses_average_grade( array( $course_id ) );
@@ -230,10 +232,12 @@ function course_data_render_callback( $attributes, $content ) {
 			'label' => __( 'Number of learners', 'wporg-learn' ),
 			'value' => $learners,
 		),
-		// 'completions' => array(
-		// 	'label' => __( 'Completion rate', 'wporg-learn' ),
-		// 	'value' => $percent_complete . '%',
-		// ),
+		/**
+		'completions' => array(
+			'label' => __( 'Completion rate', 'wporg-learn' ),
+			'value' => $percent_complete . '%',
+		),
+		**/
 		'grade' => array(
 			'label' => __( 'Average grade', 'wporg-learn' ),
 			'value' => $average_grade,

--- a/wp-content/plugins/wporg-learn/inc/blocks.php
+++ b/wp-content/plugins/wporg-learn/inc/blocks.php
@@ -222,7 +222,7 @@ function course_data_render_callback( $attributes, $content ) {
 	$average_grade = $course_service->get_courses_average_grade( array( $course_id ) );
 
 	// Get the average number of days it takes to complete a course
-	$avergage_days = $course_service->get_average_days_to_completion( array( $course_id ) );
+	$average_days = $course_service->get_average_days_to_completion( array( $course_id ) );
 
 	// Set up array of data to be used
 	$data = array(
@@ -240,7 +240,7 @@ function course_data_render_callback( $attributes, $content ) {
 		),
 		'days' => array(
 			'label' => __( 'Average days to complete', 'wporg-learn' ),
-			'value' => $avergage_days,
+			'value' => $average_days,
 		),
 	);
 

--- a/wp-content/plugins/wporg-learn/js/course-data/block.json
+++ b/wp-content/plugins/wporg-learn/js/course-data/block.json
@@ -1,0 +1,16 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "wporg-learn/course-data",
+	"title": "Course Data",
+	"category": "widgets",
+	"icon": "info-outline",
+	"description": "",
+	"textdomain": "wporg-learn",
+	"supports": {
+		"html": false
+	},
+	"editorScript": "file:../../build/course-data.js",
+	"editorStyle": "file:../../build/course-data.css",
+	"style": "file:../../build/style-course-data.css"
+}

--- a/wp-content/plugins/wporg-learn/js/course-data/src/edit.js
+++ b/wp-content/plugins/wporg-learn/js/course-data/src/edit.js
@@ -1,0 +1,26 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Placeholder } from '@wordpress/components';
+
+import { useIsBlockInSidebar, useGetCurrentPostType } from '../../hooks';
+import { getBlockPlaceholderMessage } from '../../utils';
+
+export default function Edit( { clientId } ) {
+	const message = getBlockPlaceholderMessage(
+		'lesson-plan',
+		useGetCurrentPostType(),
+		useIsBlockInSidebar( clientId, 'wporg-learn-courses' ),
+		__(
+			'This will be dynamically populated based on the current course data.',
+			'wporg-learn'
+		)
+	);
+
+	return (
+		<Placeholder label={ __( 'Course Data', 'wporg-learn' ) }>
+			<p>{ message }</p>
+		</Placeholder>
+	);
+}

--- a/wp-content/plugins/wporg-learn/js/course-data/src/index.js
+++ b/wp-content/plugins/wporg-learn/js/course-data/src/index.js
@@ -1,0 +1,77 @@
+/**
+ * Registers a new block provided a unique name and an object defining its behavior.
+ *
+ * @see https://developer.wordpress.org/block-editor/developers/block-api/#registering-a-block
+ */
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Retrieves the translation of text.
+ *
+ * @see https://developer.wordpress.org/block-editor/packages/packages-i18n/
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Lets webpack process CSS, SASS or SCSS files referenced in JavaScript files.
+ * All files containing `style` keyword are bundled together. The code used
+ * gets applied both to the front of your site and to the editor.
+ *
+ * @see https://www.npmjs.com/package/@wordpress/scripts#using-css
+ */
+import './style.scss';
+
+/**
+ * Internal dependencies
+ */
+import Edit from './edit';
+import metadata from '../block.json';
+
+/**
+ * Every block starts by registering a new block type definition.
+ *
+ * @see https://developer.wordpress.org/block-editor/developers/block-api/#registering-a-block
+ */
+registerBlockType( metadata.name, {
+	/**
+	 * This is the display title for your block, which can be translated with `i18n` functions.
+	 * The block inserter will show this name.
+	 */
+	title: __( 'Course Data', 'wporg-learn' ),
+
+	/**
+	 * This is a short description for your block, can be translated with `i18n` functions.
+	 * It will be shown in the Block Tab in the Settings Sidebar.
+	 */
+	description: __(
+		'Show average learner details for the course.',
+		'wporg-learn'
+	),
+
+	/**
+	 * Blocks are grouped into categories to help users browse and discover them.
+	 * The categories provided by core are `common`, `embed`, `formatting`, `layout` and `widgets`.
+	 */
+	category: metadata.category,
+
+	/**
+	 * An icon property should be specified to make it easier to identify a block.
+	 * These can be any of WordPress’ Dashicons, or a custom svg element.
+	 */
+	icon: metadata.icon,
+
+	/**
+	 * Optional block extended support features.
+	 */
+	supports: metadata.supports,
+
+	/**
+	 * @see ./edit.js
+	 */
+	edit: Edit,
+
+	/**
+	 * @see ./save.js
+	 */
+	save: () => null,
+} );

--- a/wp-content/plugins/wporg-learn/js/course-data/src/style.scss
+++ b/wp-content/plugins/wporg-learn/js/course-data/src/style.scss
@@ -14,7 +14,7 @@
 		display: flex;
 		justify-content: space-between;
 		border-bottom: 1px solid #e2e4e7;
-		padding: 0.5rem 0 !important;
+		padding: 0.5rem 0;
 
 		> strong {
 			font-weight: 600;

--- a/wp-content/plugins/wporg-learn/js/course-data/src/style.scss
+++ b/wp-content/plugins/wporg-learn/js/course-data/src/style.scss
@@ -1,0 +1,42 @@
+/**
+ * The following styles get applied both on the front of your site
+ * and in the editor.
+ *
+ * Replace them with your own styles or remove the file completely.
+ */
+
+.wp-block-wporg-learn-course-data {
+	border-top: 1px solid #e2e4e7;
+	list-style: none;
+	margin: 0 0 2rem 0;
+
+	> li {
+		display: flex;
+		justify-content: space-between;
+		border-bottom: 1px solid #e2e4e7;
+		padding: 0.5rem 0 !important;
+
+		> strong {
+			font-weight: 600;
+			color: #555d66;
+		}
+
+		> span {
+			text-align: right;
+		}
+	}
+}
+
+@media only print {
+	.wp-block-wporg-learn-course-data {
+		display: block !important;
+		border: none;
+		margin-bottom: 2rem;
+
+		> li {
+			display: inline-block;
+			padding: 0 1rem 0 0;
+			border: none;
+		}
+	}
+}

--- a/wp-content/plugins/wporg-learn/views/block-course-data.php
+++ b/wp-content/plugins/wporg-learn/views/block-course-data.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace WPOrg_Learn\View\Blocks;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * @var array $data
+ */
+
+?>
+
+<?php if ( get_post_type() === 'course' && ! empty( $data ) ) : ?>
+	<ul class="wp-block-wporg-learn-course-data">
+		<?php
+		foreach ( $data as $key => $item ) { ?>
+			<li>
+				<strong><?php echo esc_html( $item['label'] ); ?></strong>
+				<span><?php echo esc_html( $item['value'] ); ?></span>
+			</li>
+			<?php
+		}
+		?>
+	</ul>
+<?php endif; ?>

--- a/wp-content/plugins/wporg-learn/webpack.config.js
+++ b/wp-content/plugins/wporg-learn/webpack.config.js
@@ -13,6 +13,7 @@ config.entry = {
 	'locale-notice': './js/locale-notice.js',
 	'lesson-plan-actions': './js/lesson-plan-actions/src/index.js',
 	'lesson-plan-details': './js/lesson-plan-details/src/index.js',
+	'course-data': './js/course-data/src/index.js',
 	'language-meta': './js/language-meta/index.js',
 };
 

--- a/wp-content/themes/pub/wporg-learn-2020/sidebar-course.php
+++ b/wp-content/themes/pub/wporg-learn-2020/sidebar-course.php
@@ -53,16 +53,28 @@ use Sensei_Reports_Overview_Service_Courses;
 
 			// Set up array of data to be output
 			$course_data = array(
-				'learners' => array( 'label' => __( 'Number of enrolled learners', 'wporg-learn' ), 'value' => $learners ),
-				'completions' => array( 'label' => __( 'Completion rate', 'wporg-learn' ), 'value' => $percent_complete . '%' ),
-				'grade' => array( 'label' => __( 'Average grade', 'wporg-learn' ), 'value' => $average_grade ),
-				'days' => array( 'label' => __( 'Average days to complete', 'wporg-learn' ), 'value' => $avergage_days ),
+				'learners' => array(
+					'label' => __( 'Number of enrolled learners', 'wporg-learn' ),
+					'value' => $learners,
+				),
+				'completions' => array(
+					'label' => __( 'Completion rate', 'wporg-learn' ),
+					'value' => $percent_complete . '%',
+				),
+				'grade' => array(
+					'label' => __( 'Average grade', 'wporg-learn' ),
+					'value' => $average_grade,
+				),
+				'days' => array(
+					'label' => __( 'Average days to complete', 'wporg-learn' ),
+					'value' => $avergage_days,
+				),
 			);
 
 			?>
 
 			<div id="course-data" class="widget course_data">
-				<p><strong><?php _e( 'Course data', 'wporg-learn' ) ?></strong></p>
+				<p><strong><?php esc_html_e( 'Course data', 'wporg-learn' ); ?></strong></p>
 				<ul>
 					<?php
 					foreach ( $course_data as $k => $data ) {
@@ -72,7 +84,7 @@ use Sensei_Reports_Overview_Service_Courses;
 				</ul>
 			</div>
 
-		<?php
+			<?php
 		}
 
 		if ( is_active_sidebar( 'wporg-learn-courses' ) ) :

--- a/wp-content/themes/pub/wporg-learn-2020/sidebar-course.php
+++ b/wp-content/themes/pub/wporg-learn-2020/sidebar-course.php
@@ -11,7 +11,7 @@ namespace WordPressdotorg\Theme;
 
 ?>
 <aside class="lp-sidebar">
-	<div class="lp-details">
+	<div>
 		<?php
 		if ( is_active_sidebar( 'wporg-learn-courses' ) ) :
 			dynamic_sidebar( 'wporg-learn-courses' );

--- a/wp-content/themes/pub/wporg-learn-2020/sidebar-course.php
+++ b/wp-content/themes/pub/wporg-learn-2020/sidebar-course.php
@@ -11,11 +11,9 @@ namespace WordPressdotorg\Theme;
 
 ?>
 <aside class="lp-sidebar">
-	<div class="lp-details">
-		<?php
-		if ( is_active_sidebar( 'wporg-learn-courses' ) ) :
-			dynamic_sidebar( 'wporg-learn-courses' );
-		endif;
-		?>
-	</div>
+	<?php
+	if ( is_active_sidebar( 'wporg-learn-courses' ) ) :
+		dynamic_sidebar( 'wporg-learn-courses' );
+	endif;
+	?>
 </aside>

--- a/wp-content/themes/pub/wporg-learn-2020/sidebar-course.php
+++ b/wp-content/themes/pub/wporg-learn-2020/sidebar-course.php
@@ -8,10 +8,73 @@
  */
 
 namespace WordPressdotorg\Theme;
+
+// Setup necessary Sensei classes for course data
+use Sensei_Utils;
+use Sensei_Reports_Overview_Service_Courses;
+
 ?>
 <aside class="lp-sidebar">
 	<div class="lp-details">
 		<?php
+
+		if ( isset( $post->ID ) ) {
+			$course_id = $post->ID;
+
+			// Get the course service class
+			$course_service = new Sensei_Reports_Overview_Service_Courses();
+
+			// Get the total number of learners enrolled in the course
+			$learners = Sensei_Utils::sensei_check_for_activity(
+				array(
+					'type'     => 'sensei_course_status',
+					'status'   => 'in-progress',
+					'post__in' => $course_id,
+				)
+			);
+
+			// Get the total number of learners who have completed the course
+			$completions = Sensei_Utils::sensei_check_for_activity(
+				array(
+					'type'     => 'sensei_course_status',
+					'status'   => 'complete',
+					'post__in' => $course_id,
+				)
+			);
+
+			// Calculate the percentage of learners who have completed the course, rounded off to 1 decimal point
+			$percent_complete = round( ( $completions / $learners * 100 ), 1 );
+
+			// Get the average grade scross all learners
+			$average_grade = $course_service->get_courses_average_grade( array( $course_id ) );
+
+			// Get the average number of days it takes to complete a course
+			$avergage_days = $course_service->get_average_days_to_completion( array( $course_id ) );
+
+			// Set up array of data to be output
+			$course_data = array(
+				'learners' => array( 'label' => __( 'Number of enrolled learners', 'wporg-learn' ), 'value' => $learners ),
+				'completions' => array( 'label' => __( 'Completion rate', 'wporg-learn' ), 'value' => $percent_complete . '%' ),
+				'grade' => array( 'label' => __( 'Average grade', 'wporg-learn' ), 'value' => $average_grade ),
+				'days' => array( 'label' => __( 'Average days to complete', 'wporg-learn' ), 'value' => $avergage_days ),
+			);
+
+			?>
+
+			<div id="course-data" class="widget course_data">
+				<p><strong><?php _e( 'Course data', 'wporg-learn' ) ?></strong></p>
+				<ul>
+					<?php
+					foreach ( $course_data as $k => $data ) {
+						echo '<li>' . esc_attr( $data['label'] ) . ': ' . esc_html( $data['value'] ) . '</li>';
+					}
+					?>
+				</ul>
+			</div>
+
+		<?php
+		}
+
 		if ( is_active_sidebar( 'wporg-learn-courses' ) ) :
 			dynamic_sidebar( 'wporg-learn-courses' );
 		endif;

--- a/wp-content/themes/pub/wporg-learn-2020/sidebar-course.php
+++ b/wp-content/themes/pub/wporg-learn-2020/sidebar-course.php
@@ -9,84 +9,10 @@
 
 namespace WordPressdotorg\Theme;
 
-// Setup necessary Sensei classes for course data
-use Sensei_Utils;
-use Sensei_Reports_Overview_Service_Courses;
-
 ?>
 <aside class="lp-sidebar">
 	<div class="lp-details">
 		<?php
-
-		if ( isset( $post->ID ) ) {
-			$course_id = $post->ID;
-
-			// Get the course service class
-			$course_service = new Sensei_Reports_Overview_Service_Courses();
-
-			// Get the total number of learners enrolled in the course
-			$learners = Sensei_Utils::sensei_check_for_activity(
-				array(
-					'type'     => 'sensei_course_status',
-					'status'   => 'in-progress',
-					'post__in' => $course_id,
-				)
-			);
-
-			// Get the total number of learners who have completed the course
-			$completions = Sensei_Utils::sensei_check_for_activity(
-				array(
-					'type'     => 'sensei_course_status',
-					'status'   => 'complete',
-					'post__in' => $course_id,
-				)
-			);
-
-			// Calculate the percentage of learners who have completed the course, rounded off to 1 decimal point
-			$percent_complete = round( ( $completions / $learners * 100 ), 1 );
-
-			// Get the average grade scross all learners
-			$average_grade = $course_service->get_courses_average_grade( array( $course_id ) );
-
-			// Get the average number of days it takes to complete a course
-			$avergage_days = $course_service->get_average_days_to_completion( array( $course_id ) );
-
-			// Set up array of data to be output
-			$course_data = array(
-				'learners' => array(
-					'label' => __( 'Number of enrolled learners', 'wporg-learn' ),
-					'value' => $learners,
-				),
-				'completions' => array(
-					'label' => __( 'Completion rate', 'wporg-learn' ),
-					'value' => $percent_complete . '%',
-				),
-				'grade' => array(
-					'label' => __( 'Average grade', 'wporg-learn' ),
-					'value' => $average_grade,
-				),
-				'days' => array(
-					'label' => __( 'Average days to complete', 'wporg-learn' ),
-					'value' => $avergage_days,
-				),
-			);
-
-			?>
-
-			<div id="course-data" class="widget course_data">
-				<p><strong><?php esc_html_e( 'Course data', 'wporg-learn' ); ?></strong></p>
-				<ul>
-					<?php
-					foreach ( $course_data as $k => $data ) {
-						echo '<li>' . esc_attr( $data['label'] ) . ': ' . esc_html( $data['value'] ) . '</li>';
-					}
-					?>
-				</ul>
-			</div>
-
-			<?php
-		}
-
 		if ( is_active_sidebar( 'wporg-learn-courses' ) ) :
 			dynamic_sidebar( 'wporg-learn-courses' );
 		endif;


### PR DESCRIPTION
This PR adds the average learner data for a course to the sidebar on the single course page.

Some questions from my side that I'm uncertain about:
* I did everything in the `sidebar-course.php` template file, but should the logic perhaps be added to a function elsewhere?
* Should this instead be defined as a block that can be moved around as a widget?
* Is the HTML semantic and accessible?

I'm happy to make changes accordingly but thought I'd get the initial PR up first for feedback.

Fixes #1089