### PR TITLE
try to algin jetpack form checkbox with sensei.

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2020/assets/images/check.svg
+++ b/wp-content/themes/pub/wporg-learn-2020/assets/images/check.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M18.3 5.6L9.9 16.9l-4.6-3.4-.9 1.2 5.8 4.3 9.3-12.6z"></path></svg>

--- a/wp-content/themes/pub/wporg-learn-2020/css/base/_base.scss
+++ b/wp-content/themes/pub/wporg-learn-2020/css/base/_base.scss
@@ -5,6 +5,7 @@
 @import "../../../wporg/css/base/lists";
 @import "../../../wporg/css/base/tables";
 @import "../../../wporg/css/base/typography";
+@import "checkbox";
 @import "html";
 @import "select";
 @import "table";

--- a/wp-content/themes/pub/wporg-learn-2020/css/base/_checkbox.scss
+++ b/wp-content/themes/pub/wporg-learn-2020/css/base/_checkbox.scss
@@ -4,10 +4,8 @@
 */
 
 .contact-form .grunion-field-wrap.wporg-learn-form-wrap input.checkbox-multiple {
-	-webkit-appearance: none;
-	appearance: none;
+	position: relative;
 	border: 1px solid rgb(50, 55, 60);
-	box-sizing: border-box;
 	height: 26px;
 	width: 26px;
 	border-radius: 4px;
@@ -19,26 +17,20 @@
 		content: "";
 		background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M18.3 5.6L9.9 16.9l-4.6-3.4-.9 1.2 5.8 4.3 9.3-12.6z"></path></svg>');
 		background-size: 20px;
-		background-position: 4px 3px;
+		background-position:center;
 		background-repeat: no-repeat;
-		font-size: 16px;
-		color: #0073aa;
-		text-align: center;
-		line-height: 26px;
 		transform: none;
-		top: auto;
-		left: auto;
+		top: 0;
+		left: 0;
 		width: 100%;
 		height: 100%;
-		padding-top: 1px;
-		padding-left: 1px;
+		margin: 0;
 	}
 }
 
 .contact-form .wporg-learn-form-wrap .grunion-checkbox-multiple-options .contact-form-field {
 	display: flex;
 	align-items: center;
-
 	.grunion-field-text {
 		font-family: "open sans", sans-serif;
 		font-size: 16px;

--- a/wp-content/themes/pub/wporg-learn-2020/css/base/_checkbox.scss
+++ b/wp-content/themes/pub/wporg-learn-2020/css/base/_checkbox.scss
@@ -15,7 +15,7 @@
 
 	&:checked::before {
 		content: "";
-		background-image: url(./assets/images/check.svg);
+		background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M18.3 5.6L9.9 16.9l-4.6-3.4-.9 1.2 5.8 4.3 9.3-12.6z"></path></svg>');
 		background-size: 20px;
 		background-position: center;
 		background-repeat: no-repeat;

--- a/wp-content/themes/pub/wporg-learn-2020/css/base/_checkbox.scss
+++ b/wp-content/themes/pub/wporg-learn-2020/css/base/_checkbox.scss
@@ -15,9 +15,9 @@
 
 	&:checked::before {
 		content: "";
-		background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M18.3 5.6L9.9 16.9l-4.6-3.4-.9 1.2 5.8 4.3 9.3-12.6z"></path></svg>');
+		background-image: url(./assets/images/check.svg);
 		background-size: 20px;
-		background-position:center;
+		background-position: center;
 		background-repeat: no-repeat;
 		transform: none;
 		top: 0;
@@ -31,6 +31,7 @@
 .contact-form .wporg-learn-form-wrap .grunion-checkbox-multiple-options .contact-form-field {
 	display: flex;
 	align-items: center;
+
 	.grunion-field-text {
 		font-family: "open sans", sans-serif;
 		font-size: 16px;

--- a/wp-content/themes/pub/wporg-learn-2020/css/base/_checkbox.scss
+++ b/wp-content/themes/pub/wporg-learn-2020/css/base/_checkbox.scss
@@ -1,0 +1,47 @@
+/*
+* Fixes for checkbox styling in jetpack forms so it align with sensei.
+*
+*/
+
+.contact-form .grunion-field-wrap.wporg-learn-form-wrap input.checkbox-multiple {
+	-webkit-appearance: none;
+	appearance: none;
+	border: 1px solid rgb(50, 55, 60);
+	box-sizing: border-box;
+	height: 26px;
+	width: 26px;
+	border-radius: 4px;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+
+	&:checked::before {
+		content: "";
+		background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M18.3 5.6L9.9 16.9l-4.6-3.4-.9 1.2 5.8 4.3 9.3-12.6z"></path></svg>');
+		background-size: 20px;
+		background-position: 4px 3px;
+		background-repeat: no-repeat;
+		font-size: 16px;
+		color: #0073aa;
+		text-align: center;
+		line-height: 26px;
+		transform: none;
+		top: auto;
+		left: auto;
+		width: 100%;
+		height: 100%;
+		padding-top: 1px;
+		padding-left: 1px;
+	}
+}
+
+.contact-form .wporg-learn-form-wrap .grunion-checkbox-multiple-options .contact-form-field {
+	display: flex;
+	align-items: center;
+
+	.grunion-field-text {
+		font-family: "open sans", sans-serif;
+		font-size: 16px;
+	}
+
+}

--- a/wp-content/themes/pub/wporg-learn-2020/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2020/functions.php
@@ -1248,14 +1248,16 @@ function wporg_learn_get_sticky_topics_with_selected_first( $first = 'general' )
 }
 
 /**
- * Add custom class to jetpack forms
+ * Adds a custom class to Jetpack contact form inputs.
  *
- * @param string 
- * @return string
+ * This function appends a custom class to the existing classes of Jetpack contact form input elements.
+ *
+ * @param string $class Current input classes.
+ * @return string Modified input classes including the custom class.
  */
-function my_custom_jetpack_contact_form_class( $class ) {
-    // Add 'my-custom-class' to the existing class string
+function wporg_learn_add_custom_class_to_jetpack_forms( $class ) {
+    // Append 'wporg-learn-form' class to the existing class string.
     $class .= ' wporg-learn-form';
     return $class;
 }
-add_filter( 'jetpack_contact_form_input_class', 'my_custom_jetpack_contact_form_class' );
+add_filter( 'jetpack_contact_form_input_class', 'wporg_learn_add_custom_class_to_jetpack_forms' );

--- a/wp-content/themes/pub/wporg-learn-2020/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2020/functions.php
@@ -1246,3 +1246,16 @@ function wporg_learn_get_sticky_topics_with_selected_first( $first = 'general' )
 
 	return $topics;
 }
+
+/**
+ * Add custom class to jetpack forms
+ *
+ * @param string 
+ * @return string
+ */
+function my_custom_jetpack_contact_form_class( $class ) {
+    // Add 'my-custom-class' to the existing class string
+    $class .= ' wporg-learn-form';
+    return $class;
+}
+add_filter( 'jetpack_contact_form_input_class', 'my_custom_jetpack_contact_form_class' );


### PR DESCRIPTION
#2221 - try to align jetpack form checkbox with sensei.

- Added a hook for custom class in jetpack form fields (wporg-learn-form)
- Styled it

Open questions:

How could we make a good use of sensei css variables?
I use the SVG icon in the CSS, I find it bad... (and the linter too) can someone tell me how to do it properly?
And where to put this "checkbox.scss" it is an override of a vendor, any good practice?
