### PR TITLE
Add the Experience Level taxonomy to Courses and Lessons

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2024/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2024/functions.php
@@ -3,6 +3,11 @@
 namespace WordPressdotorg\Theme\Learn_2024;
 
 /**
+ * Admin.
+ */
+require __DIR__ . '/inc/admin.php';
+
+/**
  * Taxonomies.
  */
 require __DIR__ . '/inc/taxonomy.php';

--- a/wp-content/themes/pub/wporg-learn-2024/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2024/functions.php
@@ -3,6 +3,11 @@
 namespace WordPressdotorg\Theme\Learn_2024;
 
 /**
+ * Taxonomies.
+ */
+require __DIR__ . '/inc/taxonomy.php';
+
+/**
  * Actions and filters.
  */
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
@@ -39,19 +44,19 @@ function add_site_navigation_menus( $menus ) {
 		'learn' => array(
 			array(
 				'label' => __( 'User', 'wporg-learn' ),
-				'url' => '/learning-pathways/user/',
+				'url'   => '/learning-pathways/user/',
 			),
 			array(
 				'label' => __( 'Designer', 'wporg-learn' ),
-				'url' => '/learning-pathways/designer/',
+				'url'   => '/learning-pathways/designer/',
 			),
 			array(
 				'label' => __( 'Contributor', 'wporg-learn' ),
-				'url' => '/learning-pathways/contributor/',
+				'url'   => '/learning-pathways/contributor/',
 			),
 			array(
 				'label' => __( 'Developer', 'wporg-learn' ),
-				'url' => '/learning-pathways/developer/',
+				'url'   => '/learning-pathways/developer/',
 			),
 		),
 	);

--- a/wp-content/themes/pub/wporg-learn-2024/inc/admin.php
+++ b/wp-content/themes/pub/wporg-learn-2024/inc/admin.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace WordPressdotorg\Theme\Learn_2024\Admin;
+
+use WP_Query;
+use function WordPressdotorg\Theme\Learn_2024\Taxonomy\get_available_taxonomy_terms;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Actions and filters.
+ */
+add_action( 'restrict_manage_posts', __NAMESPACE__ . '\add_admin_list_table_filters', 10, 2 );
+
+/**
+ * Add filtering controls for the course and lesson list tables.
+ *
+ * @param string $post_type
+ * @param string $which
+ *
+ * @return void
+ */
+function add_admin_list_table_filters( $post_type, $which ) {
+	if ( ( 'course' !== $post_type && 'lesson' !== $post_type ) || 'top' !== $which ) {
+		return;
+	}
+
+	$level            = filter_input( INPUT_GET, 'experience_level', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+	$available_levels = get_available_taxonomy_terms( 'experience_level', $post_type );
+
+	if ( empty( $available_levels ) ) {
+		return;
+	}
+
+	?>
+
+		<label for="filter-by-experience_level" class="screen-reader-text">
+			<?php esc_html_e( 'Filter by level', 'wporg-learn' ); ?>
+		</label>
+		<select id="filter-by-experience_level" name="experience_level">
+			<option value=""<?php selected( ! $level ); ?>><?php esc_html_e( 'Any level', 'wporg-learn' ); ?></option>
+			<?php foreach ( $available_levels as $code => $name ) : ?>
+				<option value="<?php echo esc_attr( $code ); ?>"<?php selected( $code, $level ); ?>>
+					<?php echo esc_html( $name ); ?>
+				</option>
+			<?php endforeach; ?>
+		</select>
+
+	<?php
+}

--- a/wp-content/themes/pub/wporg-learn-2024/inc/taxonomy.php
+++ b/wp-content/themes/pub/wporg-learn-2024/inc/taxonomy.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace WPOrg_Learn\Taxonomy;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Actions and filters.
+ */
+add_action( 'init', __NAMESPACE__ . '\register' );
+
+/**
+ * Register all the taxonomies.
+ */
+function register() {
+	register_experience_level();
+}
+
+/**
+ * Register the Experience Level taxonomy.
+ */
+function register_experience_level() {
+	$labels = array(
+		'name'                       => _x( 'Experience Levels', 'Taxonomy General Name', 'wporg-learn' ),
+		'singular_name'              => _x( 'Experience Level', 'Taxonomy Singular Name', 'wporg-learn' ),
+		'menu_name'                  => __( 'Experience level', 'wporg-learn' ),
+		'all_items'                  => __( 'All experience levels', 'wporg-learn' ),
+		'parent_item'                => __( 'Parent experience level', 'wporg-learn' ),
+		'parent_item_colon'          => __( 'Parent experience level:', 'wporg-learn' ),
+		'new_item_name'              => __( 'New experience level Name', 'wporg-learn' ),
+		'add_new_item'               => __( 'Add New experience level', 'wporg-learn' ),
+		'edit_item'                  => __( 'Edit experience level', 'wporg-learn' ),
+		'update_item'                => __( 'Update experience level', 'wporg-learn' ),
+		'view_item'                  => __( 'View experience level', 'wporg-learn' ),
+		'separate_items_with_commas' => __( 'Separate experience levels with commas', 'wporg-learn' ),
+		'add_or_remove_items'        => __( 'Add or remove experience levels', 'wporg-learn' ),
+		'choose_from_most_used'      => __( 'Choose from the most used', 'wporg-learn' ),
+		'popular_items'              => __( 'Popular experience levels', 'wporg-learn' ),
+		'search_items'               => __( 'Search experience levels', 'wporg-learn' ),
+		'not_found'                  => __( 'No experience level found', 'wporg-learn' ),
+		'no_terms'                   => __( 'No experience levels', 'wporg-learn' ),
+		'items_list'                 => __( 'Experience levels list', 'wporg-learn' ),
+		'items_list_navigation'      => __( 'Experience levels list navigation', 'wporg-learn' ),
+	);
+
+	$args = array(
+		'labels'            => $labels,
+		'hierarchical'      => false,
+		'public'            => true,
+		'query_var'         => 'experience_level',
+		'show_ui'           => true,
+		'show_admin_column' => true,
+		'show_in_nav_menus' => true,
+		'show_tagcloud'     => false,
+		'show_in_rest'      => true,
+		'capabilities'      => array(
+			'assign_terms' => 'edit_lessons',
+		),
+	);
+
+	register_taxonomy( 'level', array( 'lesson', 'course' ), $args );
+}
+

--- a/wp-content/themes/pub/wporg-learn-2024/inc/taxonomy.php
+++ b/wp-content/themes/pub/wporg-learn-2024/inc/taxonomy.php
@@ -58,6 +58,53 @@ function register_experience_level() {
 		),
 	);
 
-	register_taxonomy( 'level', array( 'lesson', 'course' ), $args );
+	register_taxonomy( 'experience_level', array( 'lesson', 'course' ), $args );
 }
 
+/**
+ * Get available taxonomy terms for a post type.
+ *
+ * @param string $taxonomy The taxonomy.
+ * @param string $post_type The post type.
+ * @param string $post_status The post status.
+ * @return array The available taxonomy terms.
+ */
+function get_available_taxonomy_terms( $taxonomy, $post_type, $post_status = null ) {
+	$posts = get_posts( array(
+		'post_status'    => $post_status ?? 'any',
+		'post_type'      => $post_type,
+		'posts_per_page' => -1,
+	) );
+
+	if ( empty( $posts ) ) {
+		return array();
+	}
+
+	$term_ids = array();
+	foreach ( $posts as $post ) {
+		$post_terms = wp_get_post_terms( $post->ID, $taxonomy, array( 'fields' => 'ids' ) );
+
+		if ( ! is_wp_error( $post_terms ) ) {
+			$term_ids = array_merge( $term_ids, $post_terms );
+		}
+	}
+
+	if ( empty( $term_ids ) ) {
+		return array();
+	}
+
+	$term_ids = array_unique( $term_ids );
+
+	$terms = get_terms( array(
+		'taxonomy'   => $taxonomy,
+		'include'    => $term_ids,
+		'hide_empty' => false,
+	) );
+
+	$levels = array();
+	foreach ( $terms as $term ) {
+		$levels[ $term->slug ] = $term->name;
+	}
+
+	return $levels;
+}

--- a/wp-content/themes/pub/wporg-learn-2024/inc/taxonomy.php
+++ b/wp-content/themes/pub/wporg-learn-2024/inc/taxonomy.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WPOrg_Learn\Taxonomy;
+namespace WordPressdotorg\Theme\Learn_2024\Taxonomy;
 
 defined( 'WPINC' ) || die();
 


### PR DESCRIPTION
Closes https://github.com/WordPress/Learn/issues/2387

Adds an Experience Level taxonomy to Lessons and Courses. The taxonomy isn't added to the Sensei sidebar entries, but it possible to add more options directly on a Course or Lesson. Do you think we need a sidebar entry?

![localhost_8888_wp-admin_edit php_post_type=course(2 1366x768)](https://github.com/WordPress/Learn/assets/1017872/703ddf0c-e421-4caf-a3bf-6c23df3c0358)

![localhost_8888_wp-admin_post php_post=43 action=edit(2 1366x768) (1)](https://github.com/WordPress/Learn/assets/1017872/c624e9df-ba1b-44d1-a255-5225aa82978a)
