### PR TITLE
Add WPTV URL meta field for online workshops

### DIFF
--- a/wp-content/plugins/wporg-learn/inc/admin.php
+++ b/wp-content/plugins/wporg-learn/inc/admin.php
@@ -13,26 +13,29 @@ defined( 'WPINC' ) || die();
  * Actions and filters.
  */
 add_action( 'admin_notices', __NAMESPACE__ . '\show_term_translation_notice' );
-add_filter( 'manage_wporg_workshop_posts_columns', __NAMESPACE__ . '\add_workshop_list_table_columns' );
-add_filter( 'manage_edit-topic_columns', __NAMESPACE__ . '\add_topic_list_table_column' );
-foreach ( array( 'lesson-plan', 'meeting', 'course', 'lesson' ) as $pt ) {
-	add_filter( 'manage_' . $pt . '_posts_columns', __NAMESPACE__ . '\add_list_table_language_column' );
-}
-add_action( 'manage_wporg_workshop_posts_custom_column', __NAMESPACE__ . '\render_workshop_list_table_columns', 10, 2 );
-add_action( 'manage_topic_custom_column', __NAMESPACE__ . '\render_topics_list_table_columns', 10, 3 );
-foreach ( array( 'lesson-plan', 'meeting', 'course', 'lesson' ) as $pt ) {
-	add_filter( 'manage_' . $pt . '_posts_custom_column', __NAMESPACE__ . '\render_list_table_language_column', 10, 2 );
-}
-add_filter( 'manage_edit-wporg_workshop_sortable_columns', __NAMESPACE__ . '\add_workshop_list_table_sortable_columns' );
-add_action( 'restrict_manage_posts', __NAMESPACE__ . '\add_workshop_list_table_filters', 10, 2 );
 add_action( 'pre_get_posts', __NAMESPACE__ . '\handle_workshop_list_table_filters' );
 add_filter( 'display_post_states', __NAMESPACE__ . '\add_post_states', 10, 2 );
-foreach ( array( 'lesson-plan', 'wporg_workshop', 'course', 'lesson' ) as $pt ) {
-	add_filter( 'views_edit-' . $pt, __NAMESPACE__ . '\list_table_views' );
-}
 add_action( 'pre_get_posts', __NAMESPACE__ . '\handle_list_table_views' );
 add_action( 'bulk_edit_custom_box', __NAMESPACE__ . '\add_language_bulk_edit_field', 10, 2 );
 add_action( 'save_post', __NAMESPACE__ . '\language_bulk_edit_save' );
+// Workshop columns management
+add_filter( 'manage_wporg_workshop_posts_columns', __NAMESPACE__ . '\add_workshop_list_table_columns' );
+add_action( 'manage_wporg_workshop_posts_custom_column', __NAMESPACE__ . '\render_workshop_list_table_columns', 10, 2 );
+add_filter( 'manage_edit-wporg_workshop_sortable_columns', __NAMESPACE__ . '\add_workshop_list_table_sortable_columns' );
+add_action( 'restrict_manage_posts', __NAMESPACE__ . '\add_workshop_list_table_filters', 10, 2 );
+// Topic columns management
+add_filter( 'manage_edit-topic_columns', __NAMESPACE__ . '\add_topic_list_table_column' );
+add_action( 'manage_topic_custom_column', __NAMESPACE__ . '\render_topics_list_table_columns', 10, 3 );
+// Mulitple post types columns management
+foreach ( array( 'lesson-plan', 'meeting', 'course', 'lesson' ) as $pt ) {
+	add_filter( 'manage_' . $pt . '_posts_columns', __NAMESPACE__ . '\add_list_table_language_column' );
+}
+foreach ( array( 'lesson-plan', 'meeting', 'course', 'lesson' ) as $pt ) {
+	add_filter( 'manage_' . $pt . '_posts_custom_column', __NAMESPACE__ . '\render_list_table_language_column', 10, 2 );
+}
+foreach ( array( 'lesson-plan', 'wporg_workshop', 'course', 'lesson' ) as $pt ) {
+	add_filter( 'views_edit-' . $pt, __NAMESPACE__ . '\list_table_views' );
+}
 
 /**
  * Show a notice on taxonomy term screens about terms being translatable.

--- a/wp-content/plugins/wporg-learn/inc/admin.php
+++ b/wp-content/plugins/wporg-learn/inc/admin.php
@@ -26,6 +26,9 @@ add_action( 'restrict_manage_posts', __NAMESPACE__ . '\add_workshop_list_table_f
 // Topic columns management
 add_filter( 'manage_edit-topic_columns', __NAMESPACE__ . '\add_topic_list_table_column' );
 add_action( 'manage_topic_custom_column', __NAMESPACE__ . '\render_topics_list_table_columns', 10, 3 );
+// Meeting columns management
+add_filter( 'manage_meeting_posts_columns', __NAMESPACE__ . '\add_meeting_list_table_columns' );
+add_action( 'manage_meeting_posts_custom_column', __NAMESPACE__ . '\render_meeting_list_table_columns', 10, 2 );
 // Mulitple post types columns management
 foreach ( array( 'lesson-plan', 'meeting', 'course', 'lesson' ) as $pt ) {
 	add_filter( 'manage_' . $pt . '_posts_columns', __NAMESPACE__ . '\add_list_table_language_column' );
@@ -98,6 +101,40 @@ function add_workshop_list_table_columns( $columns ) {
 				+ array_slice( $columns, -2, 2, true );
 
 	return $columns;
+}
+
+/**
+ * Add additional columns to the post list table for meetings.
+ *
+ * @param array $columns
+ *
+ * @return array
+ */
+function add_meeting_list_table_columns( $columns ) {
+	$columns = array_slice( $columns, 0, -1, true )
+				+ array( 'wptv_url' => __( 'WPTV URL', 'wporg-learn' ) )
+				+ array_slice( $columns, -1, 1, true );
+	return $columns;
+}
+
+/**
+ * Render the cell contents for the additional columns in the post list table for meetings.
+ *
+ * @param string $column_name
+ * @param int    $post_id
+ *
+ * @return void
+ */
+function render_meeting_list_table_columns( $column_name, $post_id ) {
+	$post = get_post( $post_id );
+
+	switch ( $column_name ) {
+		case 'wptv_url':
+			$wptv_url = get_post_meta( $post->ID, 'wptv_url', true );
+
+			printf( '%s', esc_html( $wptv_url ) ?: '—' );
+			break;
+	}
 }
 
 /**

--- a/wp-content/plugins/wporg-learn/inc/post-meta.php
+++ b/wp-content/plugins/wporg-learn/inc/post-meta.php
@@ -588,6 +588,9 @@ function save_meeting_metabox_fields( $post_id ) {
 
 	$language = filter_input( INPUT_POST, 'meeting-language' );
 	update_post_meta( $post_id, 'language', $language );
+
+	$wptv_url = filter_input( INPUT_POST, 'wptv-url', FILTER_VALIDATE_URL ) ?: '';
+	update_post_meta( $post_id, 'wptv_url', $wptv_url );
 }
 
 /**

--- a/wp-content/plugins/wporg-learn/inc/post-meta.php
+++ b/wp-content/plugins/wporg-learn/inc/post-meta.php
@@ -27,9 +27,30 @@ add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_editor_asse
  * Register all post meta keys.
  */
 function register() {
+	register_meeting_meta();
 	register_lesson_plan_meta();
 	register_workshop_meta();
 	register_misc_meta();
+}
+
+/**
+ * Register post meta keys for meeting.
+ */
+function register_meeting_meta() {
+	$post_type = 'meeting';
+
+	register_post_meta(
+		$post_type,
+		'wptv_url',
+		array(
+			'description'       => __( 'A WPTV URL of recorded online workshop.', 'wporg_learn' ),
+			'type'              => 'string',
+			'single'            => true,
+			'default'           => '',
+			'sanitize_callback' => 'esc_url_raw',
+			'show_in_rest'      => true,
+		)
+	);
 }
 
 /**
@@ -551,7 +572,6 @@ function save_meeting_metabox_fields( $post_id ) {
 
 	$language = filter_input( INPUT_POST, 'meeting-language' );
 	update_post_meta( $post_id, 'language', $language );
-
 }
 
 /**

--- a/wp-content/plugins/wporg-learn/inc/post-meta.php
+++ b/wp-content/plugins/wporg-learn/inc/post-meta.php
@@ -418,6 +418,13 @@ function add_meeting_metaboxes( $post_type = '' ) {
 		'meeting',
 		'side'
 	);
+	add_meta_box(
+		'meeting-wptv-url',
+		__( 'WPTV URL', 'wporg_learn' ),
+		__NAMESPACE__ . '\render_metabox_meeting_wptv_url',
+		'meeting',
+		'side'
+	);
 }
 
 /**
@@ -487,6 +494,15 @@ function render_metabox_meeting_language( WP_Post $post ) {
 	$language = get_post_meta( $post->ID, 'language', true ) ?: '';
 
 	require get_views_path() . 'metabox-meeting-language.php';
+}
+
+/**
+ * Render the Meeting WPTV URL meta box.
+ *
+ * @param WP_Post $post
+ */
+function render_metabox_meeting_wptv_url( WP_Post $post ) {
+	require get_views_path() . 'metabox-meeting-wptv-url.php';
 }
 
 /**

--- a/wp-content/plugins/wporg-learn/views/metabox-meeting-wptv-url.php
+++ b/wp-content/plugins/wporg-learn/views/metabox-meeting-wptv-url.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace WPOrg_Learn\View\Metabox;
+
+use WP_Post;
+
+defined( 'WPINC' ) || die();
+
+/** @var WP_Post $post */
+?>
+
+<p>
+	<label for="meeting-wptv-url"><?php esc_html_e( 'WPTV URL', 'wporg_learn' ); ?></label>
+	<input
+		type="url"
+		name="wptv-url"
+		id="meeting-wptv-url"
+		class="large-text"
+		value="<?php echo esc_attr( $post->wptv_url ); ?>"
+	/>
+</p>
+
+<?php wp_nonce_field( 'meeting-metaboxes', 'meeting-metabox-nonce' ); ?>


### PR DESCRIPTION
Fixes #1003 

This PR adds a new meta field, the WPTV URL of recorded online workshops, to the online workshops with a text field form with URL validation.

## Screenshots

| ![list table](https://user-images.githubusercontent.com/18050944/224119496-65048f2c-11ce-41cd-99aa-374a9a665eb1.png) | ![post editor](https://user-images.githubusercontent.com/18050944/224119503-4920ebab-fd50-4d11-ba77-fd403e120852.png) | ![url check](https://user-images.githubusercontent.com/18050944/224119509-d03df20b-1a06-43d0-81f7-62e8841bcfc7.png) |
|:--:|:--:|:--:|
| Add to the meeting list table| Add to the meeting editor | URL validation |


