### PR TITLE
Fixed Firefox Lesson Plan Overlap issue for all languages

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2020/css/components/_card.scss
+++ b/wp-content/themes/pub/wporg-learn-2020/css/components/_card.scss
@@ -12,6 +12,7 @@ body:not(.single):not(.search) .site-main .card.post.course {
 	padding: 1.75rem;
 	position: relative;
 	white-space: unset;
+	word-break: break-all;
 
 	/* Fix over-specific rule in the parent theme. */
 	body:not(.single):not(.search) .site-main &.post {


### PR DESCRIPTION
Fixed Lesson Plan Overlap Issue with Sidebar for All Languages in Firefox.