### PR TITLE
 Fix tutorials with default language not showing in archive when filtered

### DIFF
--- a/wp-content/plugins/wporg-learn/inc/post-meta.php
+++ b/wp-content/plugins/wporg-learn/inc/post-meta.php
@@ -18,7 +18,7 @@ add_action( 'add_meta_boxes', __NAMESPACE__ . '\add_lesson_plan_metaboxes' );
 add_action( 'add_meta_boxes', __NAMESPACE__ . '\add_workshop_metaboxes' );
 add_action( 'add_meta_boxes', __NAMESPACE__ . '\add_meeting_metaboxes' );
 add_action( 'save_post_lesson-plan', __NAMESPACE__ . '\save_lesson_plan_metabox_fields' );
-add_action( 'save_post_wporg_workshop', __NAMESPACE__ . '\save_workshop_metabox_fields' );
+add_action( 'save_post_wporg_workshop', __NAMESPACE__ . '\save_workshop_meta_fields' );
 add_action( 'save_post_meeting', __NAMESPACE__ . '\save_meeting_metabox_fields' );
 add_action( 'admin_footer', __NAMESPACE__ . '\render_locales_list' );
 add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_editor_assets' );
@@ -469,11 +469,11 @@ function render_metabox_meeting_language( WP_Post $post ) {
 }
 
 /**
- * Update the post meta values from the meta box fields when the post is saved.
+ * Update the post meta values from the meta fields when the post is saved.
  *
  * @param int $post_id
  */
-function save_workshop_metabox_fields( $post_id ) {
+function save_workshop_meta_fields( $post_id ) {
 	if ( wp_is_post_revision( $post_id ) || ! current_user_can( 'edit_post', $post_id ) ) {
 		return;
 	}
@@ -520,6 +520,16 @@ function save_workshop_metabox_fields( $post_id ) {
 		foreach ( $other_contributor_usernames as $username ) {
 			add_post_meta( $post_id, 'other_contributor_wporg_username', $username );
 		}
+	}
+
+	// This language meta field is rendered in the editor sidebar using a PluginDocumentSettingPanel block,
+	// which won't save the field on publish if it has the default value.
+	// Our custom workshops query for locale prioritized tutorials (see functions.php `wporg_archive_query_prioritize_locale`)
+	// depends on it being set, so we force it to be updated after saving:
+	$language         = get_post_meta( $post_id, 'language', true );
+	$language_default = 'en_US';
+	if ( ! isset( $language ) || $language_default === $language ) {
+		update_post_meta( $post_id, 'language', $language_default );
 	}
 }
 


### PR DESCRIPTION
Fixes #1172

### Bug
Newly published tutorials with the default language (en_US) do not show in the [archive](https://learn.wordpress.org/tutorials/) when filtered by that language.

### Context
We have a [custom query for the Tutorial archive](https://github.com/WordPress/Learn/blob/trunk/wp-content/themes/pub/wporg-learn-2020/functions.php#L477) view which prioritises Tutorials with either `language` or `video_caption_language` meta fields matching the user's language.

This universal `language` field has only recently been added, and the `video_language` field was deprecated, with the query switching to the new field. The crucial difference appears to be that `language` is using a `PluginDocumentSettingPanel` block, whereas the old `video_language` field was using a meta box.

The bug presents because publishing with the block does not save the default `language` value, resulting in the tutorial being filtered out of the query results.

### The fix
Force the default `language` post meta value to be saved when saving the tutorial if it is not set.

### How to test
1. Add a new tutorial, leaving the meta language field with the default value 'English'
2. Publish and navigate to http://localhost:8888/tutorials/
3. Your tutorial should be in the results towards the end. Note that searching does not use this query so you need to page through until you find it.
4. Filter the tutorials by language: English [en_US] and observe that the tutorial is still in the results

#### Edge testing
Try different combinations of tutorial language, frontend locale setting and frontend filtering