### PR TITLE
Add WordPress Playground Block

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -94,6 +94,6 @@
 		"lint": "phpcs"
 	},
 	"require": {
-		"wpackagist-plugin/interactive-code-block": "^0.1.4"
+		"wpackagist-plugin/interactive-code-block": "^0.2.1"
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -92,5 +92,8 @@
 	"scripts": {
 		"format": "phpcbf -p",
 		"lint": "phpcs"
+	},
+	"require": {
+		"wpackagist-plugin/interactive-code-block": "^0.1.4"
 	}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -159,7 +159,7 @@
         },
         {
             "name": "wpackagist-plugin/interactive-code-block",
-            "version": "0.1.4",
+            "version": "0.2.1",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/interactive-code-block/",

--- a/composer.lock
+++ b/composer.lock
@@ -4,9 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9839452a5f944bb49fa2c470a01902b1",
-    "packages": [],
-    "packages-dev": [
+    "content-hash": "221986e29ded57bdfd417837c302eaa3",
+    "packages": [
         {
             "name": "composer/installers",
             "version": "v1.12.0",
@@ -158,6 +157,26 @@
             ],
             "time": "2021-09-13T08:19:44+00:00"
         },
+        {
+            "name": "wpackagist-plugin/interactive-code-block",
+            "version": "0.1.4",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/interactive-code-block/",
+                "reference": "trunk"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/interactive-code-block.zip?timestamp=1705482591"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/interactive-code-block/"
+        }
+    ],
+    "packages-dev": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
             "version": "v0.7.2",


### PR DESCRIPTION
## Description

This PR adds the [WordPress Playground Block](https://wordpress.org/plugins/interactive-code-block/) to Composer dependencies.

The block enables embedding [WordPress Playground](https://w.org/playground) in posts and pages – both as:

* A plain WordPress site
* An interactive plugin code editor + WordPress site preview combo

![banner-1544x500](https://github.com/WordPress/Learn/assets/205419/233c0ce7-04ef-4a75-9d76-081ebc9a685e)

## Motivation

The Playground block would unlock a next-level interactive learning experience on learn.wp.org. Tutorials for testers, designers, and developers could include not just screenshots and videos, but actual live WordPress instances opened directly on the relevant page, e.g. the Site editor. Developers could learn to build plugins by interacting with a live code editor where a simple plugin is already created for them, and they're encouraged to customize it.

## How does it work?

The WordPress site displayed in the Playground block can be customized using the block toolbar and block inspector controls. The changes made directly in the embedded WordPress are [_not_ saved yet](https://github.com/WordPress/playground-tools/issues/166). The most powerful customization tool available in the block is the custom [Blueprint](https://wordpress.github.io/wordpress-playground/blueprints-api/index) inspector control – with a single JSON file, you can prepare any WordPress site at all.

## Next steps

I would love to hear your thoughts and find out whether the block has the features most important for you or is it missing anything crucial.

cc @westnz @jonathanbossenger 