### PR TITLE
Enable word wrapping in cards

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2020/css/components/_card.scss
+++ b/wp-content/themes/pub/wporg-learn-2020/css/components/_card.scss
@@ -11,6 +11,7 @@ body:not(.single):not(.search) .site-main .card.post.course {
 	color: #555d66;
 	padding: 1.75rem;
 	position: relative;
+	white-space: unset;
 
 	/* Fix over-specific rule in the parent theme. */
 	body:not(.single):not(.search) .site-main &.post {


### PR DESCRIPTION
Fixes #2223 

Allows cards to resize to fit smaller screens, by enabling long text to wrap.

### Screenshots

| Before | After |
|-|-|
| ![learn wordpress org_lesson-plans_(iPad)](https://github.com/WordPress/Learn/assets/1017872/ae078a14-8a07-4d88-a35c-3b2f0b8ddbda) | ![learn wordpress org_lesson-plans_(iPad) (1)](https://github.com/WordPress/Learn/assets/1017872/cc282e9f-c327-42b1-9d14-86c8392a1962) |

