### PR TITLE
Add/redirect for content error to feedback update

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2020/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2020/functions.php
@@ -1168,7 +1168,7 @@ function wporg_learn_redirect_old_urls() {
 		'/workshops'                      => '/tutorials',
 		'/social-learning'                => '/online-workshops',
 		'/workshop-presenter-application' => '/tutorial-presenter-application',
-		'/report-content-errors'          => '/report-content-feedback'
+		'/report-content-errors'          => '/report-content-feedback',
 	);
 
 	// Use `REQUEST_URI` rather than `$wp->request`, to get the entire source URI including url parameters.

--- a/wp-content/themes/pub/wporg-learn-2020/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2020/functions.php
@@ -1168,6 +1168,7 @@ function wporg_learn_redirect_old_urls() {
 		'/workshops'                      => '/tutorials',
 		'/social-learning'                => '/online-workshops',
 		'/workshop-presenter-application' => '/tutorial-presenter-application',
+		'/report-content-errors'          => '/report-content-feedback'
 	);
 
 	// Use `REQUEST_URI` rather than `$wp->request`, to get the entire source URI including url parameters.


### PR DESCRIPTION
While updating the Training team handbook terminology from Content Error to Content feedback, the permalink for https://learn.wordpress.org/report-content-errors/ needs to be updated. 

The new permalink will be https://learn.wordpress.org/report-content-feedback/ 

This PR provides the redirect, which is handled within the theme. 

