### PR TITLE
Add 2024 block theme

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,12 +52,14 @@ jobs:
           rm -rf wp-content/mu-plugins/pub/locale-switcher/node_modules
           rm -rf wp-content/plugins/wporg-learn/node_modules
           rm -rf wp-content/themes/pub/wporg-learn-2020/node_modules
+          rm -rf wp-content/themes/pub/wporg-learn-2024/node_modules
           mv wp-content/mu-plugins/pub/locale-switcher $RUNNER_TEMP
           mv wp-content/mu-plugins/pub/class-validator.php $RUNNER_TEMP
           mv wp-content/mu-plugins/pub/locales.php $RUNNER_TEMP
           mv wp-content/plugins/sensei-pro $RUNNER_TEMP
           mv wp-content/plugins/wporg-learn $RUNNER_TEMP
           mv wp-content/themes/pub/wporg-learn-2020 $RUNNER_TEMP
+          mv wp-content/themes/pub/wporg-learn-2024 $RUNNER_TEMP
           git rm -rfq .
           rm -rf *
           mkdir -p wp-content/mu-plugins/pub
@@ -69,6 +71,7 @@ jobs:
           mv $RUNNER_TEMP/sensei-pro wp-content/plugins
           mv $RUNNER_TEMP/wporg-learn wp-content/plugins
           mv $RUNNER_TEMP/wporg-learn-2020 wp-content/themes/pub
+          mv $RUNNER_TEMP/wporg-learn-2024 wp-content/themes/pub
 
       - name: Add all the files
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /**/node_modules
 /vendor
 *.map
+/**/build
 
 .wp-env.override.json
 
@@ -34,6 +35,7 @@
 !/wp-content/themes
 !/wp-content/themes/pub
 !/wp-content/themes/pub/wporg-learn-2020
+!/wp-content/themes/pub/wporg-learn-2024
 
 # Ignore subfolders in our custom code.
 /wp-content/plugins/wporg-learn/build

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,10 @@
 			"url": "git@github.com:WordPress/wporg-repo-tools.git"
 		},
 		{
+			"type": "vcs",
+			"url": "git@github.com:WordPress/wporg-parent-2021.git"
+		},
+		{
 			"type": "package",
 			"package": [
 				{
@@ -87,6 +91,7 @@
 		"phpcompatibility/phpcompatibility-wp": "*",
 		"rmccue/requests": "^1.7",
 		"wporg/wporg-mu-plugins": "dev-build",
+		"wporg/wporg-parent-2021": "dev-build",
 		"wporg/wporg-repo-tools": "dev-trunk"
 	},
 	"scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c999b3e6a405f7852f0dc04cd339528d",
+    "content-hash": "d2ecc3e83a7c9db5a0375a7a3af8b309",
     "packages": [
         {
             "name": "composer/installers",
@@ -867,6 +867,27 @@
             "time": "2024-04-18T23:15:59+00:00"
         },
         {
+            "name": "wporg/wporg-parent-2021",
+            "version": "dev-build",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/WordPress/wporg-parent-2021.git",
+                "reference": "7bf402d5ca819d54ed677292c48c39166ce7d7ab"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/WordPress/wporg-parent-2021/zipball/7bf402d5ca819d54ed677292c48c39166ce7d7ab",
+                "reference": "7bf402d5ca819d54ed677292c48c39166ce7d7ab",
+                "shasum": ""
+            },
+            "type": "wordpress-theme",
+            "support": {
+                "source": "https://github.com/WordPress/wporg-parent-2021/tree/build",
+                "issues": "https://github.com/WordPress/wporg-parent-2021/issues"
+            },
+            "time": "2024-04-16T18:42:38+00:00"
+        },
+        {
             "name": "wporg/wporg-repo-tools",
             "version": "dev-trunk",
             "source": {
@@ -901,6 +922,7 @@
     "minimum-stability": "stable",
     "stability-flags": {
         "wporg/wporg-mu-plugins": 20,
+        "wporg/wporg-parent-2021": 20,
         "wporg/wporg-repo-tools": 20
     },
     "prefer-stable": false,

--- a/package.json
+++ b/package.json
@@ -31,9 +31,9 @@
 		"format:php": "composer run format",
 		"lint:css": "yarn workspaces run lint:css",
 		"lint:js": "yarn workspaces run lint:js",
-		"watch:theme:old": "yarn workspace wporg-learn-theme start",
-		"watch:theme": "yarn workspace wporg-learn-2024 start",
-		"watch:plugin": "yarn workspace wporg-learn-plugin start",
+		"start:theme:old": "yarn workspace wporg-learn-theme start",
+		"start:theme": "yarn workspace wporg-learn-2024 start",
+		"start:plugin": "yarn workspace wporg-learn-plugin start",
 		"setup:tools": "TEXTDOMAIN=wporg-learn composer exec update-configs"
 	},
 	"main": "index.js"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
 		"packages": [
 			"wp-content/mu-plugins/pub/locale-switcher",
 			"wp-content/plugins/wporg-learn",
-			"wp-content/themes/pub/wporg-learn-2020"
+			"wp-content/themes/pub/wporg-learn-2020",
+			"wp-content/themes/pub/wporg-learn-2024"
 		],
 		"nohoist": [
 			"**/grunt-*"
@@ -30,7 +31,8 @@
 		"format:php": "composer run format",
 		"lint:css": "yarn workspaces run lint:css",
 		"lint:js": "yarn workspaces run lint:js",
-		"watch:theme": "yarn workspace wporg-learn-theme start",
+		"watch:theme:old": "yarn workspace wporg-learn-theme start",
+		"watch:theme": "yarn workspace wporg-learn-2024 start",
 		"watch:plugin": "yarn workspace wporg-learn-plugin start",
 		"setup:tools": "TEXTDOMAIN=wporg-learn composer exec update-configs"
 	},

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -20,7 +20,7 @@
 	<exclude-pattern>*/build/*</exclude-pattern>
 
 	<!-- Exclude all themes except the learn theme -->
-	<exclude-pattern>/wp-content/themes/pub/(?!wporg-learn-2020)</exclude-pattern>
+	<exclude-pattern>/wp-content/themes/pub/(?!wporg-learn-2020|wporg-learn-2024)</exclude-pattern>
 
 	<!-- Exclude all plugins except the learn plugin -->
 	<exclude-pattern>/wp-content/plugins/(?!wporg-learn)</exclude-pattern>

--- a/wp-content/themes/pub/wporg-learn-2024/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2024/functions.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace WordPressdotorg\Theme\Learn_2024;
+
+/**
+ * Actions and filters.
+ */
+add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
+
+/**
+ * Enqueue scripts and styles.
+ */
+function enqueue_assets() {
+	// The parent style is registered as `wporg-parent-2021-style`, and will be loaded unless
+	// explicitly unregistered. We can load any child-theme overrides by declaring the parent
+	// stylesheet as a dependency.
+	wp_enqueue_style(
+		'wporg-learn-2024-style',
+		get_stylesheet_directory_uri() . '/build/style/style-index.css',
+		array( 'wporg-parent-2021-style', 'wporg-global-fonts' ),
+		filemtime( __DIR__ . '/build/style/style-index.css' )
+	);
+}

--- a/wp-content/themes/pub/wporg-learn-2024/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2024/functions.php
@@ -6,6 +6,7 @@ namespace WordPressdotorg\Theme\Learn_2024;
  * Actions and filters.
  */
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
+add_filter( 'wporg_block_navigation_menus', __NAMESPACE__ . '\add_site_navigation_menus' );
 
 /**
  * Enqueue scripts and styles.
@@ -21,3 +22,34 @@ function enqueue_assets() {
 		filemtime( __DIR__ . '/build/style/style-index.css' )
 	);
 }
+
+/**
+ * Provide a list of local navigation menus.
+ */
+function add_site_navigation_menus( $menus ) {
+	return array(
+		'learn' => array(
+			array(
+				'label' => __( 'Courses', 'wporg-learn' ),
+				'url' => '/courses/',
+			),
+			array(
+				'label' => __( 'Lessons', 'wporg-learn' ),
+				'url' => '/lessons/',
+			),
+			array(
+				'label' => __( 'Learning Pathways', 'wporg-learn' ),
+				'url' => '/learning-pathways/',
+			),
+			array(
+				'label' => __( 'Contribute', 'wporg-learn' ),
+				'url' => '/contribute/',
+			),
+			array(
+				'label' => __( 'Instruct', 'wporg-learn' ),
+				'url' => '/instruct/',
+			),
+		),
+	);
+}
+

--- a/wp-content/themes/pub/wporg-learn-2024/package.json
+++ b/wp-content/themes/pub/wporg-learn-2024/package.json
@@ -1,0 +1,25 @@
+{
+    "name": "wporg-learn-2024",
+    "version": "1.0.0",
+    "description": "Theme for learn.wordpress.org",
+	"author": "WordPress.org",
+	"license": "GPL-2.0-or-later",
+	"private": true,
+	"eslintConfig": {
+		"extends": "../../../../.eslintrc.js"
+	},
+	"stylelint": {
+		"extends": "../../../../.stylelintrc",
+		"ignoreFiles": [
+			"**/*.css",
+			"**/*.css.map"
+		]
+	},
+	"scripts": {
+		"build": "wp-scripts build --experimental-modules",
+		"start": "wp-scripts start --experimental-modules",
+		"lint:js": "wp-scripts lint-js src",
+		"lint:css": "wp-scripts lint-style src/**/*.scss",
+		"format": "wp-scripts format src -- --config=../../../../.prettierrc.js"
+	}
+}

--- a/wp-content/themes/pub/wporg-learn-2024/package.json
+++ b/wp-content/themes/pub/wporg-learn-2024/package.json
@@ -5,6 +5,10 @@
 	"author": "WordPress.org",
 	"license": "GPL-2.0-or-later",
 	"private": true,
+	"devDependencies": {
+		"@wordpress/scripts": "27.2.0",
+		"rtlcss-webpack-plugin": "4.0.7"
+	},
 	"eslintConfig": {
 		"extends": "../../../../.eslintrc.js"
 	},

--- a/wp-content/themes/pub/wporg-learn-2024/parts/footer.html
+++ b/wp-content/themes/pub/wporg-learn-2024/parts/footer.html
@@ -1,0 +1,1 @@
+<!-- wp:wporg/global-footer /-->

--- a/wp-content/themes/pub/wporg-learn-2024/parts/header.html
+++ b/wp-content/themes/pub/wporg-learn-2024/parts/header.html
@@ -1,0 +1,17 @@
+<!-- wp:wporg/global-header {"style":{"border":{"bottom":{"color":"var:preset|color|white-opacity-15","style":"solid","width":"1px"}}}} /-->
+
+<!-- wp:wporg/local-navigation-bar {"className":"has-display-contents","backgroundColor":"charcoal-2","style":{"elements":{"link":{"color":{"text":"var:preset|color|white"},":hover":{"color":{"text":"var:preset|color|white"}}}}},"textColor":"white","fontSize":"small"} -->
+
+	<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"textColor":"light-grey-1","layout":{"type":"flex","flexWrap":"nowrap"}} -->
+	<div class="wp-block-group has-light-grey-1-color has-text-color">
+		<!-- wp:site-title {"level":0,"fontSize":"small","textColor":"white"} /-->
+
+		<!-- wp:query-title {"type":"filter","level":0,"fontSize":"small","fontFamily":"inter","className":"wporg-local-navigation-bar__fade-in-scroll"} /-->
+
+		<!-- wp:post-title {"level":0,"fontSize":"small","fontFamily":"inter","className":"wporg-local-navigation-bar__fade-in-scroll"} /-->
+	</div>
+	<!-- /wp:group -->
+
+	<!-- wp:navigation {"menuSlug":"main","icon":"menu","overlayBackgroundColor":"charcoal-2","overlayTextColor":"white","layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small"} /-->
+
+<!-- /wp:wporg/local-navigation-bar -->

--- a/wp-content/themes/pub/wporg-learn-2024/parts/header.html
+++ b/wp-content/themes/pub/wporg-learn-2024/parts/header.html
@@ -12,6 +12,6 @@
 	</div>
 	<!-- /wp:group -->
 
-	<!-- wp:navigation {"menuSlug":"main","icon":"menu","overlayBackgroundColor":"charcoal-2","overlayTextColor":"white","layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small"} /-->
+	<!-- wp:navigation {"menuSlug":"learn","icon":"menu","overlayBackgroundColor":"charcoal-2","overlayTextColor":"white","layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small"} /-->
 
 <!-- /wp:wporg/local-navigation-bar -->

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/block.json
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/block.json
@@ -1,0 +1,3 @@
+{
+	"script": "file:./index.js"
+}

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/index.js
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/index.js
@@ -1,0 +1,2 @@
+// Noop, just imports the CSS for webpack.
+import './style.scss';

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/style.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/style.scss
@@ -1,0 +1,4 @@
+/*
+ * Note: only add styles here in cases where you can't achieve the style with
+ * templates or theme.json settings.
+ */

--- a/wp-content/themes/pub/wporg-learn-2024/style.css
+++ b/wp-content/themes/pub/wporg-learn-2024/style.css
@@ -1,0 +1,20 @@
+/**
+ * Theme Name: WordPress.org Learn 2024
+ * Theme URI: http://learn.wordpress.org/
+ * Author: WordPress.org
+ * Author URI: http://wordpress.org/
+ * Description: A theme for learn.wordpress.org, built in 2024.
+ * Version: 1.0.0
+ * License: GNU General Public License v2 or later
+ * License URI: http://www.gnu.org/licenses/gpl-2.0.html
+ * Text Domain: wporg-learn
+ * Template: wporg-parent-2021
+ */
+
+/**
+ * This theme, like WordPress, is licensed under the GPL.
+ * Use it to make something cool, have fun,
+ * and share what you've learned with others.
+ */
+
+/* This file is not used. Add CSS to `src/style/*`. */

--- a/wp-content/themes/pub/wporg-learn-2024/templates/index.html
+++ b/wp-content/themes/pub/wporg-learn-2024/templates/index.html
@@ -1,0 +1,3 @@
+<!-- wp:template-part {"slug":"header","className":"has-display-contents"} /-->
+index
+<!-- wp:template-part {"slug":"footer"} /-->

--- a/wp-content/themes/pub/wporg-learn-2024/templates/page.html
+++ b/wp-content/themes/pub/wporg-learn-2024/templates/page.html
@@ -1,0 +1,17 @@
+<!-- wp:template-part {"slug":"header","className":"has-display-contents"} /-->
+
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"},"className":"entry-content","style":{"spacing":{"blockGap":"0px"}}} -->
+<main class="wp-block-group entry-content">
+
+	<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space","top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--edge-space)">
+
+		<!-- wp:post-content /-->
+
+	</div>
+	<!-- /wp:group -->
+
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer"} /-->

--- a/wp-content/themes/pub/wporg-learn-2024/theme.json
+++ b/wp-content/themes/pub/wporg-learn-2024/theme.json
@@ -1,0 +1,178 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"version": 2,
+	"settings": {
+		"custom": {
+			"heading": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--inter)",
+					"lineHeight": 1.2
+				},
+				"level-1": {
+					"typography": {
+						"lineHeight": 1.2
+					},
+					"breakpoint": {
+						"small-only": {
+							"typography": {
+								"fontSize": "26px",
+								"lineHeight": 1.2
+							}
+						}
+					}
+				},
+				"level-2": {
+					"typography": {
+						"lineHeight": 1.2
+					},
+					"breakpoint": {
+						"small-only": {
+							"typography": {
+								"fontSize": "24px",
+								"lineHeight": 1.2
+							}
+						}
+					}
+				},
+				"level-3": {
+					"typography": {
+						"lineHeight": 1.2
+					},
+					"breakpoint": {
+						"small-only": {
+							"typography": {
+								"fontSize": "22px",
+								"lineHeight": 1.2
+							}
+						}
+					}
+				},
+				"level-4": {
+					"typography": {
+						"lineHeight": 1.2
+					},
+					"breakpoint": {
+						"small-only": {
+							"typography": {
+								"fontSize": "20px",
+								"lineHeight": 1.2
+							}
+						}
+					}
+				},
+				"level-5": {
+					"typography": {
+						"lineHeight": 1.2
+					},
+					"breakpoint": {
+						"small-only": {
+							"typography": {
+								"fontSize": "18px",
+								"lineHeight": 1.2
+							}
+						}
+					}
+				},
+				"level-6": {
+					"typography": {
+						"lineHeight": 1.2
+					},
+					"breakpoint": {
+						"small-only": {
+							"typography": {
+								"fontSize": "16px",
+								"lineHeight": 1.2
+							}
+						}
+					}
+				}
+			}
+		},
+		"layout": {
+			"contentSize": "960px"
+		},
+		"typography": {
+			"fontSizes": [
+				{
+					"name": "Heading 6",
+					"size": "18px",
+					"slug": "heading-6"
+				},
+				{
+					"name": "Heading 5",
+					"size": "20px",
+					"slug": "heading-5"
+				},
+				{
+					"name": "Heading 4",
+					"size": "24px",
+					"slug": "heading-4"
+				},
+				{
+					"name": "Heading 3",
+					"size": "29px",
+					"slug": "heading-3"
+				},
+				{
+					"name": "Heading 2",
+					"size": "32px",
+					"slug": "heading-2"
+				},
+				{
+					"name": "Heading 1",
+					"size": "38px",
+					"slug": "heading-1"
+				}
+			]
+		}
+	},
+	"styles": {
+		"blocks": {
+			"core/post-title": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--eb-garamond)",
+					"fontSize": "36px",
+					"lineHeight": "1.3"
+				}
+			},
+			"core/query-title": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--eb-garamond)",
+					"fontSize": "36px",
+					"lineHeight": "1.3"
+				}
+			}
+		},
+		"elements": {
+			"h2": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--heading-4)",
+					"fontWeight": "600"
+				},
+				"spacing": {
+					"margin": {
+						"top": "0",
+						"bottom": "var(--wp--style--block-gap)"
+					}
+				}
+			},
+			"h3": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--heading-5)",
+					"fontWeight": "600"
+				}
+			},
+			"h4": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--heading-6)",
+					"fontWeight": "600"
+				}
+			},
+			"h5": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--heading-6)"
+				}
+			}
+		}
+	}
+}

--- a/wp-content/themes/pub/wporg-learn-2024/webpack.config.js
+++ b/wp-content/themes/pub/wporg-learn-2024/webpack.config.js
@@ -1,0 +1,14 @@
+const RtlCssPlugin = require( 'rtlcss-webpack-plugin' );
+const defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
+
+const [ scriptConfig ] = defaultConfig;
+
+module.exports = {
+	...scriptConfig,
+	plugins: [
+		...scriptConfig.plugins,
+		new RtlCssPlugin( {
+			filename: `[name]-rtl.css`,
+		} ),
+	],
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2834,7 +2834,7 @@
     "@wordpress/dom-ready" "^2.13.2"
     "@wordpress/i18n" "^3.20.0"
 
-"@wordpress/a11y@^3.22.0", "@wordpress/a11y@^3.31.0":
+"@wordpress/a11y@^3.20.0", "@wordpress/a11y@^3.22.0", "@wordpress/a11y@^3.31.0":
   version "3.56.0"
   resolved "https://registry.yarnpkg.com/@wordpress/a11y/-/a11y-3.56.0.tgz#5e7dec425fed64f3f81cb34b61a3cc957683d5b8"
   integrity sha512-Q3xWPlAhCrwPidqpfVfOXpEMUZEb89xY9jzg+h4MTEwGcA6M24stSuxdDyeUVA1VG75juC41n+Vzb/Zbf8Lgzw==
@@ -3335,6 +3335,54 @@
     tinycolor2 "^1.4.2"
     uuid "^8.3.0"
 
+"@wordpress/components@^21.3.0":
+  version "21.3.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/components/-/components-21.3.0.tgz#3040e3c982485a39bcb06e81f24b74ca1784b77f"
+  integrity sha512-rg+fuHcSi1+qE+mECfdSYOU5v+MDRGRKAEc4gJ09pSXYvdadp0wc5h9sRM1P+Gm9Rxs4OrNqee5eeqArN42yHw==
+  dependencies:
+    "@babel/runtime" "^7.16.0"
+    "@emotion/cache" "^11.7.1"
+    "@emotion/css" "^11.7.1"
+    "@emotion/react" "^11.7.1"
+    "@emotion/serialize" "^1.0.2"
+    "@emotion/styled" "^11.6.0"
+    "@emotion/utils" "^1.0.0"
+    "@floating-ui/react-dom" "^1.0.0"
+    "@use-gesture/react" "^10.2.6"
+    "@wordpress/a11y" "^3.20.0"
+    "@wordpress/compose" "^5.18.0"
+    "@wordpress/date" "^4.20.0"
+    "@wordpress/deprecated" "^3.20.0"
+    "@wordpress/dom" "^3.20.0"
+    "@wordpress/element" "^4.18.0"
+    "@wordpress/escape-html" "^2.20.0"
+    "@wordpress/hooks" "^3.20.0"
+    "@wordpress/i18n" "^4.20.0"
+    "@wordpress/icons" "^9.11.0"
+    "@wordpress/is-shallow-equal" "^4.20.0"
+    "@wordpress/keycodes" "^3.20.0"
+    "@wordpress/primitives" "^3.18.0"
+    "@wordpress/rich-text" "^5.18.0"
+    "@wordpress/warning" "^2.20.0"
+    change-case "^4.1.2"
+    classnames "^2.3.1"
+    colord "^2.7.0"
+    date-fns "^2.28.0"
+    dom-scroll-into-view "^1.2.1"
+    downshift "^6.0.15"
+    framer-motion "^6.2.8"
+    gradient-parser "^0.1.5"
+    highlight-words-core "^1.2.2"
+    lodash "^4.17.21"
+    memize "^1.1.0"
+    re-resizable "^6.4.0"
+    react-colorful "^5.3.1"
+    reakit "^1.3.8"
+    remove-accents "^0.4.2"
+    use-lilius "^2.0.1"
+    uuid "^8.3.0"
+    valtio "^1.7.0"
+
 "@wordpress/components@^22.1.0":
   version "22.1.0"
   resolved "https://registry.yarnpkg.com/@wordpress/components/-/components-22.1.0.tgz#b41b807479f8108224ffa43f973ae0d25c21463e"
@@ -3402,7 +3450,7 @@
     react-resize-aware "^3.1.0"
     use-memo-one "^1.1.1"
 
-"@wordpress/compose@^5.20.0":
+"@wordpress/compose@^5.18.0", "@wordpress/compose@^5.20.0":
   version "5.20.0"
   resolved "https://registry.yarnpkg.com/@wordpress/compose/-/compose-5.20.0.tgz#e5c5181bca058f73b13fb7007d96f800b6501f71"
   integrity sha512-IcmXeAIgZoJUFIO3bxBpPYfAre41H6zxQTC5N6nqhGqpISvbO1SsAIikd6B4AoSHUZmYV5UoTxk9kECqZZGVOw==
@@ -3592,7 +3640,7 @@
     moment "^2.22.1"
     moment-timezone "^0.5.31"
 
-"@wordpress/date@^4.22.0":
+"@wordpress/date@^4.20.0", "@wordpress/date@^4.22.0":
   version "4.56.0"
   resolved "https://registry.yarnpkg.com/@wordpress/date/-/date-4.56.0.tgz#0ea0748b9d6cdae2593ad36adbd560b353a29c1b"
   integrity sha512-ic0HuZ4BR7xdTVoqVXwFfxZYOmxfjLH/P/4gh/rSdCOoEJo239/uIznZByZf3ZCPVSkK5stZ4qgJQ6YQTTM32w==
@@ -3617,7 +3665,7 @@
     "@babel/runtime" "^7.13.10"
     "@wordpress/hooks" "^2.12.3"
 
-"@wordpress/deprecated@^3.18.0", "@wordpress/deprecated@^3.22.0", "@wordpress/deprecated@^3.56.0":
+"@wordpress/deprecated@^3.18.0", "@wordpress/deprecated@^3.20.0", "@wordpress/deprecated@^3.22.0", "@wordpress/deprecated@^3.56.0":
   version "3.56.0"
   resolved "https://registry.yarnpkg.com/@wordpress/deprecated/-/deprecated-3.56.0.tgz#1d378e39d97391b1a65ac51a485c630cb088fe42"
   integrity sha512-7L59mZPzth3xZqL/MdIMWZjKc4muQjQH7U6ZAP9ur4YVnosAhMBKkNRaUQwMVyr9ZjT1xd/Cpl3ukcdlsfhbQw==
@@ -3647,7 +3695,7 @@
     "@babel/runtime" "^7.13.10"
     lodash "^4.17.19"
 
-"@wordpress/dom@^3.18.0", "@wordpress/dom@^3.22.0", "@wordpress/dom@^3.56.0":
+"@wordpress/dom@^3.18.0", "@wordpress/dom@^3.20.0", "@wordpress/dom@^3.22.0", "@wordpress/dom@^3.56.0":
   version "3.56.0"
   resolved "https://registry.yarnpkg.com/@wordpress/dom/-/dom-3.56.0.tgz#101b97fddc82cdf48ec5a59bc86e8001ea3bf1e8"
   integrity sha512-Ty9av6A9mH+1loT2OHpdBtawlYzmqF8lzebN54HY2gp1gUnpYQiBi5iKbDYuiEKQukfaSsX/PtqYgWx18UCiCg==
@@ -3773,7 +3821,7 @@
     react "^16.13.1"
     react-dom "^16.13.1"
 
-"@wordpress/element@^4.16.0", "@wordpress/element@^4.20.0":
+"@wordpress/element@^4.16.0", "@wordpress/element@^4.18.0", "@wordpress/element@^4.20.0":
   version "4.20.0"
   resolved "https://registry.yarnpkg.com/@wordpress/element/-/element-4.20.0.tgz#d78499521cbb471b97e011a81ec6236daeac24ad"
   integrity sha512-Ou7EoGtGe4FUL6fKALINXJLKoSfyWTBJzkJfN2HzSgM1wira9EuWahl8MQN0HAUaWeOoDqMKPvnglfS+kC8JLA==
@@ -3826,7 +3874,7 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
 
-"@wordpress/escape-html@^2.22.0", "@wordpress/escape-html@^2.56.0":
+"@wordpress/escape-html@^2.20.0", "@wordpress/escape-html@^2.22.0", "@wordpress/escape-html@^2.56.0":
   version "2.56.0"
   resolved "https://registry.yarnpkg.com/@wordpress/escape-html/-/escape-html-2.56.0.tgz#042626b9fc33dbd210b24ed554e71a9a9665b246"
   integrity sha512-f+NDe9ZyUtaoiU8VYSKRjxsKqqzinrVcpcqj+umiLhKD5ShGW8V7LcSr3JOdE4TgjHvw2eezFvRmEo/kXowmMA==
@@ -3863,7 +3911,7 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
 
-"@wordpress/hooks@^3.18.0", "@wordpress/hooks@^3.22.0", "@wordpress/hooks@^3.56.0":
+"@wordpress/hooks@^3.18.0", "@wordpress/hooks@^3.20.0", "@wordpress/hooks@^3.22.0", "@wordpress/hooks@^3.56.0":
   version "3.56.0"
   resolved "https://registry.yarnpkg.com/@wordpress/hooks/-/hooks-3.56.0.tgz#57099d1eded025c907ed7cd847bdcc59a72e87d8"
   integrity sha512-sxoNbXdqfhlRNduDqR5y5Cq7Rwm5ATZGIr5U9nrM5RHWd+8v7g8wpB/rpTSqi+HeCW3suiFuN6qJJZ4eFwRB2w==
@@ -3910,7 +3958,7 @@
     sprintf-js "^1.1.1"
     tannin "^1.2.0"
 
-"@wordpress/i18n@^4.18.0", "@wordpress/i18n@^4.22.0", "@wordpress/i18n@^4.56.0":
+"@wordpress/i18n@^4.18.0", "@wordpress/i18n@^4.20.0", "@wordpress/i18n@^4.22.0", "@wordpress/i18n@^4.56.0":
   version "4.56.0"
   resolved "https://registry.yarnpkg.com/@wordpress/i18n/-/i18n-4.56.0.tgz#fffad73dd73ec9f83ac05e2bbda0dcab5f1fcd11"
   integrity sha512-W+WL8vxwqUeicgXvIHZ3Htq6pYrJe2Dn/9SBsQ7gFPUrGWe2ww5IzPocLv4rAha3lca2ZVIX2q47rGaSs9t8Kw==
@@ -3931,7 +3979,7 @@
     "@wordpress/element" "^2.20.3"
     "@wordpress/primitives" "^1.12.3"
 
-"@wordpress/icons@^9.13.0":
+"@wordpress/icons@^9.11.0", "@wordpress/icons@^9.13.0":
   version "9.47.0"
   resolved "https://registry.yarnpkg.com/@wordpress/icons/-/icons-9.47.0.tgz#ea817c822b2e307bdfb5c9ec555933037a2c0c6a"
   integrity sha512-IQIoEr0LxPWUOgcHnMIqU/ytg3x/swxbl8AGG1ONFks3/2tYdDk3I2/CAYgQGpaiSFIOJjNVk1keqa8DBOnciw==
@@ -3969,7 +4017,7 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
 
-"@wordpress/is-shallow-equal@^4.18.0", "@wordpress/is-shallow-equal@^4.22.0", "@wordpress/is-shallow-equal@^4.56.0":
+"@wordpress/is-shallow-equal@^4.18.0", "@wordpress/is-shallow-equal@^4.20.0", "@wordpress/is-shallow-equal@^4.22.0", "@wordpress/is-shallow-equal@^4.56.0":
   version "4.56.0"
   resolved "https://registry.yarnpkg.com/@wordpress/is-shallow-equal/-/is-shallow-equal-4.56.0.tgz#708eab17afcf53b589b847017068bc1246ac09fb"
   integrity sha512-lwDDqWuK5gtaL/avECX6dd29qoX1MmE0c9iDT64lBHGAVkYPZu6z31HycvRrEbzM5nbn/C2SU542qqqy/MzNoA==
@@ -4025,7 +4073,7 @@
     "@wordpress/i18n" "^3.20.0"
     lodash "^4.17.19"
 
-"@wordpress/keycodes@^3.22.0", "@wordpress/keycodes@^3.51.1", "@wordpress/keycodes@^3.56.0":
+"@wordpress/keycodes@^3.20.0", "@wordpress/keycodes@^3.22.0", "@wordpress/keycodes@^3.51.1", "@wordpress/keycodes@^3.56.0":
   version "3.56.0"
   resolved "https://registry.yarnpkg.com/@wordpress/keycodes/-/keycodes-3.56.0.tgz#06378bf696232ece6c4fbbe8ffd0afe7a5346b7f"
   integrity sha512-YIvqB0AEsu3fjkuQHNT7XladaTDE1Thntv+oqzkRejdNodH5tbPb3CAePAK3F7iQurZ0GCaqlmJTy9qcHwDU0Q==
@@ -4116,7 +4164,7 @@
     "@wordpress/element" "^2.20.3"
     classnames "^2.2.5"
 
-"@wordpress/primitives@^3.20.0", "@wordpress/primitives@^3.54.0":
+"@wordpress/primitives@^3.18.0", "@wordpress/primitives@^3.20.0", "@wordpress/primitives@^3.54.0":
   version "3.54.0"
   resolved "https://registry.yarnpkg.com/@wordpress/primitives/-/primitives-3.54.0.tgz#7e46aed14c1e261314171b4fc496ce5214604d54"
   integrity sha512-2TrXDvYW3V0nlq6ZCYYvJ5obPZNtrsuIdB0iLdUavCOSBoXTROhRZY9Pxz45bB2CLlmEUs9OfL7izx9IuAg4Mw==
@@ -4203,7 +4251,7 @@
     memize "^1.1.0"
     rememo "^3.0.0"
 
-"@wordpress/rich-text@^5.20.0":
+"@wordpress/rich-text@^5.18.0", "@wordpress/rich-text@^5.20.0":
   version "5.20.0"
   resolved "https://registry.yarnpkg.com/@wordpress/rich-text/-/rich-text-5.20.0.tgz#c1e367f3503b5e9d89e949afe60fa11cc4facc40"
   integrity sha512-7W4PksJ6/SnQ+KuwvZ0dlKSwbaS6ejvWBm2N8R5S79AzbdmB69BpDCz0U/GUfGDXDhrU9dpzg5NIivoW2LC8Kg==
@@ -4382,7 +4430,7 @@
     lodash "^4.17.19"
     react-native-url-polyfill "^1.1.2"
 
-"@wordpress/url@^3.23.0", "@wordpress/url@^3.52.1", "@wordpress/url@^3.57.0":
+"@wordpress/url@^3.21.0", "@wordpress/url@^3.23.0", "@wordpress/url@^3.52.1", "@wordpress/url@^3.57.0":
   version "3.57.0"
   resolved "https://registry.yarnpkg.com/@wordpress/url/-/url-3.57.0.tgz#a552798e4d71772dfa4caedf0c1027f3d5913fcc"
   integrity sha512-W3F0KVEaMoRENya7GGUPXrZGYnhAg3fuLSLpNcf1skSrM5rUVMNdeRlZj+jln1O/+qjboJnC+y+IzOlQRwlS6A==
@@ -4405,7 +4453,7 @@
   resolved "https://registry.yarnpkg.com/@wordpress/warning/-/warning-1.4.2.tgz#433e5b2b711cac5b954bafbe1b5bfc626f933b08"
   integrity sha512-MjrkSp6Jyfx+92AE32A83P503noUtGb6//BYUH4GiWzzzSNhDHgbQ0UcOJwJaEYK166DxSNpMk/JXc4YENi1Cw==
 
-"@wordpress/warning@^2.22.0", "@wordpress/warning@^2.56.0":
+"@wordpress/warning@^2.20.0", "@wordpress/warning@^2.22.0", "@wordpress/warning@^2.56.0":
   version "2.56.0"
   resolved "https://registry.yarnpkg.com/@wordpress/warning/-/warning-2.56.0.tgz#6fabe9bf3671810e359a9f675b35d755becdcf17"
   integrity sha512-Bd1Zy5eWQPKoQsfQwD9T1KZWPpq+ZFyozirx+Z5MnX59J0i80p8KiEMcmXhPH+Os9An2PtlVV9j0gY9z5z0oAw==
@@ -5200,6 +5248,14 @@ babel-preset-jest@^29.6.3:
   dependencies:
     babel-plugin-jest-hoist "^29.6.3"
     babel-preset-current-node-syntax "^1.0.0"
+
+babel-runtime@~6.25.0:
+  version "6.25.0"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.25.0.tgz#33b98eaa5d482bb01a8d1aa6b437ad2b01aec41c"
+  integrity sha512-zeCYxDePWYAT/DfmQWIHsMSFW2vv45UIwIAMjGvQVsTd47RwsiRH0uK1yzyWZ7LDBKdhnGDPM6NYEO5CZyhPrg==
+  dependencies:
+    core-js "^2.4.0"
+    regenerator-runtime "^0.10.0"
 
 balanced-match@^1.0.0:
   version "1.0.2"
@@ -6003,6 +6059,11 @@ core-js-pure@^3.23.3:
   version "3.37.0"
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.37.0.tgz#ce99fb4a7cec023fdbbe5b5bd1f06bbcba83316e"
   integrity sha512-d3BrpyFr5eD4KcbRvQ3FTUx/KWmaDesr7+a3+1+P46IUnNoEt+oiLijPINZMEon7w9oGkIINWxrBAU9DEciwFQ==
+
+core-js@^2.4.0:
+  version "2.6.12"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
+  integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
 
 core-js@^3.31.0:
   version "3.37.0"
@@ -11764,7 +11825,7 @@ postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.17, postcss@^7.0.27, postcss@^7.0.7
     picocolors "^0.2.1"
     source-map "^0.6.1"
 
-postcss@^8.4.19, postcss@^8.4.33, postcss@^8.4.5:
+postcss@^8.3.11, postcss@^8.4.19, postcss@^8.4.33, postcss@^8.4.5:
   version "8.4.38"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.38.tgz#b387d533baf2054288e337066d81c6bee9db9e0e"
   integrity sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==
@@ -12457,6 +12518,11 @@ regenerate@^1.4.2:
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.2.tgz#b9346d8827e8f5a32f7ba29637d398b69014848a"
   integrity sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==
 
+regenerator-runtime@^0.10.0:
+  version "0.10.5"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
+  integrity sha512-02YopEIhAgiBHWeoTiA8aitHDt8z6w+rQqNuIftlM+ZtvSl/brTouaU7DW6GO/cHtvxJvS4Hwv2ibKdxIRi24w==
+
 regenerator-runtime@^0.14.0:
   version "0.14.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz#356ade10263f685dda125100cd862c1db895327f"
@@ -12691,6 +12757,14 @@ robots-parser@^3.0.0:
   resolved "https://registry.yarnpkg.com/robots-parser/-/robots-parser-3.0.1.tgz#3d8a3cdfa8ac240cbb062a4bd16fcc0e0fb9ed23"
   integrity sha512-s+pyvQeIKIZ0dx5iJiQk1tPLJAWln39+MI5jtM8wnyws+G5azk+dMnMX0qfbqNetKKNgcWWOdi0sfm+FbQbgdQ==
 
+rtlcss-webpack-plugin@4.0.7:
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/rtlcss-webpack-plugin/-/rtlcss-webpack-plugin-4.0.7.tgz#38b1708029f890f2db14bee510f25e57faf81669"
+  integrity sha512-ouSbJtgcLBBQIsMgarxsDnfgRqm/AS4BKls/mz/Xb6HSl+PdEzefTR+Wz5uWQx4odoX0g261Z7yb3QBz0MTm0g==
+  dependencies:
+    babel-runtime "~6.25.0"
+    rtlcss "^3.5.0"
+
 rtlcss@^2.0.0, rtlcss@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rtlcss/-/rtlcss-2.6.2.tgz#55b572b52c70015ba6e03d497e5c5cb8137104b4"
@@ -12701,6 +12775,16 @@ rtlcss@^2.0.0, rtlcss@^2.6.2:
     mkdirp "^0.5.1"
     postcss "^6.0.23"
     strip-json-comments "^2.0.0"
+
+rtlcss@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/rtlcss/-/rtlcss-3.5.0.tgz#c9eb91269827a102bac7ae3115dd5d049de636c3"
+  integrity sha512-wzgMaMFHQTnyi9YOwsx9LjOxYXJPzS8sYnFaKm6R5ysvTkwzHiB0vxnbHwchHQT65PTdBjDG21/kQBWI7q9O7A==
+  dependencies:
+    find-up "^5.0.0"
+    picocolors "^1.0.0"
+    postcss "^8.3.11"
+    strip-json-comments "^3.1.1"
 
 run-async@^2.4.0:
   version "2.4.1"


### PR DESCRIPTION
Adds the basic building blocks of the Learn 2024 block theme. Much of this is copied from the new Pattern Directory block theme and recent Developer Resources block theme.

The resulting build can be viewed at https://github.com/WordPress/Learn/tree/build-test

Closes #2383 

![localhost_8888__locale=en_US(Desktop)](https://github.com/WordPress/Learn/assets/1017872/921fc657-8376-4f1a-9c09-0f99524a73d8)
