### PR TITLE
Issue Link Added for Hacktoberfest PR

### DIFF
--- a/hacktoberfest-2023.md
+++ b/hacktoberfest-2023.md
@@ -18,4 +18,5 @@ Contributors:
 | @devmuhib009 | https://github.com/WordPress/Learn/issues/1882 |
 | @jonathanbossenger | https://github.com/WordPress/Learn/issues/1893 |
 | @westnz| https://github.com/WordPress/Learn/issues/455 |
+| @shail-mehta | https://github.com/WordPress/Learn/issues/1881 |
 | @westnz | https://github.com/WordPress/Learn/issues/1896 |


### PR DESCRIPTION
I have Added issue link for https://github.com/WordPress/Learn/issues/1881