### PR TITLE
Try wp-now for local development

### DIFF
--- a/blueprint.json
+++ b/blueprint.json
@@ -3,7 +3,7 @@
 	"steps": [
 		{
 			"step": "activateTheme",
-			"themeFolderName": "pub/wporg-learn-2020"
+			"themeFolderName": "pub/wporg-learn-2024"
 		},
 		{
 			"step": "activatePlugin",

--- a/blueprint.json
+++ b/blueprint.json
@@ -1,0 +1,14 @@
+{
+	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
+	"steps": [
+		{
+			"step": "activateTheme",
+			"themeFolderName": "wporg-learn-2020"
+		},
+		{
+			"step": "activatePlugin",
+			"pluginName": "WordPress.org Learn",
+			"pluginPath": "wporg-learn/wporg-learn.php"
+		}
+	]
+}

--- a/blueprint.json
+++ b/blueprint.json
@@ -3,7 +3,7 @@
 	"steps": [
 		{
 			"step": "activateTheme",
-			"themeFolderName": "wporg-learn-2020"
+			"themeFolderName": "pub/wporg-learn-2020"
 		},
 		{
 			"step": "activatePlugin",

--- a/blueprint.json
+++ b/blueprint.json
@@ -2,13 +2,9 @@
 	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
 	"steps": [
 		{
-			"step": "activateTheme",
-			"themeFolderName": "pub/wporg-learn-2024"
-		},
-		{
-			"step": "activatePlugin",
-			"pluginName": "WordPress.org Learn",
-			"pluginPath": "wporg-learn/wporg-learn.php"
+			"step": "login",
+			"username": "admin",
+			"password": "password"
 		},
 		{
 			"step": "activatePlugin",
@@ -27,28 +23,12 @@
 		},
 		{
 			"step": "activatePlugin",
-			"pluginName": "Jetpack",
-			"pluginPath": "jetpack/jetpack.php"
+			"pluginName": "WordPress.org Learn",
+			"pluginPath": "wporg-learn/wporg-learn.php"
 		},
 		{
-			"step": "activatePlugin",
-			"pluginName": "Edit Flow",
-			"pluginPath": "edit-flow/edit_flow.php"
-		},
-		{
-			"step": "activatePlugin",
-			"pluginName": "Code Syntax Block",
-			"pluginPath": "code-syntax-block/index.php"
-		},
-		{
-			"step": "activatePlugin",
-			"pluginName": "Locale Detection",
-			"pluginPath": "locale-detection/locale-detection.php"
-		},
-		{
-			"step": "activatePlugin",
-			"pluginName": "WordPress Importer",
-			"pluginPath": "wordpress-importer/wordpress-importer.php"
+			"step": "activateTheme",
+			"themeFolderName": "pub/wporg-learn-2024"
 		}
 	]
 }

--- a/blueprint.json
+++ b/blueprint.json
@@ -9,6 +9,46 @@
 			"step": "activatePlugin",
 			"pluginName": "WordPress.org Learn",
 			"pluginPath": "wporg-learn/wporg-learn.php"
+		},
+		{
+			"step": "activatePlugin",
+			"pluginName": "Gutenberg",
+			"pluginPath": "gutenberg/gutenberg.php"
+		},
+		{
+			"step": "activatePlugin",
+			"pluginName": "Sensei LMS",
+			"pluginPath": "sensei-lms/sensei-lms.php"
+		},
+		{
+			"step": "activatePlugin",
+			"pluginName": "Sensei Pro",
+			"pluginPath": "sensei-pro/sensei-pro.php"
+		},
+		{
+			"step": "activatePlugin",
+			"pluginName": "Jetpack",
+			"pluginPath": "jetpack/jetpack.php"
+		},
+		{
+			"step": "activatePlugin",
+			"pluginName": "Edit Flow",
+			"pluginPath": "edit-flow/edit_flow.php"
+		},
+		{
+			"step": "activatePlugin",
+			"pluginName": "Code Syntax Block",
+			"pluginPath": "code-syntax-block/index.php"
+		},
+		{
+			"step": "activatePlugin",
+			"pluginName": "Locale Detection",
+			"pluginPath": "locale-detection/locale-detection.php"
+		},
+		{
+			"step": "activatePlugin",
+			"pluginName": "WordPress Importer",
+			"pluginPath": "wordpress-importer/wordpress-importer.php"
 		}
 	]
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"start:plugin": "yarn workspace wporg-learn-plugin start",
 		"start:theme": "yarn workspace wporg-learn-2024 start",
 		"wp-env": "wp-env",
-		"wp-now": "(cd wp-content && wp-now start --blueprint=../blueprint.json --reset)"
+		"wp-now": "(cd wp-content && wp-now start --blueprint=../blueprint.json)"
 	},
 	"main": "index.js"
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
 		"start:locale-switcher": "yarn workspace wporg-locale-switcher start",
 		"start:plugin": "yarn workspace wporg-learn-plugin start",
 		"start:theme": "yarn workspace wporg-learn-2024 start",
-		"wp-env": "wp-env"
+		"wp-env": "wp-env",
+		"wp-now": "(cd wp-content && wp-now start --blueprint=../blueprint.json --reset)"
 	},
 	"main": "index.js"
 }


### PR DESCRIPTION
Add a blueprint to enable local development. This needs to replicate everything we currently do with wp-env.

**Currently does not work.**

## Problems

~1. Theme and plugin specified in blueprint are not activated~
~2. For wp-now to be a dev dependency, the Node 18.18.2 requirement for blueprint files requires updates to other tooling (eg. current jsdoc dependency does not support Node 18.18.2)~
3. `wp-content/mu-plugins` are not loaded

## How to test

Install PHP and JS dependencies as normal and build the project:

1. Run `composer install`
2. Run `nvm use`
4. Run `yarn`
5. Run `yarn setup:tools`
6. Run `yarn build`

Install wp-now and run the project:

1. Install wp-now globally, run `npm i -g @wp-now/wp-now`
3. Run `yarn wp-now`

### Expected
- Plugins defined in steps are activated on first run. They are already installed via composer, so just need to be activated.
- Learn 2024 theme is activated on first run. Parent theme has been installed via composer so it should be available.
- Mu-plugins have been detected and loaded
- Site homepage is loaded in the browser with styles, fonts, and no errors.