### PR TITLE
Customize single lesson template

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -147,7 +147,7 @@
 	     provided as a comma-delimited list. -->
 	<rule ref="WordPress.WP.I18n">
 		<properties>
-			<property name="text_domain" type="array" value="wporg-learn,wporg_learn" />
+			<property name="text_domain" type="array" value="wporg-learn,wporg_learn,sensei-lms" />
 		</properties>
 	</rule>
 </ruleset>

--- a/wp-content/themes/pub/wporg-learn-2024/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2024/functions.php
@@ -59,6 +59,21 @@ require get_includes_path() . 'taxonomy.php';
 add_action( 'after_setup_theme', __NAMESPACE__ . '\setup' );
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
 add_filter( 'wporg_block_navigation_menus', __NAMESPACE__ . '\add_site_navigation_menus' );
+add_filter( 'single_template_hierarchy', __NAMESPACE__ . '\modify_single_template' );
+
+/**
+ * Modify the single template hierarchy to use a customised copy of the Sensei Course Theme template for lessons.
+ *
+ * @param array $templates Array of template files.
+ * @return array
+ */
+function modify_single_template( $templates ) {
+	if ( is_singular( 'lesson' ) ) {
+		array_unshift( $templates, 'single-lesson.html' );
+	}
+
+	return $templates;
+}
 
 /**
  * Sets up theme defaults and registers support for various WordPress features.

--- a/wp-content/themes/pub/wporg-learn-2024/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2024/functions.php
@@ -70,6 +70,8 @@ add_filter( 'single_template_hierarchy', __NAMESPACE__ . '\modify_single_templat
 function modify_single_template( $templates ) {
 	if ( is_singular( 'lesson' ) ) {
 		array_unshift( $templates, 'single-lesson.html' );
+	} elseif ( is_singular( 'quiz' ) ) {
+		array_unshift( $templates, 'single-quiz.html' );
 	}
 
 	return $templates;

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/sensei-lesson-header.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/sensei-lesson-header.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Title: Sensei Lesson header
+ * Slug: wporg-learn-2024/sensei-lesson-header
+ * Inserter: no
+ *
+ * Copied from https://github.com/Automattic/sensei/blob/trunk/themes/sensei-course-theme/patterns/header.html
+ */
+
+?>
+
+<!-- wp:sensei-lms/ui {"elementClass":"sensei-course-theme__header","className":"sensei-version\u002d\u002d4-16-2"} -->
+<div class="wp-block-sensei-lms-ui sensei-course-theme__frame sensei-version--4-16-2 sensei-course-theme__header">
+	<!-- wp:group {"style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space","top":"0px","bottom":"0px"}}},"className":"sensei-course-theme-header-content","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+	<div class="wp-block-group sensei-course-theme-header-content" style="padding-top:0px;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:0px;padding-left:var(--wp--preset--spacing--edge-space)">
+
+		<!-- wp:group {"style":{"spacing":{"blockGap":"15px"}},"layout":{"type":"flex","flexWrap":"wrap"}} -->
+		<div class="wp-block-group">
+
+			<!-- wp:site-title {"level":2,"style":{"elements":{"link":{"color":{"text":"var:preset|color|charcoal-4"}}},"typography":{"fontStyle":"normal","fontWeight":"400"}},"textColor":"charcoal-4","fontSize":"small"} /-->
+
+			<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|light-grey-1"}}}},"textColor":"light-grey-1"} -->
+			<p class="has-light-grey-1-color has-text-color has-link-color" aria-hidden="true">/</p>
+			<!-- /wp:paragraph -->
+
+			<!-- wp:sensei-lms/course-title {"style":{"typography":{"fontStyle":"normal","fontWeight":"400"},"spacing":{"margin":{"top":"0"},"padding":{"right":"0","left":"0"}}},"fontSize":"small"} /-->
+
+		</div>
+		<!-- /wp:group -->
+
+		<!-- wp:group {"style":{"spacing":{"blockGap":"12px"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+		<div class="wp-block-group">
+
+			<!-- wp:group {"style":{"spacing":{"blockGap":"16px"}},"className":"sensei-course-theme__header__info","layout":{"type":"flex","flexWrap":"nowrap"}} -->
+			<div class="wp-block-group sensei-course-theme__header__info">
+				<!-- wp:sensei-lms/course-theme-course-progress-counter {"fontSize":"small"} /-->
+
+				<!-- wp:sensei-lms/exit-course {"fontSize":"small"} /-->
+			</div>
+			<!-- /wp:group -->
+
+			<!-- wp:sensei-lms/sidebar-toggle-button /-->
+
+		</div>
+		<!-- /wp:group -->
+
+	</div>
+	<!-- /wp:group -->
+
+	<!-- wp:sensei-lms/course-theme-course-progress-bar /-->
+</div>
+<!-- /wp:sensei-lms/ui -->

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/sensei-lesson-header.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/sensei-lesson-header.php
@@ -4,7 +4,7 @@
  * Slug: wporg-learn-2024/sensei-lesson-header
  * Inserter: no
  *
- * Copied from https://github.com/Automattic/sensei/blob/trunk/themes/sensei-course-theme/patterns/header.html
+ * Original source: https://github.com/Automattic/sensei/blob/af62fb1115daf2063bc56331a7d8b1b3ea805866/themes/sensei-course-theme/patterns/header.html
  */
 
 ?>

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/sensei-lesson.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/sensei-lesson.php
@@ -4,7 +4,7 @@
  * Slug: wporg-learn-2024/sensei-lesson
  * Inserter: no
  *
- * Copied from https://github.com/Automattic/sensei/blob/trunk/themes/sensei-course-theme/templates/default/lesson.php
+ * Original source: https://github.com/Automattic/sensei/blob/af62fb1115daf2063bc56331a7d8b1b3ea805866/themes/sensei-course-theme/templates/default/lesson.php
  */
 
 ?>

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/sensei-lesson.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/sensei-lesson.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Title: Sensei Lesson content
+ * Slug: wporg-learn-2024/sensei-lesson
+ * Inserter: no
+ *
+ * Copied from https://github.com/Automattic/sensei/blob/trunk/themes/sensei-course-theme/templates/default/lesson.php
+ */
+
+?>
+
+<!-- wp:pattern {"slug":"wporg-learn-2024/sensei-lesson-header"} /-->
+
+<!-- wp:sensei-lms/ui {"elementClass":"sensei-course-theme__columns","className":"sensei-version\u002d\u002d4-16-2"} -->
+<div class="wp-block-sensei-lms-ui sensei-course-theme__columns sensei-version--4-16-2">
+
+	<!-- wp:sensei-lms/ui {"elementClass":"sensei-course-theme__sidebar","className":"","style"={"spacing":{"margin":{"top":"var:preset|spacing|50"},"padding":{"top":"var:preset|spacing|20","right":"var:preset|spacing|30","bottom":"var:preset|spacing|50","left":"var:preset|spacing|edge-space"}}}} -->
+	<div class="wp-block-sensei-lms-ui sensei-course-theme__frame sensei-course-theme__sidebar" style="margin-top:var(--wp--preset--spacing--50);padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--edge-space)">
+
+		<!-- wp:sensei-lms/course-navigation /-->
+
+	</div>
+	<!-- /wp:sensei-lms/ui -->
+
+	<!-- wp:sensei-lms/ui {"elementClass":"sensei-course-theme__main-content","lock":{"move":false,"remove":false},"style"={"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|edge-space"}}}} -->
+	<div class="wp-block-sensei-lms-ui sensei-course-theme__main-content" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--edge-space)">
+
+		<!-- wp:sensei-lms/course-theme-lesson-module /-->
+
+		<!-- wp:post-title {"level":1,"fontSize":"heading-1"} /-->
+
+		<!-- wp:sensei-lms/course-theme-notices /-->
+
+		<!-- wp:post-content {"layout":{"inherit":true}} /-->
+
+		<!-- wp:group {"style":{"spacing":{"margin":{"top":"40px"}}},"layout":{"type":"constrained"}} -->
+		<div class="wp-block-group" style="margin-top:40px">
+			<!-- wp:sensei-lms/page-actions {"style":{"spacing":{"blockGap":"43px"}}} /-->
+
+			<!-- wp:group {"style":{"spacing":{"margin":{"top":"20px"}}},"className":"sensei-lesson-footer","layout":{"type":"flex","flexWrap":"nowrap"}} -->
+			<div class="wp-block-group sensei-lesson-footer" style="margin-top:20px">
+				<!-- wp:sensei-lms/lesson-actions {"toggledBlocks":{"sensei-lms/button-reset-lesson":false}} -->
+				<div class="wp-block-sensei-lms-lesson-actions">
+					<div class="sensei-buttons-container">
+						<!-- wp:sensei-lms/button-complete-lesson {"inContainer":true,"className":"is-style-outline"} -->
+						<div class="wp-block-sensei-lms-button-complete-lesson is-style-outline sensei-buttons-container__button-block wp-block-sensei-lms-button-complete-lesson__wrapper"><div class="wp-block-sensei-lms-button-complete-lesson is-style-outline wp-block-sensei-button wp-block-button has-text-align-left"><button class="wp-block-button__link sensei-stop-double-submission"><?php esc_html_e( 'Complete Lesson', 'sensei-lms' ); ?></button></div></div>
+						<!-- /wp:sensei-lms/button-complete-lesson -->
+
+						<!-- wp:sensei-lms/button-view-quiz {"inContainer":true} -->
+						<div class="wp-block-sensei-lms-button-view-quiz is-style-default sensei-buttons-container__button-block wp-block-sensei-lms-button-view-quiz__wrapper"><div class="wp-block-sensei-lms-button-view-quiz is-style-default wp-block-sensei-button wp-block-button has-text-align-left"><button class="wp-block-button__link"><?php esc_html_e( 'Take Quiz', 'sensei-lms' ); ?></button></div></div>
+						<!-- /wp:sensei-lms/button-view-quiz -->
+
+						<!-- wp:sensei-lms/button-lesson-completed {"inContainer":true,"className":"is-style-outline"} -->
+						<div class="wp-block-sensei-lms-button-lesson-completed is-style-outline sensei-buttons-container__button-block wp-block-sensei-lms-button-lesson-completed__wrapper"><div class="wp-block-sensei-lms-button-lesson-completed is-style-outline wp-block-sensei-button wp-block-button has-text-align-left"><button class="wp-block-button__link"><?php esc_html_e( 'Completed', 'sensei-lms' ); ?></button></div></div>
+						<!-- /wp:sensei-lms/button-lesson-completed -->
+
+						<!-- wp:sensei-lms/button-next-lesson {"inContainer":true} -->
+						<div class="wp-block-sensei-lms-button-next-lesson is-style-default sensei-buttons-container__button-block wp-block-sensei-lms-button-next-lesson__wrapper"><div class="wp-block-sensei-lms-button-next-lesson is-style-default wp-block-sensei-button wp-block-button has-text-align-left"><button class="wp-block-button__link"><?php esc_html_e( 'Next Lesson', 'sensei-lms' ); ?></button></div></div>
+						<!-- /wp:sensei-lms/button-next-lesson -->
+					</div>
+				</div>
+				<!-- /wp:sensei-lms/lesson-actions -->
+			</div>
+			<!-- /wp:group -->
+		</div>
+		<!-- /wp:group -->
+	</div>
+	<!-- /wp:sensei-lms/ui -->
+</div>
+<!-- /wp:sensei-lms/ui -->

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
@@ -1,11 +1,25 @@
 body.sensei {
 	--sensei-secondary-color: var(--wp--preset--color--blueberry-1);
+	--sensei-course-progress-bar-color: var(--wp--custom--color--border);
 	--sensei-course-progress-bar-inner-color: var(--wp--preset--color--blueberry-1);
 	--sensei-lesson-meta-color: var(--wp--preset--color--charcoal-4);
 	--sensei-module-lesson-color: var(--wp--preset--color--charcoal-1);
+	--sensei-button-text-color: var(--wp--preset--color--white);
+	--sensei-lm-header-height: 60px;
+	--sensei-lm-sidebar-width: calc(280px + var(--wp--preset--spacing--edge-space));
+	--border-color: var(--wp--custom--color--border);
+	--content-size: var(--wp--style--global--content-size);
 
-	.wp-block-sensei-lms-course-title {
-		margin-top: unset;
+	.sensei-course-theme-header-content > .wp-block-group {
+		row-gap: 0;
+	}
+
+	.sensei-course-theme__columns .sensei-course-theme__sidebar ~ .sensei-course-theme__main-content {
+		--sensei-lm-sidebar-width: calc(280px + (var(--wp--preset--spacing--edge-space) * 2) - 24px);
+
+		@media (min-width: 890px) {
+			padding-right: calc(var(--wp--preset--spacing--edge-space) - 24px);
+		}
 	}
 
 	.sensei-lms-course-navigation-module__header {
@@ -38,6 +52,20 @@ body.sensei {
 		&.status-in-progress,
 		&.status-not-started {
 			--sensei-module-lesson-color: var(--wp--preset--color--charcoal-4);
+		}
+	}
+
+	.sensei-course-theme .wp-block-post-title {
+		font-size: var(--wp--preset--typography--font-size--large);
+	}
+
+	@media screen and (max-width: 782px) {
+		.sensei-lesson-footer .wp-block-sensei-lms-button-lesson-completed {
+			display: flex;
+
+			.wp-block-button__link {
+				flex: 1;
+			}
 		}
 	}
 }

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
@@ -9,6 +9,7 @@ body.sensei {
 	--sensei-lm-sidebar-width: calc(280px + var(--wp--preset--spacing--edge-space));
 	--border-color: var(--wp--custom--color--border);
 	--content-size: var(--wp--style--global--content-size);
+	--content-padding: var(--wp--preset--spacing--edge-space);
 
 	.sensei-course-theme-header-content > .wp-block-group {
 		row-gap: 0;
@@ -62,6 +63,12 @@ body.sensei {
 			.wp-block-button__link {
 				flex: 1;
 			}
+		}
+	}
+
+	&.quiz {
+		#sensei-quiz-list .question-title {
+			font-size: var(--wp--preset--font-size--heading-2);
 		}
 	}
 }

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
@@ -1,0 +1,43 @@
+body.sensei {
+	--sensei-secondary-color: var(--wp--preset--color--blueberry-1);
+	--sensei-course-progress-bar-inner-color: var(--wp--preset--color--blueberry-1);
+	--sensei-lesson-meta-color: var(--wp--preset--color--charcoal-4);
+	--sensei-module-lesson-color: var(--wp--preset--color--charcoal-1);
+
+	.wp-block-sensei-lms-course-title {
+		margin-top: unset;
+	}
+
+	.sensei-lms-course-navigation-module__header {
+		.sensei-collapsible__toggle.sensei-lms-course-navigation-module__button {
+			flex-direction: row-reverse;
+			align-items: flex-start;
+			gap: 0;
+		}
+	}
+
+	.sensei-lms-course-navigation-module__title {
+		font-weight: 700;
+		font-size: var(--wp--preset--font-size--small);
+		color: var(--wp--preset--color--charcoal-1);
+		margin-top: unset;
+	}
+
+	.sensei-lms-course-navigation-module__lessons.sensei-collapsible__content,
+	.sensei-lms-course-navigation-module__summary {
+		padding-left: 24px;
+	}
+
+	.sensei-lms-course-navigation-module__summary {
+		font-size: var(--wp--preset--font-size--xsmall);
+	}
+
+	.sensei-lms-course-navigation-lesson {
+		font-size: var(--wp--preset--font-size--small);
+
+		&.status-in-progress,
+		&.status-not-started {
+			--sensei-module-lesson-color: var(--wp--preset--color--charcoal-4);
+		}
+	}
+}

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
@@ -1,15 +1,17 @@
 body.sensei {
+	--content-size: var(--wp--style--global--content-size);
+	--content-padding: var(--wp--preset--spacing--edge-space);
+	--sensei-lm-header-height: 60px;
+	--sensei-lm-sidebar-width: calc(280px + var(--wp--preset--spacing--edge-space));
+
+	--border-color: var(--wp--custom--color--border);
 	--sensei-secondary-color: var(--wp--preset--color--blueberry-1);
+	--sensei-button-text-color: var(--wp--preset--color--white);
+
 	--sensei-course-progress-bar-color: var(--wp--custom--color--border);
 	--sensei-course-progress-bar-inner-color: var(--wp--preset--color--blueberry-1);
 	--sensei-lesson-meta-color: var(--wp--preset--color--charcoal-4);
 	--sensei-module-lesson-color: var(--wp--preset--color--charcoal-1);
-	--sensei-button-text-color: var(--wp--preset--color--white);
-	--sensei-lm-header-height: 60px;
-	--sensei-lm-sidebar-width: calc(280px + var(--wp--preset--spacing--edge-space));
-	--border-color: var(--wp--custom--color--border);
-	--content-size: var(--wp--style--global--content-size);
-	--content-padding: var(--wp--preset--spacing--edge-space);
 
 	.sensei-course-theme-header-content > .wp-block-group {
 		row-gap: 0;

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
@@ -55,10 +55,6 @@ body.sensei {
 		}
 	}
 
-	.sensei-course-theme .wp-block-post-title {
-		font-size: var(--wp--preset--typography--font-size--large);
-	}
-
 	@media screen and (max-width: 782px) {
 		.sensei-lesson-footer .wp-block-sensei-lms-button-lesson-completed {
 			display: flex;

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/style.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/style.scss
@@ -2,3 +2,5 @@
  * Note: only add styles here in cases where you can't achieve the style with
  * templates or theme.json settings.
  */
+
+@import "sensei";

--- a/wp-content/themes/pub/wporg-learn-2024/templates/single-lesson.html
+++ b/wp-content/themes/pub/wporg-learn-2024/templates/single-lesson.html
@@ -1,0 +1,1 @@
+<!-- wp:pattern {"slug":"wporg-learn-2024/sensei-lesson"} /-->

--- a/wp-content/themes/pub/wporg-learn-2024/templates/single-quiz.html
+++ b/wp-content/themes/pub/wporg-learn-2024/templates/single-quiz.html
@@ -7,11 +7,15 @@
 	<!-- wp:sensei-lms/quiz-back-to-lesson /-->
 
 	<!-- wp:group {"style":{"spacing":{"padding":{"top":"0","bottom":"0"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
-	<div class="wp-block-group" style="margin-top:0;margin-bottom:0;padding-top:0;padding-bottom:0"><!-- wp:post-title {"level":1,"style":{"spacing":{"margin":{"bottom":"0"},"padding":{"bottom":"0"}}}} /-->
+	<div class="wp-block-group" style="margin-top:0;margin-bottom:0;padding-top:0;padding-bottom:0">
+		
+		<!-- wp:post-title {"level":1,"style":{"spacing":{"margin":{"bottom":"0"},"padding":{"bottom":"0"}}},"fontSize":"heading-1"} /-->
 
 		<!-- wp:group {"style":{"spacing":{"margin":{"top":"0","bottom":"0"},"padding":{"right":"0","left":"0","top":"0","bottom":"0"}}},"className":"sensei-course-theme__quiz__header__right","layout":{"type":"constrained"}} -->
 		<div class="wp-block-group sensei-course-theme__quiz__header__right" style="margin-top:0;margin-bottom:0;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"></div>
-		<!-- /wp:group --></div>
+		<!-- /wp:group -->
+	
+	</div>
 	<!-- /wp:group -->
 
 	<!-- wp:sensei-lms/course-theme-notices /-->
@@ -21,10 +25,12 @@
 
 <!-- wp:group {"className":"sensei-course-theme__quiz__footer_wrapper sensei-course-theme__frame"} -->
 <div class="wp-block-group sensei-course-theme__quiz__footer__wrapper sensei-course-theme__frame">
+
 	<!-- wp:group {"className":"sensei-course-theme__quiz__footer alignwide"} -->
 	<div class="wp-block-group sensei-course-theme__quiz__footer alignwide">
 		<!-- wp:sensei-lms/quiz-actions /-->
 	</div>
 	<!-- /wp:group -->
+
 </div>
 <!-- /wp:group -->

--- a/wp-content/themes/pub/wporg-learn-2024/templates/single-quiz.html
+++ b/wp-content/themes/pub/wporg-learn-2024/templates/single-quiz.html
@@ -2,8 +2,9 @@
 
 <!-- wp:pattern {"slug":"wporg-learn-2024/sensei-lesson-header"} /-->
 
-<!-- wp:group {"className":"sensei-course-theme__quiz__main-content sensei-version\u002d\u002d4-16-2 sensei-course-theme__main-content", "tagName": "main"} -->
-<main class="wp-block-group sensei-course-theme__quiz__main-content sensei-version--4-16-2 sensei-course-theme__main-content">
+<!-- wp:group {"className":"sensei-course-theme__quiz__main-content sensei-version\u002d\u002d4-16-2 sensei-course-theme__main-content", "tagName": "main","style"={"spacing":{"padding":{"top":"var:preset|spacing|80","bottom":"var:preset|spacing|edge-space"}}}} -->
+<main class="wp-block-group sensei-course-theme__quiz__main-content sensei-version--4-16-2 sensei-course-theme__main-content" style="padding-top:var(--wp--preset--spacing--80);padding-bottom:var(--wp--preset--spacing--edge-space)">
+
 	<!-- wp:sensei-lms/quiz-back-to-lesson /-->
 
 	<!-- wp:group {"style":{"spacing":{"padding":{"top":"0","bottom":"0"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
@@ -19,7 +20,9 @@
 	<!-- /wp:group -->
 
 	<!-- wp:sensei-lms/course-theme-notices /-->
+
 	<!-- wp:post-content /-->
+
 </main>
 <!-- /wp:group -->
 

--- a/wp-content/themes/pub/wporg-learn-2024/templates/single-quiz.html
+++ b/wp-content/themes/pub/wporg-learn-2024/templates/single-quiz.html
@@ -1,0 +1,30 @@
+<!-- Original source: https://github.com/Automattic/sensei/blob/af62fb1115daf2063bc56331a7d8b1b3ea805866/themes/sensei-course-theme/templates/quiz.html -->
+
+<!-- wp:pattern {"slug":"wporg-learn-2024/sensei-lesson-header"} /-->
+
+<!-- wp:group {"className":"sensei-course-theme__quiz__main-content sensei-version\u002d\u002d4-16-2 sensei-course-theme__main-content", "tagName": "main"} -->
+<main class="wp-block-group sensei-course-theme__quiz__main-content sensei-version--4-16-2 sensei-course-theme__main-content">
+	<!-- wp:sensei-lms/quiz-back-to-lesson /-->
+
+	<!-- wp:group {"style":{"spacing":{"padding":{"top":"0","bottom":"0"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+	<div class="wp-block-group" style="margin-top:0;margin-bottom:0;padding-top:0;padding-bottom:0"><!-- wp:post-title {"level":1,"style":{"spacing":{"margin":{"bottom":"0"},"padding":{"bottom":"0"}}}} /-->
+
+		<!-- wp:group {"style":{"spacing":{"margin":{"top":"0","bottom":"0"},"padding":{"right":"0","left":"0","top":"0","bottom":"0"}}},"className":"sensei-course-theme__quiz__header__right","layout":{"type":"constrained"}} -->
+		<div class="wp-block-group sensei-course-theme__quiz__header__right" style="margin-top:0;margin-bottom:0;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"></div>
+		<!-- /wp:group --></div>
+	<!-- /wp:group -->
+
+	<!-- wp:sensei-lms/course-theme-notices /-->
+	<!-- wp:post-content /-->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:group {"className":"sensei-course-theme__quiz__footer_wrapper sensei-course-theme__frame"} -->
+<div class="wp-block-group sensei-course-theme__quiz__footer__wrapper sensei-course-theme__frame">
+	<!-- wp:group {"className":"sensei-course-theme__quiz__footer alignwide"} -->
+	<div class="wp-block-group sensei-course-theme__quiz__footer alignwide">
+		<!-- wp:sensei-lms/quiz-actions /-->
+	</div>
+	<!-- /wp:group -->
+</div>
+<!-- /wp:group -->

--- a/wp-content/themes/pub/wporg-learn-2024/theme.json
+++ b/wp-content/themes/pub/wporg-learn-2024/theme.json
@@ -3,6 +3,9 @@
 	"version": 2,
 	"settings": {
 		"custom": {
+			"color": {
+				"border": "var(--wp--preset--color--light-grey-1)"
+			},
 			"heading": {
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--inter)",
@@ -84,6 +87,13 @@
 								"lineHeight": 1.2
 							}
 						}
+					}
+				}
+			},
+			"sensei": {
+				"lesson": {
+					"main-content": {
+						"padding-right": "calc(var(--wp--preset--spacing--edge-space) - 24px)"
 					}
 				}
 			}

--- a/wp-content/themes/pub/wporg-learn-2024/theme.json
+++ b/wp-content/themes/pub/wporg-learn-2024/theme.json
@@ -89,13 +89,6 @@
 						}
 					}
 				}
-			},
-			"sensei": {
-				"lesson": {
-					"main-content": {
-						"padding-right": "calc(var(--wp--preset--spacing--edge-space) - 24px)"
-					}
-				}
 			}
 		},
 		"layout": {


### PR DESCRIPTION
Closes #2429 

Amends the Sensei single lesson template to match the [designs](https://www.figma.com/design/ZKaf6u8mIHkAanluWafXAp/Learn?node-id=2741-10473&m=dev).

These templates for Sensei Learning Mode [appear to be dynamically created](https://github.com/Automattic/sensei/blob/af62fb1115daf2063bc56331a7d8b1b3ea805866/includes/course-theme/class-sensei-course-theme-templates.php#L71), and [don't seem to be able to be overridden in the normal fashion](https://senseilms.com/documentation/theming/#sensei-lms-theming), so they've been copied into the theme as patterns. A `single_template_hierarchy` filter is then used to inject our single lesson template instead of the Sensei one, and it then loads the patterns. I did try adding `templates/single-lesson.html` and `templates/lesson.html` and the php equivalents, but the Sensei plugin template was always loaded.

## Screenshots

### Lesson

| Desktop | Tablet | Mobile |
|-|-|-|
| ![localhost_8888_lesson_wordpress-and-web-servers_(Desktop) (1)](https://github.com/WordPress/Learn/assets/1017872/ab7226e4-4192-4655-ae48-338f787c627c) | ![localhost_8888_lesson_wordpress-and-web-servers_(iPad)](https://github.com/WordPress/Learn/assets/1017872/dd612a10-73ae-45e0-9f95-dbe662dd5703) | ![localhost_8888_lesson_wordpress-and-web-servers_(Samsung Galaxy S20 Ultra)](https://github.com/WordPress/Learn/assets/1017872/d1d4c14a-c23e-49f3-96a2-06d0ef9d9ed4) |

### Lesson Quiz

### Screenshots

| Default | Graded | Mobile |
|-|-|-|
| ![localhost_8888_quiz_wordpress-and-web-servers_(Desktop) (1)](https://github.com/WordPress/Learn/assets/1017872/0cc7cdb1-08e5-47ec-bad6-e82c0a7f76a3) | ![localhost_8888_quiz_wordpress-and-web-servers_(Desktop)](https://github.com/WordPress/Learn/assets/1017872/35f3d038-65f6-409f-a337-48fa0f603965) | ![localhost_8888_quiz_wordpress-and-web-servers_(Samsung Galaxy S20 Ultra)](https://github.com/WordPress/Learn/assets/1017872/0b7ccd15-56bd-403e-afe6-994ba97ae59b) |

