### PR TITLE
Breadcrumbs: Try to add a single space to avoid screen reader run-on sentences

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2020/template-parts/component-breadcrumbs.php
+++ b/wp-content/themes/pub/wporg-learn-2020/template-parts/component-breadcrumbs.php
@@ -55,7 +55,7 @@ if ( is_post_type_archive() ) {
 		}
 
 		if ( $x < $crumb_length - 1 ) {
-			echo '<span class="screen-reader-text">, </span><span aria-hidden="true" class="bbp-breadcrumb-sep"> » </span>';
+			echo '<span class="screen-reader-text">,  </span><span aria-hidden="true" class="bbp-breadcrumb-sep"> » </span>';
 		}
 	}
 	?>


### PR DESCRIPTION
See WordPress/wporg-mu-plugins#644 

Not sure if this will work or not, but worth a try. Might need to use a non-breaking space here.