### PR TITLE
Single: Fix an accessibility bug in Google Chrome where sidebars are not recognized

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2020/template-parts/content-single.php
+++ b/wp-content/themes/pub/wporg-learn-2020/template-parts/content-single.php
@@ -11,7 +11,7 @@
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
 
-	<section>
+	<div>
 		<header class="row align-middle between section-heading section-heading--with-space">
 			<h1 class="section-heading_title h2"><?php the_title(); ?></h1>
 		</header>
@@ -54,7 +54,7 @@
 			}
 			?>
 		</div>
-	</section>
+	</div>
 
 	<?php if ( is_object_in_term( get_the_ID(), 'wporg_lesson_plan_series' ) ) : ?>
 		<hr class="wp-block-separator" />

--- a/wp-content/themes/pub/wporg-learn-2020/template-parts/content-workshop-single-hardcoded.php
+++ b/wp-content/themes/pub/wporg-learn-2020/template-parts/content-workshop-single-hardcoded.php
@@ -21,7 +21,7 @@ $other_contributors = array_map(
 );
 ?>
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
-	<section>
+	<div>
 		<div class="row align-middle between section-heading section-heading--with-space">
 			<h1 class="section-heading_title h2"><?php the_title(); ?></h1>
 		</div>
@@ -71,5 +71,5 @@ $other_contributors = array_map(
 				</section>
 			<?php endif; ?>
 		</div>
-	</section>
+	</div>
 </article>

--- a/wp-content/themes/pub/wporg-learn-2020/template-parts/content-workshop-single.php
+++ b/wp-content/themes/pub/wporg-learn-2020/template-parts/content-workshop-single.php
@@ -19,7 +19,7 @@ $other_contributors = array_map(
 );
 ?>
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
-	<section>
+	<div>
 		<div class="row align-middle between section-heading section-heading--with-space">
 			<h1 class="section-heading_title h2"><?php the_title(); ?></h1>
 		</div>
@@ -98,5 +98,5 @@ $other_contributors = array_map(
 				</section>
 			<?php endif; ?>
 		</div> <!-- end workshop-page -->
-	</section>
+	</div>
 </article>


### PR DESCRIPTION
This bug happens because the `<section>` tag gets a `role="generic"` in Google Chrome. Since this tag wraps the `<aside>`, the sidebar semantics are removed from the accessibility tree. Let's use `<div>` instead.