### PR TITLE
Fix header row text overlapping search

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2020/archive-course.php
+++ b/wp-content/themes/pub/wporg-learn-2020/archive-course.php
@@ -20,10 +20,12 @@ get_template_part( 'template-parts/component', 'breadcrumbs' );
 
 <main id="main" class="site-main">
 	<section>
-		<div class="section-heading section-heading--with-space row align-middle between">
-			<?php the_archive_title( '<h1 class="section-heading_title h2">', '</h1>' ); ?>
+		<div class="section-heading section-heading--with-space row align-middle between gutters">
+			<?php the_archive_title( '<h1 class="section-heading_title h2 col-8">', '</h1>' ); ?>
 			<?php if ( is_user_logged_in() ) : ?>
-				<a class="section-heading_link" href="/my-courses/"><?php esc_html_e( 'My Courses', 'wporg-learn' ); ?></a>
+				<div class="col-4 row section-heading_links">
+					<a class="section-heading_link" href="/my-courses/"><?php esc_html_e( 'My Courses', 'wporg-learn' ); ?></a>
+				</div>
 			<?php endif; ?>
 		</div>
 

--- a/wp-content/themes/pub/wporg-learn-2020/archive-lesson-plan.php
+++ b/wp-content/themes/pub/wporg-learn-2020/archive-lesson-plan.php
@@ -187,11 +187,9 @@ if ( '' === get_query_var( 'search' ) && empty( $_GET ) && is_post_type_archive(
 
 <?php else : ?>
 	<section>
-		<div class="row align-right">
+		<div class="row gutters between section-heading section-heading--with-space">
+			<?php the_archive_title( '<h1 class="section-heading_title h2 col-8">', '</h1>' ); ?>
 			<?php get_template_part( 'template-parts/component', 'archive-search' ); ?>
-		</div>
-		<div class="row align-left">
-			<?php the_archive_title( '<h1 class="section-heading_title h2">', '</h1>' ); ?>
 		</div>
 
 		<hr>

--- a/wp-content/themes/pub/wporg-learn-2020/archive-lesson-plan.php
+++ b/wp-content/themes/pub/wporg-learn-2020/archive-lesson-plan.php
@@ -19,11 +19,13 @@ get_template_part( 'template-parts/component', 'breadcrumbs' );
 if ( '' === get_query_var( 'search' ) && empty( $_GET ) && is_post_type_archive() ) :
 	?>
 	<section>
-		<div class="row align-middle between section-heading section-heading--with-space">
-			<h1 class="section-heading_title h2"><?php esc_html_e( 'Lesson Plans', 'wporg-learn' ); ?></h1>
-			<a href="<?php echo esc_url( get_post_type_archive_link( 'lesson-plan' ) . '?_view=all' ); ?>" class="button button-xlarge button-secondary">
-				<?php esc_html_e( 'Browse all lesson plans', 'wporg-learn' ); ?>
-			</a>
+		<div class="row align-middle between section-heading section-heading--with-space gutters">
+			<h1 class="section-heading_title h2 col-8"><?php esc_html_e( 'Lesson Plans', 'wporg-learn' ); ?></h1>
+			<div class="col-4 row section-heading_links">
+				<a href="<?php echo esc_url( get_post_type_archive_link( 'lesson-plan' ) . '?_view=all' ); ?>" class="button button-xlarge button-secondary">
+					<?php esc_html_e( 'Browse all lesson plans', 'wporg-learn' ); ?>
+				</a>
+			</div>
 		</div>
 
 		<hr>

--- a/wp-content/themes/pub/wporg-learn-2020/archive-lesson-plan.php
+++ b/wp-content/themes/pub/wporg-learn-2020/archive-lesson-plan.php
@@ -187,9 +187,11 @@ if ( '' === get_query_var( 'search' ) && empty( $_GET ) && is_post_type_archive(
 
 <?php else : ?>
 	<section>
-		<div class="row align-middle between section-heading section-heading--with-space">
-			<?php the_archive_title( '<h1 class="section-heading_title h2">', '</h1>' ); ?>
+		<div class="row align-right">
 			<?php get_template_part( 'template-parts/component', 'archive-search' ); ?>
+		</div>
+		<div class="row align-left">
+			<?php the_archive_title( '<h1 class="section-heading_title h2">', '</h1>' ); ?>
 		</div>
 
 		<hr>

--- a/wp-content/themes/pub/wporg-learn-2020/archive-wporg_workshop.php
+++ b/wp-content/themes/pub/wporg-learn-2020/archive-wporg_workshop.php
@@ -23,7 +23,7 @@ get_template_part( 'template-parts/component', 'breadcrumbs' );
 <main id="main" class="site-main">
 
 	<section>
-		<div class="section-heading section-heading--with-space row align-middle between">
+		<div class="section-heading section-heading--with-space">
 			<?php the_archive_title( '<h1 class="section-heading_title h2">', '</h1>' ); ?>
 			<?php if ( is_tax( 'wporg_workshop_series' ) && have_posts() ) :
 				$series_term = wporg_learn_series_get_term( $post );

--- a/wp-content/themes/pub/wporg-learn-2020/css/components/_search-form.scss
+++ b/wp-content/themes/pub/wporg-learn-2020/css/components/_search-form.scss
@@ -30,18 +30,16 @@
 .search-form {
 	&--is-inline {
 		.search-form {
+			$label-position: 2rem;
+
 			display: flex;
 			justify-content: space-between;
-			margin-top: 0.5rem;
+			margin-top: $label-position;
 			background: #fff;
-
-			@media only screen and (max-width: $breakpoint-tablet) {
-				margin-top: 2rem;
-			}
 
 			> label {
 				position: absolute;
-				transform: translateY(-2rem);
+				transform: translateY(-1 * $label-position);
 			}
 
 			input {

--- a/wp-content/themes/pub/wporg-learn-2020/css/components/_section.scss
+++ b/wp-content/themes/pub/wporg-learn-2020/css/components/_section.scss
@@ -1,15 +1,4 @@
 .section-heading {
-	&.row {
-
-		@media only screen and (min-width: $breakpoint-tablet) {
-			align-items: baseline;
-		}
-
-		.button {
-			align-self: center;
-		}
-	}
-
 	&_title,
 	&_link {
 
@@ -35,6 +24,11 @@
 	&_links {
 		gap: 1rem;
 		flex-direction: row;
+		justify-content: flex-end;
+
+		@media only screen and (max-width: $breakpoint-tablet) {
+			justify-content: flex-start;
+		}
 	}
 
 	&_link {

--- a/wp-content/themes/pub/wporg-learn-2020/front-page.php
+++ b/wp-content/themes/pub/wporg-learn-2020/front-page.php
@@ -33,9 +33,9 @@ get_header(); ?>
 		</section>
 
 		<section>
-			<div class="section-heading row align-middle between">
-				<h2 class="h4 section-heading_title"><?php esc_html_e( 'Recent Courses', 'wporg-learn' ); ?></h2>
-				<div class="section-heading_links row">
+			<div class="section-heading row align-middle between gutters">
+				<h2 class="h4 section-heading_title col-8"><?php esc_html_e( 'Recent Courses', 'wporg-learn' ); ?></h2>
+				<div class="section-heading_links col-4 row">
 					<?php if ( is_user_logged_in() ) : ?>
 						<a class="section-heading_link" href="/my-courses/"><?php esc_html_e( 'My Courses', 'wporg-learn' ); ?></a>
 					<?php endif; ?>
@@ -69,11 +69,15 @@ get_header(); ?>
 		<hr>
 
 		<section>
-			<div class="section-heading row align-middle between">
-				<h2 class="h4 section-heading_title"><?php esc_html_e( 'Recent Tutorials', 'wporg-learn' ); ?></h2>
-				<a class="section-heading_link" href="/tutorials/">
-					<?php esc_html_e( 'View All Tutorials', 'wporg-learn' ); ?>
-				</a>
+			<div class="section-heading row align-middle between gutters">
+				<h2 class="h4 section-heading_title col-8">
+					<?php esc_html_e( 'Recent Tutorials', 'wporg-learn' ); ?>
+				</h2>
+				<div class="section-heading_links col-4 row">
+					<a class="section-heading_link" href="/tutorials/">
+						<?php esc_html_e( 'View All Tutorials', 'wporg-learn' ); ?>
+					</a>
+				</div>
 				<p class="section-heading_description">
 					<em><?php esc_html_e( 'Instructional videos for all skillsets to help you level up your WordPress expertise.', 'wporg-learn' ); ?></em>
 				</p>
@@ -96,13 +100,15 @@ get_header(); ?>
 		<?php $discussion_events = \WPOrg_Learn\Events\get_discussion_events(); ?>
 		<?php if ( ! empty( $discussion_events ) ) : ?>
 			<section class="wporg-learn-workshop-discussion-events">
-				<div class="section-heading row align-middle between">
-					<h2 class="h4 section-heading_title">
+				<div class="section-heading row align-middle between gutters">
+					<h2 class="h4 section-heading_title col-8">
 						<?php esc_html_e( 'Upcoming Online Workshops', 'wporg-learn' ); ?>
 					</h2>
-					<a class="section-heading_link" href="/online-workshops/">
-						<?php esc_html_e( 'View All Online Workshops', 'wporg-learn' ); ?>
-					</a>
+					<div class="section-heading_links col-4 row">
+						<a class="section-heading_link" href="/online-workshops/">
+							<?php esc_html_e( 'View All Online Workshops', 'wporg-learn' ); ?>
+						</a>
+					</div>
 					<p class="section-heading_description">
 						<em><?php esc_html_e( 'Live sessions where you can learn alongside other WordPress enthusiasts from around the world.', 'wporg-learn' ); ?></em>
 					</p>

--- a/wp-content/themes/pub/wporg-learn-2020/page-content-calendar.php
+++ b/wp-content/themes/pub/wporg-learn-2020/page-content-calendar.php
@@ -13,7 +13,7 @@ get_template_part( 'template-parts/component', 'breadcrumbs' );
 
 	<main id="main" class="site-main">
 
-		<div class="row align-middle between section-heading section-heading--with-space">
+		<div class="section-heading section-heading--with-space">
 			<?php the_title( '<h1 class="section-heading_title h2">', '</h1>' ); ?>
 		</div>
 		<hr>

--- a/wp-content/themes/pub/wporg-learn-2020/page-online-workshops.php
+++ b/wp-content/themes/pub/wporg-learn-2020/page-online-workshops.php
@@ -12,7 +12,7 @@ get_template_part( 'template-parts/component', 'breadcrumbs' );
 <main id="main" class="site-main page-full-width">
 
 	<section>
-		<div class="section-heading section-heading--with-space row align-middle between">
+		<div class="section-heading section-heading--with-space">
 			<?php the_title( '<h1 class="section-heading_title h2">', '</h1>' ); ?>
 		</div>
 

--- a/wp-content/themes/pub/wporg-learn-2020/page.php
+++ b/wp-content/themes/pub/wporg-learn-2020/page.php
@@ -20,7 +20,7 @@ get_template_part( 'template-parts/component', 'breadcrumbs' );
 
 	<main id="main" class="site-main">
 
-		<div class="row align-middle between section-heading section-heading--with-space">
+		<div class="section-heading section-heading--with-space">
 			<?php the_title( '<h1 class="section-heading_title h2">', '</h1>' ); ?>
 		</div>
 		<hr>

--- a/wp-content/themes/pub/wporg-learn-2020/search.php
+++ b/wp-content/themes/pub/wporg-learn-2020/search.php
@@ -22,7 +22,7 @@ get_template_part( 'template-parts/component', 'breadcrumbs' );
 	<main id="main" class="site-main type-page">
 
 		<section>
-			<div class="row align-middle between section-heading section-heading--with-space">
+			<div class="section-heading section-heading--with-space">
 				<h1 class="section-heading_title h2"><?php echo esc_html( $search_query ); ?></h1>
 			</div>
 			<hr>

--- a/wp-content/themes/pub/wporg-learn-2020/taxonomy-wporg_lesson_plan_series.php
+++ b/wp-content/themes/pub/wporg-learn-2020/taxonomy-wporg_lesson_plan_series.php
@@ -13,7 +13,7 @@ get_header(); ?>
 
 	<main id="main" class="site-main type-page">
 		<section>
-			<div class="row align-middle between section-heading section-heading--with-space">
+			<div class="section-heading section-heading--with-space">
 				<?php the_archive_title( '<h1 class="section-heading_title h2">', '</h1>' ); ?>
 			</div>
 

--- a/wp-content/themes/pub/wporg-learn-2020/template-parts/content-single.php
+++ b/wp-content/themes/pub/wporg-learn-2020/template-parts/content-single.php
@@ -12,7 +12,7 @@
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
 
 	<section>
-		<header class="row align-middle between section-heading section-heading--with-space">
+		<header class="section-heading section-heading--with-space">
 			<h1 class="section-heading_title h2"><?php the_title(); ?></h1>
 		</header>
 

--- a/wp-content/themes/pub/wporg-learn-2020/template-parts/content-workshop-single-hardcoded.php
+++ b/wp-content/themes/pub/wporg-learn-2020/template-parts/content-workshop-single-hardcoded.php
@@ -22,7 +22,7 @@ $other_contributors = array_map(
 ?>
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
 	<section>
-		<div class="row align-middle between section-heading section-heading--with-space">
+		<div class="section-heading section-heading--with-space">
 			<h1 class="section-heading_title h2"><?php the_title(); ?></h1>
 		</div>
 		<hr>

--- a/wp-content/themes/pub/wporg-learn-2020/template-parts/content-workshop-single.php
+++ b/wp-content/themes/pub/wporg-learn-2020/template-parts/content-workshop-single.php
@@ -20,7 +20,7 @@ $other_contributors = array_map(
 ?>
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
 	<section>
-		<div class="row align-middle between section-heading section-heading--with-space">
+		<div class="section-heading section-heading--with-space">
 			<h1 class="section-heading_title h2"><?php the_title(); ?></h1>
 		</div>
 


### PR DESCRIPTION
Extends #1829 
Closes #1808, #1813

Props: @cynthianorman 

Uses columns for heading section layouts where there is an element to the right of the title, to avoid wrapping when titles are long.

Removes CSS which negatively affects the alignment, and fixes the styling of the search input button.

## Screenshots

### Lesson Plan archive

| Desktop | Tablet | Mobile |
|-|-|-|
| ![localhost_8888_topic_extending-wordpress_(Desktop)](https://github.com/WordPress/Learn/assets/1017872/3a88d6ad-d90b-45d4-b9e3-992bf566553b) | ![localhost_8888_topic_extending-wordpress_(iPad)](https://github.com/WordPress/Learn/assets/1017872/fb41203c-4804-41df-a2a9-75a207bbd2e0) | ![localhost_8888_topic_extending-wordpress_(Samsung Galaxy S20 Ultra)](https://github.com/WordPress/Learn/assets/1017872/09045370-2644-42ff-9678-538f4f8b2ffe) |

### Home

| Desktop | Tablet | Mobile |
|-|-|-|
| ![localhost_8888_(Desktop) (1)](https://github.com/WordPress/Learn/assets/1017872/4658311f-6496-4820-b5fc-49a8e271f60b) | ![localhost_8888_(iPad)](https://github.com/WordPress/Learn/assets/1017872/572645dc-e370-450f-a2b7-63b4c13658a2) | ![localhost_8888_(Samsung Galaxy S20 Ultra)](https://github.com/WordPress/Learn/assets/1017872/50f71ec6-812c-4c3c-8e3e-07fa542bf7de) |

## Testing

Ideally all of the pages with templates changed should be checked at various screen sizes, you may need to create these pages or content for them

- http://localhost:8888/courses/
- http://localhost:8888/lesson-plans/
- http://localhost:8888/tutorials/
- http://localhost:8888/
- http://localhost:8888/content-calendar/
- http://localhost:8888/online-workshops/
- http://localhost:8888/my-courses/
- http://localhost:8888/?s=block
- http://localhost:8888/lesson-plan-series/my-series/ (probably need to create a Lesson Plan Series)
- http://localhost:8888/topic/extending-wordpress/
- Single Lesson Plan, Tutorial and Course

Check that the search input button is fixed and there is [no white appearing below or above it](https://github.com/WordPress/Learn/issues/1813)