### PR TITLE
Update: Replace link on homepage to submit a topic idea

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2020/template-parts/component-submit-idea-cta.php
+++ b/wp-content/themes/pub/wporg-learn-2020/template-parts/component-submit-idea-cta.php
@@ -20,7 +20,7 @@ $args = wp_parse_args( $args );
 		<a class="button button-primary button-large" href="https://learn.wordpress.org/tutorial-presenter-application/">
 			<?php esc_html_e( 'Apply to present a tutorial', 'wporg-learn' ); ?>
 		</a>
-		<a class="button button-secondary button-large" href="https://github.com/WordPress/Learn/issues/new?assignees=&labels=Awaiting+Triage%2C+Needs+Subject+Matter+Expert&template=topic-idea.md&title=Topic+Idea%3A+TOPIC+TITLE" target="_blank" rel="noreferrer noopener">
+		<a class="button button-secondary button-large" href=" https://github.com/WordPress/Learn/issues/new/choose" target="_blank" rel="noreferrer noopener">
 			<?php esc_html_e( 'Submit a topic idea', 'wporg-learn' ); ?>
 		</a>
 	</div>


### PR DESCRIPTION
This change addresses #2014 by updating the link for the button based off the GitHub updates. 