### PR TITLE
Search form label: Make it clear to screen readers that search occurs for Learn only

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2020/searchform.php
+++ b/wp-content/themes/pub/wporg-learn-2020/searchform.php
@@ -10,7 +10,7 @@
 $placeholder = isset( $args['placeholder'] ) ? $args['placeholder'] : _x( 'Search for a learning resource', 'placeholder', 'wporg-learn' );
 ?>
 <form role="search" method="get" class="search-form" action="<?php echo esc_url( home_url( '/' ) ); ?>">
-	<label for="s" class="screen-reader-text"><?php echo esc_html( _x( 'Search for:', 'label', 'wporg-learn' ) ); ?></label>
+	<label for="s" class="screen-reader-text"><?php echo esc_html( _x( 'Search resources on Learn', 'label', 'wporg-learn' ) ); ?></label>
 	<input
 		type="search"
 		id="s"


### PR DESCRIPTION
Currently, the screen reader label does not contain any information about what is being searched. This PR fixes that.