### PR TITLE
Remove need for "Awaiting Triage" label to trigger workflows

### DIFF
--- a/.github/workflows/comment-with-checklist.yml
+++ b/.github/workflows/comment-with-checklist.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           issue-number: ${{ github.event.issue.number }}
           body: |
-            # Tutorial Development Checklist
+            ## Tutorial Development Checklist
             - [ ] Tutorial [created](https://make.wordpress.org/training/handbook/tutorials/creating-a-tutorial) and announced to the team for Q/A review
             - [ ] Tutorial reviewed and [ready to publish](https://make.wordpress.org/training/handbook/tutorials/publishing-a-tutorial)
             - [ ] Tutorial [submitted and published to WPTV](https://make.wordpress.org/training/handbook/tutorials/publishing-a-tutorial/#1-submit-your-video-to-wordpress-tv) 
@@ -78,7 +78,7 @@ jobs:
         with:
           issue-number: ${{ github.event.issue.number }}
           body: |
-            # Lesson Development Checklist
+            ## Lesson Development Checklist
             - [ ] Gather any relevant links to Support, Docs, or related material
             - [ ] Description and Objectives finalized
             - [ ] Lesson created and announced to the team for review

--- a/.github/workflows/content-checklist-from-comment.yml
+++ b/.github/workflows/content-checklist-from-comment.yml
@@ -7,31 +7,31 @@ on:
 
 jobs:
   tutorial-issue:
-    if: ${{ contains(github.event.issue.labels.*.name, 'Awaiting Triage') && contains(github.event.comment.body, '//tutorial') }}
+    if: ${{ contains(github.event.comment.body, '//tutorial') }}
     uses: ./.github/workflows/comment-with-checklist.yml
     with:
       content-type: 'tutorial'
       
   online-workshop-issue:
-    if: ${{ contains(github.event.issue.labels.*.name, 'Awaiting Triage') && contains(github.event.comment.body, '//online-workshop') }}
+    if: ${{ contains(github.event.comment.body, '//online-workshop') }}
     uses: ./.github/workflows/comment-with-checklist.yml
     with:
       content-type: 'online-workshop'
   
   lesson-plan-issue:
-    if: ${{ contains(github.event.issue.labels.*.name, 'Awaiting Triage') && contains(github.event.comment.body, '//lesson-plan') }}
+    if: ${{ contains(github.event.comment.body, '//lesson-plan') }}
     uses: ./.github/workflows/comment-with-checklist.yml
     with:
       content-type: 'lesson-plan'
   
   course-issue:
-    if: ${{ contains(github.event.issue.labels.*.name, 'Awaiting Triage') && contains(github.event.comment.body, '//course') }}
+    if: ${{ contains(github.event.comment.body, '//course') }}
     uses: ./.github/workflows/comment-with-checklist.yml
     with:
       content-type: 'course'
 
   lesson-issue:
-    if: ${{ contains(github.event.issue.labels.*.name, 'Awaiting Triage') && contains(github.event.comment.body, '//lesson') }}
+    if: ${{ contains(github.event.comment.body, '//lesson') }}
     uses: ./.github/workflows/comment-with-checklist.yml
     with:
       content-type: 'lesson'

--- a/.github/workflows/content-checklist-from-comment.yml
+++ b/.github/workflows/content-checklist-from-comment.yml
@@ -29,3 +29,9 @@ jobs:
     uses: ./.github/workflows/comment-with-checklist.yml
     with:
       content-type: 'course'
+
+  lesson-issue:
+    if: ${{ contains(github.event.issue.labels.*.name, 'Awaiting Triage') && contains(github.event.comment.body, '//lesson') }}
+    uses: ./.github/workflows/comment-with-checklist.yml
+    with:
+      content-type: 'lesson'

--- a/.github/workflows/content-checklist-from-issue.yml
+++ b/.github/workflows/content-checklist-from-issue.yml
@@ -7,31 +7,31 @@ on:
 
 jobs:
   tutorial-issue:
-    if: ${{ contains(github.event.issue.labels.*.name, 'Awaiting Triage') && contains(github.event.issue.body, '//tutorial') }}
+    if: ${{ contains(github.event.issue.body, '//tutorial') }}
     uses: ./.github/workflows/comment-with-checklist.yml
     with:
       content-type: 'tutorial'
       
   online-workshop-issue:
-    if: ${{ contains(github.event.issue.labels.*.name, 'Awaiting Triage') && contains(github.event.issue.body, '//online-workshop') }}
+    if: ${{ contains(github.event.issue.body, '//online-workshop') }}
     uses: ./.github/workflows/comment-with-checklist.yml
     with:
       content-type: 'online-workshop'
   
   lesson-plan-issue:
-    if: ${{ contains(github.event.issue.labels.*.name, 'Awaiting Triage') && contains(github.event.issue.body, '//teach') }}
+    if: ${{ contains(github.event.issue.body, '//teach') }}
     uses: ./.github/workflows/comment-with-checklist.yml
     with:
       content-type: 'teach'
   
   course-issue:
-    if: ${{ contains(github.event.issue.labels.*.name, 'Awaiting Triage') && contains(github.event.issue.body, '//course') }}
+    if: ${{ contains(github.event.issue.body, '//course') }}
     uses: ./.github/workflows/comment-with-checklist.yml
     with:
       content-type: 'course'
 
   lesson-issue:
-    if: ${{ contains(github.event.issue.labels.*.name, 'Awaiting Triage') && contains(github.event.issue.body, '//lesson') }}
+    if: ${{ contains(github.event.issue.body, '//lesson') }}
     uses: ./.github/workflows/comment-with-checklist.yml
     with:
       content-type: 'lesson'


### PR DESCRIPTION
This pull requests removes the need for the `Awaiting Triage` label to be present for workflows to add content development checklists.