### PR TITLE
Update label-feedback-from-issue.yml

### DIFF
--- a/.github/workflows/label-feedback-from-issue.yml
+++ b/.github/workflows/label-feedback-from-issue.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           script: console.log(context)
       - uses: actions/github-script@v7.0.1
-        if: contains(github.event.issue.labels.*.name, 'Awaiting Triage') && contains(github.event.issue.body, '/content')  
+        if: contains(github.event.issue.labels.*.name, 'Awaiting Triage') && contains(github.event.issue.body, '_content')  
         with:
           script: |
             github.rest.issues.addLabels({
@@ -27,7 +27,7 @@ jobs:
               labels: ["[Content] Feedback"]
             })
       - uses: actions/github-script@v7.0.1
-        if: contains(github.event.issue.labels.*.name, 'Awaiting Triage') && contains(github.event.issue.body, '/dev')  
+        if: contains(github.event.issue.labels.*.name, 'Awaiting Triage') && contains(github.event.issue.body, '_dev')  
         with:
           script: |
             github.rest.issues.addLabels({
@@ -37,7 +37,7 @@ jobs:
               labels: ["[Type] Bug"]
             })
       - uses: actions/github-script@v7.0.1
-        if: contains(github.event.issue.labels.*.name, 'Awaiting Triage') && contains(github.event.issue.body, '/docs')  
+        if: contains(github.event.issue.labels.*.name, 'Awaiting Triage') && contains(github.event.issue.body, '_docs')  
         with:
           script: |
             github.rest.issues.addLabels({


### PR DESCRIPTION
Replacing the `/` in commands with an underscore, as the workflow was triggering with URLs.