### PR TITLE
Add filtering of lesson plans by language

### DIFF
--- a/wp-content/plugins/wporg-learn/inc/admin.php
+++ b/wp-content/plugins/wporg-learn/inc/admin.php
@@ -5,7 +5,7 @@ namespace WPOrg_Learn\Admin;
 use WP_Query;
 use function WordPressdotorg\Locales\get_locales_with_english_names;
 use function WordPressdotorg\Locales\get_locale_name_from_code;
-use function WPOrg_Learn\Post_Meta\get_available_workshop_locales;
+use function WPOrg_Learn\Post_Meta\get_available_post_type_locales;
 
 defined( 'WPINC' ) || die();
 
@@ -235,7 +235,7 @@ function add_workshop_list_table_filters( $post_type, $which ) {
 		return;
 	}
 
-	$available_locales = get_available_workshop_locales( 'language', 'english', false );
+	$available_locales = get_available_post_type_locales( 'language', 'wporg_workshop', 'english', false );
 	$language          = filter_input( INPUT_GET, 'language', FILTER_SANITIZE_STRING );
 
 	?>

--- a/wp-content/plugins/wporg-learn/inc/admin.php
+++ b/wp-content/plugins/wporg-learn/inc/admin.php
@@ -236,7 +236,7 @@ function add_admin_list_table_filters( $post_type, $which ) {
 	}
 
 	$post_status       = filter_input( INPUT_GET, 'post_status', FILTER_SANITIZE_STRING );
-	$available_locales = get_available_post_type_locales( 'language', $post_type, 'english', $post_status );
+	$available_locales = get_available_post_type_locales( 'language', $post_type, $post_status );
 	$language          = filter_input( INPUT_GET, 'language', FILTER_SANITIZE_STRING );
 
 	?>

--- a/wp-content/plugins/wporg-learn/inc/admin.php
+++ b/wp-content/plugins/wporg-learn/inc/admin.php
@@ -236,8 +236,7 @@ function add_admin_list_table_filters( $post_type, $which ) {
 	}
 
 	$post_status       = filter_input( INPUT_GET, 'post_status', FILTER_SANITIZE_STRING );
-	$published_only    = isset( $post_status ) && 'publish' === $post_status ?? false;
-	$available_locales = get_available_post_type_locales( 'language', $post_type, 'english', $published_only );
+	$available_locales = get_available_post_type_locales( 'language', $post_type, 'english', $post_status );
 	$language          = filter_input( INPUT_GET, 'language', FILTER_SANITIZE_STRING );
 
 	?>

--- a/wp-content/plugins/wporg-learn/inc/admin.php
+++ b/wp-content/plugins/wporg-learn/inc/admin.php
@@ -24,8 +24,8 @@ foreach ( array( 'lesson-plan', 'meeting', 'course', 'lesson' ) as $pt ) {
 	add_filter( 'manage_' . $pt . '_posts_custom_column', __NAMESPACE__ . '\render_list_table_language_column', 10, 2 );
 }
 add_filter( 'manage_edit-wporg_workshop_sortable_columns', __NAMESPACE__ . '\add_workshop_list_table_sortable_columns' );
-add_action( 'restrict_manage_posts', __NAMESPACE__ . '\add_workshop_list_table_filters', 10, 2 );
-add_action( 'pre_get_posts', __NAMESPACE__ . '\handle_workshop_list_table_filters' );
+add_action( 'restrict_manage_posts', __NAMESPACE__ . '\add_admin_list_table_filters', 10, 2 );
+add_action( 'pre_get_posts', __NAMESPACE__ . '\handle_admin_list_table_filters' );
 add_filter( 'display_post_states', __NAMESPACE__ . '\add_post_states', 10, 2 );
 foreach ( array( 'lesson-plan', 'wporg_workshop', 'course', 'lesson' ) as $pt ) {
 	add_filter( 'views_edit-' . $pt, __NAMESPACE__ . '\list_table_views' );
@@ -223,19 +223,21 @@ function add_workshop_list_table_sortable_columns( $sortable_columns ) {
 }
 
 /**
- * Add filtering controls for the workshops list table.
+ * Add filtering controls for the tutorial and lesson plan list tables.
  *
  * @param string $post_type
  * @param string $which
  *
  * @return void
  */
-function add_workshop_list_table_filters( $post_type, $which ) {
-	if ( 'wporg_workshop' !== $post_type || 'top' !== $which ) {
+function add_admin_list_table_filters( $post_type, $which ) {
+	if ( ( 'wporg_workshop' !== $post_type && 'lesson-plan' !== $post_type ) || 'top' !== $which ) {
 		return;
 	}
 
-	$available_locales = get_available_post_type_locales( 'language', 'wporg_workshop', 'english', false );
+	$post_status       = filter_input( INPUT_GET, 'post_status', FILTER_SANITIZE_STRING );
+	$published_only    = isset( $post_status ) && 'publish' === $post_status ?? false;
+	$available_locales = get_available_post_type_locales( 'language', $post_type, 'english', $published_only );
 	$language          = filter_input( INPUT_GET, 'language', FILTER_SANITIZE_STRING );
 
 	?>
@@ -260,13 +262,13 @@ function add_workshop_list_table_filters( $post_type, $which ) {
 }
 
 /**
- * Alter the query to include workshop list table filters.
+ * Alter the query to include tutorial and lesson plan list table filters.
  *
  * @param WP_Query $query
  *
  * @return void
  */
-function handle_workshop_list_table_filters( WP_Query $query ) {
+function handle_admin_list_table_filters( WP_Query $query ) {
 	if ( ! is_admin() || ! function_exists( 'get_current_screen' ) ) {
 		return;
 	}
@@ -277,7 +279,7 @@ function handle_workshop_list_table_filters( WP_Query $query ) {
 		return;
 	}
 
-	if ( 'edit-wporg_workshop' === $current_screen->id ) {
+	if ( 'edit-wporg_workshop' === $current_screen->id || 'edit-lesson-plan' === $current_screen->id ) {
 		$language = filter_input( INPUT_GET, 'language', FILTER_SANITIZE_STRING );
 
 		if ( $language ) {

--- a/wp-content/plugins/wporg-learn/inc/post-meta.php
+++ b/wp-content/plugins/wporg-learn/inc/post-meta.php
@@ -261,12 +261,12 @@ function get_workshop_duration( WP_Post $workshop, $format = 'raw' ) {
  *
  * @param string $meta_key
  * @param string $post_type
- * @param string $label_language
  * @param string $post_status
+ * @param string $label_language
  *
  * @return array
  */
-function get_available_post_type_locales( $meta_key, $post_type, $label_language = 'english', $post_status ) {
+function get_available_post_type_locales( $meta_key, $post_type, $post_status, $label_language = 'english' ) {
 	global $wpdb;
 
 	$and_post_status = '';

--- a/wp-content/plugins/wporg-learn/inc/post-meta.php
+++ b/wp-content/plugins/wporg-learn/inc/post-meta.php
@@ -257,17 +257,18 @@ function get_workshop_duration( WP_Post $workshop, $format = 'raw' ) {
 }
 
 /**
- * Get a list of locales that are associated with at least one workshop.
+ * Get a list of locales that are associated with at least one post of the specified type.
  *
- * Optionally only published workshops.
+ * Optionally only published posts.
  *
  * @param string $meta_key
+ * @param string $post_type
  * @param string $label_language
  * @param bool   $published_only
  *
  * @return array
  */
-function get_available_workshop_locales( $meta_key, $label_language = 'english', $published_only = true ) {
+function get_available_post_type_locales( $meta_key, $post_type, $label_language = 'english', $published_only = true ) {
 	global $wpdb;
 
 	$and_post_status = '';
@@ -280,9 +281,10 @@ function get_available_workshop_locales( $meta_key, $label_language = 'english',
 		"
 			SELECT DISTINCT postmeta.meta_value
 			FROM {$wpdb->postmeta} postmeta
-				JOIN {$wpdb->posts} posts ON posts.ID = postmeta.post_id $and_post_status
+				JOIN {$wpdb->posts} posts ON posts.ID = postmeta.post_id AND posts.post_type = %s $and_post_status 
 			WHERE postmeta.meta_key = %s
 		",
+		$post_type,
 		$meta_key
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 	) );

--- a/wp-content/plugins/wporg-learn/inc/post-meta.php
+++ b/wp-content/plugins/wporg-learn/inc/post-meta.php
@@ -259,35 +259,38 @@ function get_workshop_duration( WP_Post $workshop, $format = 'raw' ) {
 /**
  * Get a list of locales that are associated with at least one post of the specified type.
  *
- * Optionally only published posts.
- *
  * @param string $meta_key
  * @param string $post_type
  * @param string $label_language
- * @param bool   $published_only
+ * @param string $post_status
  *
  * @return array
  */
-function get_available_post_type_locales( $meta_key, $post_type, $label_language = 'english', $published_only = true ) {
+function get_available_post_type_locales( $meta_key, $post_type, $label_language = 'english', $post_status ) {
 	global $wpdb;
 
-	$and_post_status = '';
-	if ( $published_only ) {
-		$and_post_status = "AND posts.post_status = 'publish'";
-	}
-
-	$results = $wpdb->get_col( $wpdb->prepare(
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $and_post_status contains no user input.
-		"
-			SELECT DISTINCT postmeta.meta_value
-			FROM {$wpdb->postmeta} postmeta
-				JOIN {$wpdb->posts} posts ON posts.ID = postmeta.post_id AND posts.post_type = %s $and_post_status 
-			WHERE postmeta.meta_key = %s
-		",
-		$post_type,
-		$meta_key
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-	) );
+	$results = isset( $post_status )
+		? $wpdb->get_col( $wpdb->prepare(
+			"
+				SELECT DISTINCT postmeta.meta_value
+				FROM {$wpdb->postmeta} postmeta
+					JOIN {$wpdb->posts} posts ON posts.ID = postmeta.post_id AND posts.post_type = %s AND posts.post_status = %s 
+				WHERE postmeta.meta_key = %s
+			",
+			$post_type,
+			$post_status,
+			$meta_key
+		) )
+		: $wpdb->get_col( $wpdb->prepare(
+			"
+				SELECT DISTINCT postmeta.meta_value
+				FROM {$wpdb->postmeta} postmeta
+					JOIN {$wpdb->posts} posts ON posts.ID = postmeta.post_id AND posts.post_type = %s 
+				WHERE postmeta.meta_key = %s
+			",
+			$post_type,
+			$meta_key
+		) );
 
 	if ( empty( $results ) ) {
 		return array();

--- a/wp-content/plugins/wporg-learn/inc/post-meta.php
+++ b/wp-content/plugins/wporg-learn/inc/post-meta.php
@@ -270,11 +270,7 @@ function get_available_post_type_locales( $meta_key, $post_type, $label_language
 	global $wpdb;
 
 	$and_post_status = '';
-	if ( in_array(
-		$post_status,
-		array( 'all', 'publish', 'draft', 'trash', 'private', 'needs-vetting', 'unlisted', 'declined' ),
-		true
-	) ) {
+	if ( in_array( $post_status, get_post_stati(), true ) ) {
 		$and_post_status = "AND posts.post_status = '$post_status'";
 	}
 

--- a/wp-content/plugins/wporg-learn/inc/post-meta.php
+++ b/wp-content/plugins/wporg-learn/inc/post-meta.php
@@ -350,6 +350,15 @@ function save_lesson_plan_metabox_fields( $post_id ) {
 
 	$download_url = filter_input( INPUT_POST, 'slides-download-url', FILTER_VALIDATE_URL ) ?: '';
 	update_post_meta( $post_id, 'slides_download_url', $download_url );
+
+	// This language meta field is rendered in the editor sidebar using a PluginDocumentSettingPanel block,
+	// which won't save the field on publish if it has the default value.
+	// Our filtering by locale depends on it being set, so we force it to be updated after saving:
+	$language         = get_post_meta( $post_id, 'language', true );
+	$language_default = 'en_US';
+	if ( ! isset( $language ) || $language_default === $language ) {
+		update_post_meta( $post_id, 'language', $language_default );
+	}
 }
 
 /**

--- a/wp-content/themes/pub/wporg-learn-2020/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2020/functions.php
@@ -707,7 +707,16 @@ function wporg_learn_get_card_template_args( $post_id ) {
 			break;
 
 		case 'lesson-plan':
-			$args['meta']  = wporg_learn_get_lesson_plan_taxonomy_data( $post_id, 'archive' );
+			$args['meta'] = array_merge(
+				wporg_learn_get_lesson_plan_taxonomy_data( $post_id, 'archive' ),
+				array(
+					array(
+						'icon'  => 'admin-site-alt3',
+						'label' => __( 'Language:', 'wporg-learn' ),
+						'value' => \WordPressdotorg\Locales\get_locale_name_from_code( $post->language, 'native' ),
+					),
+				)
+			);
 			break;
 
 		case 'wporg_workshop':

--- a/wp-content/themes/pub/wporg-learn-2020/template-parts/component-lesson-filters.php
+++ b/wp-content/themes/pub/wporg-learn-2020/template-parts/component-lesson-filters.php
@@ -40,7 +40,7 @@ $taxonomies = array(
 		<button type="submit" class="button button-large button-secondary">
 			<?php esc_html_e( 'Apply Filters', 'wporg-learn' ); ?>
 		</button>
-		<a href="<?php echo esc_url( get_post_type_archive_link( 'lesson-plan' ) ); ?>" class="clear-filters">
+		<a href="<?php echo esc_url( get_post_type_archive_link( 'lesson-plan' ) . '?_view=all' ); ?>" class="clear-filters">
 			<?php esc_html_e( 'Clear All Filters', 'wporg-learn' ); ?>
 		</a>
 	</div>

--- a/wp-content/themes/pub/wporg-learn-2020/template-parts/component-lesson-filters.php
+++ b/wp-content/themes/pub/wporg-learn-2020/template-parts/component-lesson-filters.php
@@ -32,7 +32,7 @@ $taxonomies = array(
 	),
 );
 
-$locales = \WPOrg_Learn\Post_Meta\get_available_post_type_locales( 'language', 'lesson-plan', 'native' );
+$locales = \WPOrg_Learn\Post_Meta\get_available_post_type_locales( 'language', 'lesson-plan', 'native', 'publish' );
 ?>
 
 <form class="sidebar-filters col-3" method="get" action="<?php echo esc_url( get_post_type_archive_link( 'lesson-plan' ) ); ?>">

--- a/wp-content/themes/pub/wporg-learn-2020/template-parts/component-lesson-filters.php
+++ b/wp-content/themes/pub/wporg-learn-2020/template-parts/component-lesson-filters.php
@@ -32,7 +32,7 @@ $taxonomies = array(
 	),
 );
 
-$locales = \WPOrg_Learn\Post_Meta\get_available_post_type_locales( 'language', 'lesson-plan', 'native', 'publish' );
+$locales = \WPOrg_Learn\Post_Meta\get_available_post_type_locales( 'language', 'lesson-plan', 'publish', 'native' );
 ?>
 
 <form class="sidebar-filters col-3" method="get" action="<?php echo esc_url( get_post_type_archive_link( 'lesson-plan' ) ); ?>">

--- a/wp-content/themes/pub/wporg-learn-2020/template-parts/component-lesson-filters.php
+++ b/wp-content/themes/pub/wporg-learn-2020/template-parts/component-lesson-filters.php
@@ -31,6 +31,8 @@ $taxonomies = array(
 		'current' => filter_input( INPUT_GET, 'wp_version', FILTER_VALIDATE_INT, FILTER_REQUIRE_ARRAY ) ?: array(),
 	),
 );
+
+$locales = \WPOrg_Learn\Post_Meta\get_available_post_type_locales( 'language', 'lesson-plan', 'native' );
 ?>
 
 <form class="sidebar-filters col-3" method="get" action="<?php echo esc_url( get_post_type_archive_link( 'lesson-plan' ) ); ?>">
@@ -43,6 +45,27 @@ $taxonomies = array(
 		<a href="<?php echo esc_url( get_post_type_archive_link( 'lesson-plan' ) . '?_view=all' ); ?>" class="clear-filters">
 			<?php esc_html_e( 'Clear All Filters', 'wporg-learn' ); ?>
 		</a>
+	</div>
+
+	<h4 class="h5" id="lp-filters-language-heading"><?php esc_html_e( 'Language', 'wporg-learn' ); ?></h4>
+	<div class="filter-group">
+		<select
+			id="<?php echo esc_attr( 'language' ); ?>"
+			class="filter-group-select"
+			name="<?php echo esc_attr( 'language' ); ?>"
+			data-placeholder="<?php esc_attr_e( 'Select', 'wporg-learn' ); ?>"
+			aria-labelledby="lp-filters-language-heading"
+		>
+			<option value=""><?php esc_html_e( 'Select', 'wporg-learn' ); ?></option>
+			<?php foreach ( $locales as $locale_value => $locale_label ) : ?>
+				<option
+					value="<?php echo esc_attr( $locale_value ); ?>"
+					<?php selected( $locale_value, filter_input( INPUT_GET, 'language' ) ); ?>
+				>
+					<?php printf( '%s [%s]', esc_html( $locale_label ), esc_html( $locale_value ) ); ?>
+				</option>
+			<?php endforeach; ?>
+		</select>
 	</div>
 
 	<?php foreach ( $taxonomies as $txnmy ) : ?>

--- a/wp-content/themes/pub/wporg-learn-2020/template-parts/component-workshop-filters.php
+++ b/wp-content/themes/pub/wporg-learn-2020/template-parts/component-workshop-filters.php
@@ -23,12 +23,12 @@ $buckets = array(
 	array(
 		'label' => __( 'Language', 'wporg-learn' ),
 		'name'  => 'language',
-		'items' => \WPOrg_Learn\Post_Meta\get_available_workshop_locales( 'language', 'native' ),
+		'items' => \WPOrg_Learn\Post_Meta\get_available_post_type_locales( 'language', 'wporg_workshop', 'native' ),
 	),
 	array(
 		'label' => __( 'Subtitles', 'wporg-learn' ),
 		'name'  => 'captions',
-		'items' => \WPOrg_Learn\Post_Meta\get_available_workshop_locales( 'video_caption_language', 'native' ),
+		'items' => \WPOrg_Learn\Post_Meta\get_available_post_type_locales( 'video_caption_language', 'wporg_workshop', 'native' ),
 	),
 	array(
 		'label' => __( 'WordPress Version', 'wporg-learn' ),

--- a/wp-content/themes/pub/wporg-learn-2020/template-parts/component-workshop-filters.php
+++ b/wp-content/themes/pub/wporg-learn-2020/template-parts/component-workshop-filters.php
@@ -23,12 +23,12 @@ $buckets = array(
 	array(
 		'label' => __( 'Language', 'wporg-learn' ),
 		'name'  => 'language',
-		'items' => \WPOrg_Learn\Post_Meta\get_available_post_type_locales( 'language', 'wporg_workshop', 'native' ),
+		'items' => \WPOrg_Learn\Post_Meta\get_available_post_type_locales( 'language', 'wporg_workshop', 'native', 'publish' ),
 	),
 	array(
 		'label' => __( 'Subtitles', 'wporg-learn' ),
 		'name'  => 'captions',
-		'items' => \WPOrg_Learn\Post_Meta\get_available_post_type_locales( 'video_caption_language', 'wporg_workshop', 'native' ),
+		'items' => \WPOrg_Learn\Post_Meta\get_available_post_type_locales( 'video_caption_language', 'wporg_workshop', 'native', 'publish' ),
 	),
 	array(
 		'label' => __( 'WordPress Version', 'wporg-learn' ),

--- a/wp-content/themes/pub/wporg-learn-2020/template-parts/component-workshop-filters.php
+++ b/wp-content/themes/pub/wporg-learn-2020/template-parts/component-workshop-filters.php
@@ -23,12 +23,12 @@ $buckets = array(
 	array(
 		'label' => __( 'Language', 'wporg-learn' ),
 		'name'  => 'language',
-		'items' => \WPOrg_Learn\Post_Meta\get_available_post_type_locales( 'language', 'wporg_workshop', 'native', 'publish' ),
+		'items' => \WPOrg_Learn\Post_Meta\get_available_post_type_locales( 'language', 'wporg_workshop', 'publish', 'native' ),
 	),
 	array(
 		'label' => __( 'Subtitles', 'wporg-learn' ),
 		'name'  => 'captions',
-		'items' => \WPOrg_Learn\Post_Meta\get_available_post_type_locales( 'video_caption_language', 'wporg_workshop', 'native', 'publish' ),
+		'items' => \WPOrg_Learn\Post_Meta\get_available_post_type_locales( 'video_caption_language', 'wporg_workshop', 'publish', 'native' ),
 	),
 	array(
 		'label' => __( 'WordPress Version', 'wporg-learn' ),


### PR DESCRIPTION
Closes #874 

This PR adds admin and frontend filtering of Lesson Plans, expanding on the functionality previously added for Tutorials.

### Screenshots

| Admin | Frontend | Cards |
|-|-|-|
| ![Screen Shot 2023-04-20 at 1 41 41 PM](https://user-images.githubusercontent.com/1017872/233236000-c3299d86-f407-4332-97a7-7cd7becdc910.jpg) | ![Screen Shot 2023-04-20 at 1 43 22 PM](https://user-images.githubusercontent.com/1017872/233236216-f8a7a6a9-6db6-4452-9687-2fe55a11886b.jpg) | ![Screen Shot 2023-04-20 at 1 44 31 PM](https://user-images.githubusercontent.com/1017872/233236333-278b4bd6-93a3-4eea-9f24-db60811e5509.jpg) |

### How to test

#### IMPORTANT before you start
In the Lesson Plan list if the Language field displays `English [en_US]` it is most likely that the Lesson Plan actually has no meta language set and the column is displaying the default value. The easiest way to fix this is to bulk edit all these entries and set them to English. This has already been done in prod, so if you're testing in sandbox things should just work.

##### Admin

1. Ensure you have Lesson Plans with multiple languages in your environment
2. In the admin, navigate to the Lesson Plan list. Check that the filter language dropdown has options covering all the items listed. If you find there is no English option, ensure you have read the note above.
3. Filter the admin list. Changing post status should update the languages in the filter dropdown.
4. Add a new Lesson Plan and leave the language as the default
5. Navigate to the Tutorial list page. Smoke test that the filtering still works there, matching the behaviour for Lesson Plans.

##### Frontend
1. Open the frontend Lesson Plan archive at http://localhost:8888/lesson-plans/?_view=all
2. Note the new language filter at the top of the sidebar
3. Test filtering and check the results against the admin
4. Check that the cards in the left have the correct language displayed
6. Filter by `English [en_US]` and check that the Lesson Plan you created in step 4 above is displayed
7. Test the 'Clear all filters' action. You should stay on the archive page and not be redirected to the Lesson Plan landing page.
8. Navigate to the Tutorials archive and smoke test filtering using the language and subtitle dropdowns