### PR TITLE
Add Learning Pathway template content

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2024/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2024/functions.php
@@ -142,7 +142,6 @@ function add_site_navigation_menus( $menus ) {
  * Get the titles and descriptions for the learning pathway levels.
  *
  * @param string $learning_pathway The learning pathway name.
- * @param string $level The level name.
  * @return array The content for the learning pathway levels.
  */
 function get_learning_pathway_level_content( $learning_pathway ) {

--- a/wp-content/themes/pub/wporg-learn-2024/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2024/functions.php
@@ -148,58 +148,58 @@ function get_learning_pathway_level_content( $learning_pathway ) {
 	$content = array(
 		'developer' => array(
 			'beginner' => array(
-				'title' => 'Beginner developer title',
-				'description'  => 'Beginner developer description',
+				'title' => __( '[TBD Beginner developer title]', 'wporg-learn' ),
+				'description' => __( '[TBD Beginner developer description]', 'wporg-learn' ),
 			),
 			'intermediate' => array(
-				'title' => 'Intermediate developer title',
-				'description'  => 'Intermediate developer description',
+				'title' => __( '[TBD Intermediate developer title]', 'wporg-learn' ),
+				'description' => __( '[TBD Intermediate developer description]', 'wporg-learn' ),
 			),
 			'advanced' => array(
-				'title' => 'Advanced developer title',
-				'description'  => 'Advanced developer description',
+				'title' => __( '[TBD Advanced developer title]', 'wporg-learn' ),
+				'description' => __( '[TBD Advanced developer description]', 'wporg-learn' ),
 			),
 		),
 		'designer' => array(
 			'beginner' => array(
-				'title' => 'Begin exploring WordPress',
-				'description'  => 'Discover the design potential of WordPress.',
+				'title' => __( 'Begin exploring WordPress', 'wporg-learn' ),
+				'description' => __( 'Discover the design potential of WordPress.', 'wporg-learn' ),
 			),
 			'intermediate' => array(
-				'title' => 'Customize your site',
-				'description'  => 'Personalize and own all the details of your WordPress site.',
+				'title' => __( 'Customize your site', 'wporg-learn' ),
+				'description' => __( 'Personalize and own all the details of your WordPress site.', 'wporg-learn' ),
 			),
 			'advanced' => array(
-				'title' => 'Elevate your site to stunning levels',
-				'description'  => 'For advanced users that are familiar with code.',
+				'title' => __( 'Elevate your site to stunning levels', 'wporg-learn' ),
+				'description' => __( 'For advanced users that are familiar with code.', 'wporg-learn' ),
 			),
 		),
 		'user' => array(
 			'beginner' => array(
-				'title' => 'Beginner user title',
-				'description'  => 'Beginner user description',
+				'title' => __( '[TBD Beginner user title]', 'wporg-learn' ),
+				'description' => __( '[TBD Beginner user description]', 'wporg-learn' ),
 			),
 			'intermediate' => array(
-				'title' => 'Intermediate user title',
-				'description'  => 'Intermediate user description',
+				'title' => __( '[TBD Intermediate user title]', 'wporg-learn' ),
+				'description' => __( '[TBD Intermediate user description]', 'wporg-learn' ),
 			),
 			'advanced' => array(
-				'title' => 'Advanced user title',
-				'description'  => 'Advanced user description',
+				'title' => __( '[TBD Advanced user title]', 'wporg-learn' ),
+				'description' => __( '[TBD Advanced user description]', 'wporg-learn' ),
 			),
 		),
 		'contributor' => array(
 			'beginner' => array(
-				'title' => 'Beginner contributor title',
-				'description'  => 'Beginner contributor description',
+				'title' => __( '[TBD Beginner contributor title]', 'wporg-learn' ),
+				'description' => __( '[TBD Beginner contributor description]', 'wporg-learn' ),
 			),
 			'intermediate' => array(
-				'title' => 'Intermediate contributor title',
-				'description'  => 'Intermediate contributor description',
+				'title' => __( '[TBD Intermediate contributor title]', 'wporg-learn' ),
+				'description' => __( '[TBD Intermediate contributor description]', 'wporg-learn' ),
 			),
 			'advanced' => array(
-				'title' => 'Advanced contributor title',
-				'description'  => 'Advanced contributor description',
+				'title' => __( '[TBD Advanced contributor title]', 'wporg-learn' ),
+				'description' => __( '[TBD Advanced contributor description]', 'wporg-learn' ),
 			),
 		),
 	);

--- a/wp-content/themes/pub/wporg-learn-2024/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2024/functions.php
@@ -137,3 +137,73 @@ function add_site_navigation_menus( $menus ) {
 
 	return $menus;
 }
+
+/**
+ * Get the titles and descriptions for the learning pathway levels.
+ *
+ * @param string $learning_pathway The learning pathway name.
+ * @param string $level The level name.
+ * @return array The content for the learning pathway levels.
+ */
+function get_learning_pathway_level_content( $learning_pathway ) {
+	$content = array(
+		'developer' => array(
+			'beginner' => array(
+				'title' => 'Beginner developer title',
+				'description'  => 'Beginner developer description',
+			),
+			'intermediate' => array(
+				'title' => 'Intermediate developer title',
+				'description'  => 'Intermediate developer description',
+			),
+			'advanced' => array(
+				'title' => 'Advanced developer title',
+				'description'  => 'Advanced developer description',
+			),
+		),
+		'designer' => array(
+			'beginner' => array(
+				'title' => 'Begin exploring WordPress',
+				'description'  => 'Discover the design potential of WordPress.',
+			),
+			'intermediate' => array(
+				'title' => 'Customize your site',
+				'description'  => 'Personalize and own all the details of your WordPress site.',
+			),
+			'advanced' => array(
+				'title' => 'Elevate your site to stunning levels',
+				'description'  => 'For advanced users that are familiar with code.',
+			),
+		),
+		'user' => array(
+			'beginner' => array(
+				'title' => 'Beginner user title',
+				'description'  => 'Beginner user description',
+			),
+			'intermediate' => array(
+				'title' => 'Intermediate user title',
+				'description'  => 'Intermediate user description',
+			),
+			'advanced' => array(
+				'title' => 'Advanced user title',
+				'description'  => 'Advanced user description',
+			),
+		),
+		'contributor' => array(
+			'beginner' => array(
+				'title' => 'Beginner contributor title',
+				'description'  => 'Beginner contributor description',
+			),
+			'intermediate' => array(
+				'title' => 'Intermediate contributor title',
+				'description'  => 'Intermediate contributor description',
+			),
+			'advanced' => array(
+				'title' => 'Advanced contributor title',
+				'description'  => 'Advanced contributor description',
+			),
+		),
+	);
+
+	return $content[ $learning_pathway ];
+}

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/taxonomy-learning-pathway-content.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/taxonomy-learning-pathway-content.php
@@ -18,6 +18,28 @@ $advanced_level_id = get_term_by( 'slug', 'advanced', 'level' )->term_id;
 $content = get_learning_pathway_level_content( $learning_pathway_slug );
 ?>
 
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","top":"0","bottom":"0"}},"border":{"bottom":{"color":"var:preset|color|light-grey-1","width":"1px"}}},"backgroundColor":"<?php echo esc_attr( $learning_pathway_slug ); ?>","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull has-<?php echo esc_attr( $learning_pathway_slug ); ?>-background-color has-background" style="border-bottom-color:var(--wp--preset--color--light-grey-1);border-bottom-width:1px;padding-top:0;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:0;padding-left:var(--wp--preset--spacing--edge-space)">
+
+	<!-- wp:group {"style":{"spacing":{"blockGap":"0"},"background":{"backgroundImage":{"url":"<?php echo esc_url( get_stylesheet_directory_uri() . '/assets/learning-pathway-' . $learning_pathway_slug . '.svg' ); ?>","source":"file"},"backgroundRepeat":"no-repeat","backgroundSize":"contain","backgroundPosition":"100% 50%"}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between","verticalAlignment":"stretch"}} -->
+	<div class="wp-block-group">
+		
+		<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}},"layout":{"selfStretch":"fixed","flexSize":"60%"}},"layout":{"type":"constrained"}} -->
+		<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)">
+
+			<!-- wp:query-title {"type":"archive","showPrefix":false,"style":{"typography":{"fontSize":"50px"}}} /-->
+
+			<!-- wp:term-description /-->
+
+		</div>
+		<!-- /wp:group -->
+
+	</div>
+	<!-- /wp:group -->
+
+</div>
+<!-- /wp:group -->
+
 <!-- wp:heading {"style":{"spacing":{"margin":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|10"}}}} -->
 <h2 class="wp-block-heading" style="margin-top:var(--wp--preset--spacing--60);margin-bottom:var(--wp--preset--spacing--10)"><?php echo esc_html( $content['beginner']['title'] ); ?></h2>
 <!-- /wp:heading -->

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/taxonomy-learning-pathway-content.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/taxonomy-learning-pathway-content.php
@@ -1,0 +1,247 @@
+<?php
+/**
+ * Title: Taxonomy Learning Pathway Content
+ * Slug: wporg-learn-2024/taxonomy-learning-pathway-content
+ * Inserter: no
+ */
+
+use function WordPressdotorg\Theme\Learn_2024\{get_learning_pathway_level_content};
+
+$learning_pathway_object = get_queried_object();
+$learning_pathway_id = $learning_pathway_object->term_id;
+$learning_pathway_slug = $learning_pathway_object->slug;
+
+$beginner_level_id = get_term_by( 'slug', 'beginner', 'level' )->term_id;
+$intermediate_level_id = get_term_by( 'slug', 'intermediate', 'level' )->term_id;
+$advanced_level_id = get_term_by( 'slug', 'advanced', 'level' )->term_id;
+
+$content = get_learning_pathway_level_content( $learning_pathway_slug );
+?>
+
+<!-- wp:heading {"style":{"spacing":{"margin":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|10"}}}} -->
+<h2 class="wp-block-heading" style="margin-top:var(--wp--preset--spacing--60);margin-bottom:var(--wp--preset--spacing--10)"><?php echo esc_html( $content['beginner']['title'] ); ?></h2>
+<!-- /wp:heading -->
+
+<!-- wp:group {"style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|40"}}},"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
+<div class="wp-block-group" style="margin-top:0;margin-bottom:var(--wp--preset--spacing--40)">
+
+	<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|charcoal-4"}}}},"textColor":"charcoal-4"} -->
+	<p class="has-charcoal-4-color has-text-color has-link-color"><?php echo esc_html( $content['beginner']['description'] ); ?></p>
+	<!-- /wp:paragraph -->
+
+	<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}}},"textColor":"charcoal-4"} -->
+	<p class="has-charcoal-4-color has-text-color has-link-color"><a href="<?php echo esc_url( site_url( '/courses/?wporg_learning_pathway=' . $learning_pathway_slug . '&wporg_lesson_level=beginner' ) ); ?>"><?php esc_html_e( 'See all', 'wporg-learn' ); ?></a></p>
+	<!-- /wp:paragraph -->
+
+</div>
+<!-- /wp:group -->
+
+<!-- wp:query {"queryId":0,"query":{"perPage":3,"postType":"course","courseFeatured":false,"taxQuery":{"level":[<?php echo esc_attr( $beginner_level_id ); ?>],"learning-pathway":[<?php echo esc_attr( $learning_pathway_id ); ?>]},"inherit":false},"namespace":"wporg-learn/course-grid","align":"wide","className":"wporg-learn-course-grid"} -->
+<div class="wp-block-query alignwide wporg-learn-course-grid">
+
+	<!-- wp:post-template {"style":{"spacing":{"blockGap":"var:preset|spacing|50"}},"layout":{"type":"grid","columnCount":null,"minimumColumnWidth":"330px"}} -->
+
+		<!-- wp:group {"style":{"border":{"width":"1px","color":"var:preset|color|light-grey-1","radius":"2px"},"spacing":{"blockGap":"0"},"dimensions":{"minHeight":"100%"}},"backgroundColor":"white","layout":{"type":"flex","orientation":"vertical"}} -->
+		<div class="wp-block-group has-border-color has-white-background-color has-background" style="border-color:var(--wp--preset--color--light-grey-1);border-width:1px;border-radius:2px;min-height:100%">
+
+			<!-- wp:post-featured-image {"style":{"spacing":{"margin":{"bottom":"0"}}}} /-->
+
+			<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"20px","right":"20px"}}},"layout":{"type":"constrained"}} -->
+			<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--20);padding-right:20px;padding-bottom:var(--wp--preset--spacing--20);padding-left:20px">
+
+				<!-- wp:post-title {"level":3,"isLink":true,"style":{"typography":{"fontStyle":"normal","fontWeight":"600","lineHeight":1.6},"spacing":{"margin":{"bottom":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}}},"fontSize":"normal","fontFamily":"inter"} /-->
+
+				<!-- wp:post-excerpt {"showMoreOnNewLine":false,"excerptLength":16,"style":{"spacing":{"margin":{"top":"var:preset|spacing|10"}},"typography":{"lineHeight":1.6}}} /-->
+
+				<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"left"}} -->
+				<div class="wp-block-group">
+
+					<!-- wp:wporg-learn/learning-duration {"style":{"elements":{"link":{"color":{"text":"var:preset|color|charcoal-4"}}}},"textColor":"charcoal-4","fontSize":"small"} /-->
+
+					<!-- wp:wporg-learn/lesson-count {"style":{"layout":{"selfStretch":"fill","flexSize":null}},"fontSize":"extra-small"} /-->
+
+					<!-- wp:wporg-learn/course-status {"fontSize":"extra-small"} /-->
+
+				</div>
+				<!-- /wp:group -->
+
+			</div>
+			<!-- /wp:group -->
+
+		</div>
+		<!-- /wp:group -->
+
+	<!-- /wp:post-template -->
+
+	<!-- wp:query-no-results -->
+
+		<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
+		<p><?php esc_html_e( 'No beginner Courses found.', 'wporg-learn' ); ?></p>
+		<!-- /wp:paragraph -->
+
+	<!-- /wp:query-no-results -->
+
+	<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"}} -->
+
+		<!-- wp:query-pagination-previous {"label":"Previous"} /-->
+
+		<!-- wp:query-pagination-numbers /-->
+
+		<!-- wp:query-pagination-next {"label":"Next"} /-->
+
+	<!-- /wp:query-pagination -->
+
+</div>
+<!-- /wp:query -->
+
+<!-- wp:heading {"style":{"spacing":{"margin":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|10"}}}} -->
+<h2 class="wp-block-heading" style="margin-top:var(--wp--preset--spacing--60);margin-bottom:var(--wp--preset--spacing--10)"><?php echo esc_html( $content['intermediate']['title'] ); ?></h2>
+<!-- /wp:heading -->
+
+<!-- wp:group {"style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|40"}}},"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
+<div class="wp-block-group" style="margin-top:0;margin-bottom:var(--wp--preset--spacing--40)">
+
+	<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|charcoal-4"}}}},"textColor":"charcoal-4"} -->
+	<p class="has-charcoal-4-color has-text-color has-link-color"><?php echo esc_html( $content['intermediate']['description'] ); ?></p>
+	<!-- /wp:paragraph -->
+
+	<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}}},"textColor":"charcoal-4"} -->
+	<p class="has-charcoal-4-color has-text-color has-link-color"><a href="<?php echo esc_url( site_url( '/courses/?wporg_learning_pathway=' . $learning_pathway_slug . '&wporg_lesson_level=intermediate' ) ); ?>"><?php esc_html_e( 'See all', 'wporg-learn' ); ?></a></p>
+	<!-- /wp:paragraph -->
+
+</div>
+<!-- /wp:group -->
+
+<!-- wp:query {"queryId":1,"query":{"perPage":3,"postType":"course","courseFeatured":false,"taxQuery":{"level":[<?php echo esc_html( $intermediate_level_id ); ?>],"learning-pathway":[<?php echo esc_html( $learning_pathway_id ); ?>]},"inherit":false},"namespace":"wporg-learn/course-grid","align":"wide","className":"wporg-learn-course-grid"} -->
+<div class="wp-block-query alignwide wporg-learn-course-grid">
+
+	<!-- wp:post-template {"style":{"spacing":{"blockGap":"var:preset|spacing|50"}},"layout":{"type":"grid","columnCount":null,"minimumColumnWidth":"330px"}} -->
+
+		<!-- wp:group {"style":{"border":{"width":"1px","color":"var:preset|color|light-grey-1","radius":"2px"},"spacing":{"blockGap":"0"},"dimensions":{"minHeight":"100%"}},"backgroundColor":"white","layout":{"type":"flex","orientation":"vertical"}} -->
+		<div class="wp-block-group has-border-color has-white-background-color has-background" style="border-color:var(--wp--preset--color--light-grey-1);border-width:1px;border-radius:2px;min-height:100%">
+
+			<!-- wp:post-featured-image {"style":{"spacing":{"margin":{"bottom":"0"}}}} /-->
+
+			<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"20px","right":"20px"}}},"layout":{"type":"constrained"}} -->
+			<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--20);padding-right:20px;padding-bottom:var(--wp--preset--spacing--20);padding-left:20px">
+
+				<!-- wp:post-title {"level":3,"isLink":true,"style":{"typography":{"fontStyle":"normal","fontWeight":"600","lineHeight":1.6},"spacing":{"margin":{"bottom":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}}},"fontSize":"normal","fontFamily":"inter"} /-->
+
+				<!-- wp:post-excerpt {"showMoreOnNewLine":false,"excerptLength":16,"style":{"spacing":{"margin":{"top":"var:preset|spacing|10"}},"typography":{"lineHeight":1.6}}} /-->
+
+				<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"left"}} -->
+				<div class="wp-block-group">
+
+					<!-- wp:wporg-learn/learning-duration {"style":{"elements":{"link":{"color":{"text":"var:preset|color|charcoal-4"}}}},"textColor":"charcoal-4","fontSize":"small"} /-->
+
+					<!-- wp:wporg-learn/lesson-count {"style":{"layout":{"selfStretch":"fill","flexSize":null}},"fontSize":"extra-small"} /-->
+
+					<!-- wp:wporg-learn/course-status {"fontSize":"extra-small"} /-->
+
+				</div>
+				<!-- /wp:group -->
+
+			</div>
+			<!-- /wp:group -->
+
+		</div>
+		<!-- /wp:group -->
+
+	<!-- /wp:post-template -->
+
+	<!-- wp:query-no-results -->
+
+		<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
+		<p><?php esc_html_e( 'No intermediate Courses found.', 'wporg-learn' ); ?></p>
+		<!-- /wp:paragraph -->
+
+	<!-- /wp:query-no-results -->
+
+	<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"}} -->
+
+		<!-- wp:query-pagination-previous {"label":"Previous"} /-->
+
+		<!-- wp:query-pagination-numbers /-->
+
+		<!-- wp:query-pagination-next {"label":"Next"} /-->
+
+	<!-- /wp:query-pagination -->
+
+</div>
+<!-- /wp:query -->
+
+<!-- wp:heading {"style":{"spacing":{"margin":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|10"}}}} -->
+<h2 class="wp-block-heading" style="margin-top:var(--wp--preset--spacing--60);margin-bottom:var(--wp--preset--spacing--10)"><?php echo esc_html( $content['advanced']['title'] ); ?></h2>
+<!-- /wp:heading -->
+
+<!-- wp:group {"style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|40"}}},"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
+<div class="wp-block-group" style="margin-top:0;margin-bottom:var(--wp--preset--spacing--40)">
+
+	<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|charcoal-4"}}}},"textColor":"charcoal-4"} -->
+	<p class="has-charcoal-4-color has-text-color has-link-color"><?php echo esc_html( $content['advanced']['description'] ); ?></p>
+	<!-- /wp:paragraph -->
+
+	<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}}},"textColor":"charcoal-4"} -->
+	<p class="has-charcoal-4-color has-text-color has-link-color"><a href="<?php echo esc_url( site_url( '/courses/?wporg_learning_pathway=' . $learning_pathway_slug . '&wporg_lesson_level=advanced' ) ); ?>"><?php esc_html_e( 'See all', 'wporg-learn' ); ?></a></p>
+	<!-- /wp:paragraph -->
+
+</div>
+<!-- /wp:group -->
+
+<!-- wp:query {"queryId":1,"query":{"perPage":3,"postType":"course","courseFeatured":false,"taxQuery":{"level":[<?php echo esc_html( $advanced_level_id ); ?>],"learning-pathway":[<?php echo esc_html( $learning_pathway_id ); ?>]},"inherit":false},"namespace":"wporg-learn/course-grid","align":"wide","className":"wporg-learn-course-grid"} -->
+<div class="wp-block-query alignwide wporg-learn-course-grid">
+
+	<!-- wp:post-template {"style":{"spacing":{"blockGap":"var:preset|spacing|50"}},"layout":{"type":"grid","columnCount":null,"minimumColumnWidth":"330px"}} -->
+
+		<!-- wp:group {"style":{"border":{"width":"1px","color":"var:preset|color|light-grey-1","radius":"2px"},"spacing":{"blockGap":"0"},"dimensions":{"minHeight":"100%"}},"backgroundColor":"white","layout":{"type":"flex","orientation":"vertical"}} -->
+		<div class="wp-block-group has-border-color has-white-background-color has-background" style="border-color:var(--wp--preset--color--light-grey-1);border-width:1px;border-radius:2px;min-height:100%">
+
+			<!-- wp:post-featured-image {"style":{"spacing":{"margin":{"bottom":"0"}}}} /-->
+
+			<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"20px","right":"20px"}}},"layout":{"type":"constrained"}} -->
+			<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--20);padding-right:20px;padding-bottom:var(--wp--preset--spacing--20);padding-left:20px">
+
+				<!-- wp:post-title {"level":3,"isLink":true,"style":{"typography":{"fontStyle":"normal","fontWeight":"600","lineHeight":1.6},"spacing":{"margin":{"bottom":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}}},"fontSize":"normal","fontFamily":"inter"} /-->
+
+				<!-- wp:post-excerpt {"showMoreOnNewLine":false,"excerptLength":16,"style":{"spacing":{"margin":{"top":"var:preset|spacing|10"}},"typography":{"lineHeight":1.6}}} /-->
+
+				<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"left"}} -->
+				<div class="wp-block-group">
+
+					<!-- wp:wporg-learn/learning-duration {"style":{"elements":{"link":{"color":{"text":"var:preset|color|charcoal-4"}}}},"textColor":"charcoal-4","fontSize":"small"} /-->
+
+					<!-- wp:wporg-learn/lesson-count {"style":{"layout":{"selfStretch":"fill","flexSize":null}},"fontSize":"extra-small"} /-->
+
+					<!-- wp:wporg-learn/course-status {"fontSize":"extra-small"} /-->
+
+				</div>
+				<!-- /wp:group -->
+
+			</div>
+			<!-- /wp:group -->
+
+		</div>
+		<!-- /wp:group -->
+
+	<!-- /wp:post-template -->
+
+	<!-- wp:query-no-results -->
+
+		<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
+		<p><?php esc_html_e( 'No advanced Courses found.', 'wporg-learn' ); ?></p>
+		<!-- /wp:paragraph -->
+
+	<!-- /wp:query-no-results -->
+
+	<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"}} -->
+
+		<!-- wp:query-pagination-previous {"label":"Previous"} /-->
+
+		<!-- wp:query-pagination-numbers /-->
+
+		<!-- wp:query-pagination-next {"label":"Next"} /-->
+
+	<!-- /wp:query-pagination -->
+
+</div>
+<!-- /wp:query -->

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/taxonomy-learning-pathway-content.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/taxonomy-learning-pathway-content.php
@@ -105,7 +105,7 @@ $content = get_learning_pathway_level_content( $learning_pathway_slug );
 		<!-- wp:query-no-results -->
 
 			<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results.","style":{"spacing":{"margin":{"top":"-20px"}}}} -->
-			<p style="margin-top:-20px"><?php esc_html_e( 'No beginner Courses found.', 'wporg-learn' ); ?></p>
+			<p style="margin-top:-20px"><?php esc_html_e( 'No beginner pathways found.', 'wporg-learn' ); ?></p>
 			<!-- /wp:paragraph -->
 
 		<!-- /wp:query-no-results -->
@@ -171,7 +171,7 @@ $content = get_learning_pathway_level_content( $learning_pathway_slug );
 		<!-- wp:query-no-results -->
 
 			<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results.","style":{"spacing":{"margin":{"top":"-20px"}}}} -->
-			<p style="margin-top:-20px"><?php esc_html_e( 'No intermediate Courses found.', 'wporg-learn' ); ?></p>
+			<p style="margin-top:-20px"><?php esc_html_e( 'No intermediate pathways found.', 'wporg-learn' ); ?></p>
 			<!-- /wp:paragraph -->
 
 		<!-- /wp:query-no-results -->
@@ -237,7 +237,7 @@ $content = get_learning_pathway_level_content( $learning_pathway_slug );
 		<!-- wp:query-no-results -->
 
 			<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results.","style":{"spacing":{"margin":{"top":"-20px"}}}} -->
-			<p style="margin-top:-20px"><?php esc_html_e( 'No advanced Courses found.', 'wporg-learn' ); ?></p>
+			<p style="margin-top:-20px"><?php esc_html_e( 'No advanced pathways found.', 'wporg-learn' ); ?></p>
 			<!-- /wp:paragraph -->
 
 		<!-- /wp:query-no-results -->

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/taxonomy-learning-pathway-content.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/taxonomy-learning-pathway-content.php
@@ -18,20 +18,24 @@ $advanced_level_id = get_term_by( 'slug', 'advanced', 'level' )->term_id;
 $content = get_learning_pathway_level_content( $learning_pathway_slug );
 ?>
 
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","top":"0","bottom":"0"}},"border":{"bottom":{"color":"var:preset|color|light-grey-1","width":"1px"}}},"backgroundColor":"<?php echo esc_attr( $learning_pathway_slug ); ?>","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull has-<?php echo esc_attr( $learning_pathway_slug ); ?>-background-color has-background" style="border-bottom-color:var(--wp--preset--color--light-grey-1);border-bottom-width:1px;padding-top:0;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:0;padding-left:var(--wp--preset--spacing--edge-space)">
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","top":"0","bottom":"0"}},"border":{"bottom":{"color":"var:preset|color|light-grey-1","width":"1px"}}},"backgroundColor":"<?php echo esc_attr( $learning_pathway_slug ); ?>","className":"wporg-learn-tax-learning-pathway-header","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull has-<?php echo esc_attr( $learning_pathway_slug ); ?>-background-color has-background wporg-learn-tax-learning-pathway-header" style="border-bottom-color:var(--wp--preset--color--light-grey-1);border-bottom-width:1px;padding-top:0;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:0;padding-left:var(--wp--preset--spacing--edge-space)">
 
-	<!-- wp:group {"style":{"spacing":{"blockGap":"0"},"background":{"backgroundImage":{"url":"<?php echo esc_url( get_stylesheet_directory_uri() . '/assets/learning-pathway-' . $learning_pathway_slug . '.svg' ); ?>","source":"file"},"backgroundRepeat":"no-repeat","backgroundSize":"contain","backgroundPosition":"100% 50%"}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between","verticalAlignment":"stretch"}} -->
+	<!-- wp:group {"style":{"spacing":{"blockGap":"0"},"background":{"backgroundRepeat":"no-repeat","backgroundSize":"contain","backgroundPosition":"100% 50%"}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between","verticalAlignment":"stretch"}} -->
 	<div class="wp-block-group">
 		
-		<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}},"layout":{"selfStretch":"fixed","flexSize":"60%"}},"layout":{"type":"constrained"}} -->
+		<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}},"layout":{"selfStretch":"fill","flexSize":null}},"layout":{"type":"constrained"}} -->
 		<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)">
 
-			<!-- wp:query-title {"type":"archive","showPrefix":false,"style":{"typography":{"fontSize":"50px"}}} /-->
+			<!-- wp:query-title {"type":"archive","showPrefix":false,"fontSize":"heading-1"} /-->
 
-			<!-- wp:term-description /-->
+			<!-- wp:term-description {"style":{"typography":{"lineHeight":1.6}}} /-->
 
 		</div>
+		<!-- /wp:group -->
+
+		<!-- wp:group {"style":{"layout":{"selfStretch":"fixed","flexSize":"33%"},"background":{"backgroundImage":{"url":"<?php echo esc_url( get_stylesheet_directory_uri() . '/assets/learning-pathway-' . $learning_pathway_slug . '.svg' ); ?>","source":"file"},"backgroundPosition":"0% 50%"}},"layout":{"type":"constrained"}} -->
+		<div class="wp-block-group"></div>
 		<!-- /wp:group -->
 
 	</div>
@@ -40,49 +44,55 @@ $content = get_learning_pathway_level_content( $learning_pathway_slug );
 </div>
 <!-- /wp:group -->
 
-<!-- wp:heading {"style":{"spacing":{"margin":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|10"}}}} -->
-<h2 class="wp-block-heading" style="margin-top:var(--wp--preset--spacing--60);margin-bottom:var(--wp--preset--spacing--10)"><?php echo esc_html( $content['beginner']['title'] ); ?></h2>
-<!-- /wp:heading -->
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space","top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60)">
 
-<!-- wp:group {"style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|40"}}},"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group" style="margin-top:0;margin-bottom:var(--wp--preset--spacing--40)">
+	<!-- wp:heading {"style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|10"}}}} -->
+	<h2 class="wp-block-heading" style="margin-top:0;margin-bottom:var(--wp--preset--spacing--10)"><?php echo esc_html( $content['beginner']['title'] ); ?></h2>
+	<!-- /wp:heading -->
 
-	<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|charcoal-4"}}}},"textColor":"charcoal-4"} -->
-	<p class="has-charcoal-4-color has-text-color has-link-color"><?php echo esc_html( $content['beginner']['description'] ); ?></p>
-	<!-- /wp:paragraph -->
+	<!-- wp:group {"style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|40"}}},"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
+	<div class="wp-block-group" style="margin-top:0;margin-bottom:var(--wp--preset--spacing--40)">
 
-	<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}}},"textColor":"charcoal-4"} -->
-	<p class="has-charcoal-4-color has-text-color has-link-color"><a href="<?php echo esc_url( site_url( '/courses/?wporg_learning_pathway=' . $learning_pathway_slug . '&wporg_lesson_level=beginner' ) ); ?>"><?php esc_html_e( 'See all', 'wporg-learn' ); ?></a></p>
-	<!-- /wp:paragraph -->
+		<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|charcoal-4"}}}},"textColor":"charcoal-4"} -->
+		<p class="has-charcoal-4-color has-text-color has-link-color"><?php echo esc_html( $content['beginner']['description'] ); ?></p>
+		<!-- /wp:paragraph -->
 
-</div>
-<!-- /wp:group -->
+		<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}}},"textColor":"charcoal-4"} -->
+		<p class="has-charcoal-4-color has-text-color has-link-color"><a href="<?php echo esc_url( site_url( '/courses/?wporg_learning_pathway=' . $learning_pathway_slug . '&wporg_lesson_level=beginner' ) ); ?>"><?php esc_html_e( 'See all', 'wporg-learn' ); ?></a></p>
+		<!-- /wp:paragraph -->
 
-<!-- wp:query {"queryId":0,"query":{"perPage":3,"postType":"course","courseFeatured":false,"taxQuery":{"level":[<?php echo esc_attr( $beginner_level_id ); ?>],"learning-pathway":[<?php echo esc_attr( $learning_pathway_id ); ?>]},"inherit":false},"namespace":"wporg-learn/course-grid","align":"wide","className":"wporg-learn-course-grid"} -->
-<div class="wp-block-query alignwide wporg-learn-course-grid">
+	</div>
+	<!-- /wp:group -->
 
-	<!-- wp:post-template {"style":{"spacing":{"blockGap":"var:preset|spacing|50"}},"layout":{"type":"grid","columnCount":null,"minimumColumnWidth":"330px"}} -->
+	<!-- wp:query {"queryId":0,"query":{"perPage":3,"postType":"course","courseFeatured":false,"taxQuery":{"level":[<?php echo esc_attr( $beginner_level_id ); ?>],"learning-pathway":[<?php echo esc_attr( $learning_pathway_id ); ?>]},"inherit":false},"namespace":"wporg-learn/course-grid","align":"wide","className":"wporg-learn-course-grid"} -->
+	<div class="wp-block-query alignwide wporg-learn-course-grid">
 
-		<!-- wp:group {"style":{"border":{"width":"1px","color":"var:preset|color|light-grey-1","radius":"2px"},"spacing":{"blockGap":"0"},"dimensions":{"minHeight":"100%"}},"backgroundColor":"white","layout":{"type":"flex","orientation":"vertical"}} -->
-		<div class="wp-block-group has-border-color has-white-background-color has-background" style="border-color:var(--wp--preset--color--light-grey-1);border-width:1px;border-radius:2px;min-height:100%">
+		<!-- wp:post-template {"style":{"spacing":{"blockGap":"var:preset|spacing|50"}},"layout":{"type":"grid","columnCount":null,"minimumColumnWidth":"330px"}} -->
 
-			<!-- wp:post-featured-image {"style":{"spacing":{"margin":{"bottom":"0"}}}} /-->
+			<!-- wp:group {"style":{"border":{"width":"1px","color":"var:preset|color|light-grey-1","radius":"2px"},"spacing":{"blockGap":"0"},"dimensions":{"minHeight":"100%"}},"backgroundColor":"white","layout":{"type":"flex","orientation":"vertical"}} -->
+			<div class="wp-block-group has-border-color has-white-background-color has-background" style="border-color:var(--wp--preset--color--light-grey-1);border-width:1px;border-radius:2px;min-height:100%">
 
-			<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"20px","right":"20px"}}},"layout":{"type":"constrained"}} -->
-			<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--20);padding-right:20px;padding-bottom:var(--wp--preset--spacing--20);padding-left:20px">
+				<!-- wp:post-featured-image {"style":{"spacing":{"margin":{"bottom":"0"}}}} /-->
 
-				<!-- wp:post-title {"level":3,"isLink":true,"style":{"typography":{"fontStyle":"normal","fontWeight":"600","lineHeight":1.6},"spacing":{"margin":{"bottom":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}}},"fontSize":"normal","fontFamily":"inter"} /-->
+				<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"20px","right":"20px"}}},"layout":{"type":"constrained"}} -->
+				<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--20);padding-right:20px;padding-bottom:var(--wp--preset--spacing--20);padding-left:20px">
 
-				<!-- wp:post-excerpt {"showMoreOnNewLine":false,"excerptLength":16,"style":{"spacing":{"margin":{"top":"var:preset|spacing|10"}},"typography":{"lineHeight":1.6}}} /-->
+					<!-- wp:post-title {"level":3,"isLink":true,"style":{"typography":{"fontStyle":"normal","fontWeight":"600","lineHeight":1.6},"spacing":{"margin":{"bottom":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}}},"fontSize":"normal","fontFamily":"inter"} /-->
 
-				<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"left"}} -->
-				<div class="wp-block-group">
+					<!-- wp:post-excerpt {"showMoreOnNewLine":false,"excerptLength":16,"style":{"spacing":{"margin":{"top":"var:preset|spacing|10"}},"typography":{"lineHeight":1.6}}} /-->
 
-					<!-- wp:wporg-learn/learning-duration {"style":{"elements":{"link":{"color":{"text":"var:preset|color|charcoal-4"}}}},"textColor":"charcoal-4","fontSize":"small"} /-->
+					<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"left"}} -->
+					<div class="wp-block-group">
 
-					<!-- wp:wporg-learn/lesson-count {"style":{"layout":{"selfStretch":"fill","flexSize":null}},"fontSize":"extra-small"} /-->
+						<!-- wp:wporg-learn/learning-duration {"style":{"elements":{"link":{"color":{"text":"var:preset|color|charcoal-4"}}}},"textColor":"charcoal-4","fontSize":"small"} /-->
 
-					<!-- wp:wporg-learn/course-status {"fontSize":"extra-small"} /-->
+						<!-- wp:wporg-learn/lesson-count {"style":{"layout":{"selfStretch":"fill","flexSize":null}},"fontSize":"extra-small"} /-->
+
+						<!-- wp:wporg-learn/course-status {"fontSize":"extra-small"} /-->
+
+					</div>
+					<!-- /wp:group -->
 
 				</div>
 				<!-- /wp:group -->
@@ -90,65 +100,65 @@ $content = get_learning_pathway_level_content( $learning_pathway_slug );
 			</div>
 			<!-- /wp:group -->
 
-		</div>
-		<!-- /wp:group -->
+		<!-- /wp:post-template -->
 
-	<!-- /wp:post-template -->
+		<!-- wp:query-no-results -->
 
-	<!-- wp:query-no-results -->
+			<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results.","style":{"spacing":{"margin":{"top":"-20px"}}}} -->
+			<p style="margin-top:-20px"><?php esc_html_e( 'No beginner Courses found.', 'wporg-learn' ); ?></p>
+			<!-- /wp:paragraph -->
 
-		<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results.","style":{"spacing":{"margin":{"top":"-20px"}}}} -->
-		<p style="margin-top:-20px"><?php esc_html_e( 'No beginner Courses found.', 'wporg-learn' ); ?></p>
+		<!-- /wp:query-no-results -->
+
+	</div>
+	<!-- /wp:query -->
+
+	<!-- wp:heading {"style":{"spacing":{"margin":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|10"}}}} -->
+	<h2 class="wp-block-heading" style="margin-top:var(--wp--preset--spacing--60);margin-bottom:var(--wp--preset--spacing--10)"><?php echo esc_html( $content['intermediate']['title'] ); ?></h2>
+	<!-- /wp:heading -->
+
+	<!-- wp:group {"style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|40"}}},"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
+	<div class="wp-block-group" style="margin-top:0;margin-bottom:var(--wp--preset--spacing--40)">
+
+		<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|charcoal-4"}}}},"textColor":"charcoal-4"} -->
+		<p class="has-charcoal-4-color has-text-color has-link-color"><?php echo esc_html( $content['intermediate']['description'] ); ?></p>
 		<!-- /wp:paragraph -->
 
-	<!-- /wp:query-no-results -->
+		<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}}},"textColor":"charcoal-4"} -->
+		<p class="has-charcoal-4-color has-text-color has-link-color"><a href="<?php echo esc_url( site_url( '/courses/?wporg_learning_pathway=' . $learning_pathway_slug . '&wporg_lesson_level=intermediate' ) ); ?>"><?php esc_html_e( 'See all', 'wporg-learn' ); ?></a></p>
+		<!-- /wp:paragraph -->
 
-</div>
-<!-- /wp:query -->
+	</div>
+	<!-- /wp:group -->
 
-<!-- wp:heading {"style":{"spacing":{"margin":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|10"}}}} -->
-<h2 class="wp-block-heading" style="margin-top:var(--wp--preset--spacing--60);margin-bottom:var(--wp--preset--spacing--10)"><?php echo esc_html( $content['intermediate']['title'] ); ?></h2>
-<!-- /wp:heading -->
+	<!-- wp:query {"queryId":1,"query":{"perPage":3,"postType":"course","courseFeatured":false,"taxQuery":{"level":[<?php echo esc_html( $intermediate_level_id ); ?>],"learning-pathway":[<?php echo esc_html( $learning_pathway_id ); ?>]},"inherit":false},"namespace":"wporg-learn/course-grid","align":"wide","className":"wporg-learn-course-grid"} -->
+	<div class="wp-block-query alignwide wporg-learn-course-grid">
 
-<!-- wp:group {"style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|40"}}},"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group" style="margin-top:0;margin-bottom:var(--wp--preset--spacing--40)">
+		<!-- wp:post-template {"style":{"spacing":{"blockGap":"var:preset|spacing|50"}},"layout":{"type":"grid","columnCount":null,"minimumColumnWidth":"330px"}} -->
 
-	<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|charcoal-4"}}}},"textColor":"charcoal-4"} -->
-	<p class="has-charcoal-4-color has-text-color has-link-color"><?php echo esc_html( $content['intermediate']['description'] ); ?></p>
-	<!-- /wp:paragraph -->
+			<!-- wp:group {"style":{"border":{"width":"1px","color":"var:preset|color|light-grey-1","radius":"2px"},"spacing":{"blockGap":"0"},"dimensions":{"minHeight":"100%"}},"backgroundColor":"white","layout":{"type":"flex","orientation":"vertical"}} -->
+			<div class="wp-block-group has-border-color has-white-background-color has-background" style="border-color:var(--wp--preset--color--light-grey-1);border-width:1px;border-radius:2px;min-height:100%">
 
-	<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}}},"textColor":"charcoal-4"} -->
-	<p class="has-charcoal-4-color has-text-color has-link-color"><a href="<?php echo esc_url( site_url( '/courses/?wporg_learning_pathway=' . $learning_pathway_slug . '&wporg_lesson_level=intermediate' ) ); ?>"><?php esc_html_e( 'See all', 'wporg-learn' ); ?></a></p>
-	<!-- /wp:paragraph -->
+				<!-- wp:post-featured-image {"style":{"spacing":{"margin":{"bottom":"0"}}}} /-->
 
-</div>
-<!-- /wp:group -->
+				<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"20px","right":"20px"}}},"layout":{"type":"constrained"}} -->
+				<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--20);padding-right:20px;padding-bottom:var(--wp--preset--spacing--20);padding-left:20px">
 
-<!-- wp:query {"queryId":1,"query":{"perPage":3,"postType":"course","courseFeatured":false,"taxQuery":{"level":[<?php echo esc_html( $intermediate_level_id ); ?>],"learning-pathway":[<?php echo esc_html( $learning_pathway_id ); ?>]},"inherit":false},"namespace":"wporg-learn/course-grid","align":"wide","className":"wporg-learn-course-grid"} -->
-<div class="wp-block-query alignwide wporg-learn-course-grid">
+					<!-- wp:post-title {"level":3,"isLink":true,"style":{"typography":{"fontStyle":"normal","fontWeight":"600","lineHeight":1.6},"spacing":{"margin":{"bottom":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}}},"fontSize":"normal","fontFamily":"inter"} /-->
 
-	<!-- wp:post-template {"style":{"spacing":{"blockGap":"var:preset|spacing|50"}},"layout":{"type":"grid","columnCount":null,"minimumColumnWidth":"330px"}} -->
+					<!-- wp:post-excerpt {"showMoreOnNewLine":false,"excerptLength":16,"style":{"spacing":{"margin":{"top":"var:preset|spacing|10"}},"typography":{"lineHeight":1.6}}} /-->
 
-		<!-- wp:group {"style":{"border":{"width":"1px","color":"var:preset|color|light-grey-1","radius":"2px"},"spacing":{"blockGap":"0"},"dimensions":{"minHeight":"100%"}},"backgroundColor":"white","layout":{"type":"flex","orientation":"vertical"}} -->
-		<div class="wp-block-group has-border-color has-white-background-color has-background" style="border-color:var(--wp--preset--color--light-grey-1);border-width:1px;border-radius:2px;min-height:100%">
+					<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"left"}} -->
+					<div class="wp-block-group">
 
-			<!-- wp:post-featured-image {"style":{"spacing":{"margin":{"bottom":"0"}}}} /-->
+						<!-- wp:wporg-learn/learning-duration {"style":{"elements":{"link":{"color":{"text":"var:preset|color|charcoal-4"}}}},"textColor":"charcoal-4","fontSize":"small"} /-->
 
-			<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"20px","right":"20px"}}},"layout":{"type":"constrained"}} -->
-			<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--20);padding-right:20px;padding-bottom:var(--wp--preset--spacing--20);padding-left:20px">
+						<!-- wp:wporg-learn/lesson-count {"style":{"layout":{"selfStretch":"fill","flexSize":null}},"fontSize":"extra-small"} /-->
 
-				<!-- wp:post-title {"level":3,"isLink":true,"style":{"typography":{"fontStyle":"normal","fontWeight":"600","lineHeight":1.6},"spacing":{"margin":{"bottom":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}}},"fontSize":"normal","fontFamily":"inter"} /-->
+						<!-- wp:wporg-learn/course-status {"fontSize":"extra-small"} /-->
 
-				<!-- wp:post-excerpt {"showMoreOnNewLine":false,"excerptLength":16,"style":{"spacing":{"margin":{"top":"var:preset|spacing|10"}},"typography":{"lineHeight":1.6}}} /-->
-
-				<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"left"}} -->
-				<div class="wp-block-group">
-
-					<!-- wp:wporg-learn/learning-duration {"style":{"elements":{"link":{"color":{"text":"var:preset|color|charcoal-4"}}}},"textColor":"charcoal-4","fontSize":"small"} /-->
-
-					<!-- wp:wporg-learn/lesson-count {"style":{"layout":{"selfStretch":"fill","flexSize":null}},"fontSize":"extra-small"} /-->
-
-					<!-- wp:wporg-learn/course-status {"fontSize":"extra-small"} /-->
+					</div>
+					<!-- /wp:group -->
 
 				</div>
 				<!-- /wp:group -->
@@ -156,65 +166,65 @@ $content = get_learning_pathway_level_content( $learning_pathway_slug );
 			</div>
 			<!-- /wp:group -->
 
-		</div>
-		<!-- /wp:group -->
+		<!-- /wp:post-template -->
 
-	<!-- /wp:post-template -->
+		<!-- wp:query-no-results -->
 
-	<!-- wp:query-no-results -->
+			<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results.","style":{"spacing":{"margin":{"top":"-20px"}}}} -->
+			<p style="margin-top:-20px"><?php esc_html_e( 'No intermediate Courses found.', 'wporg-learn' ); ?></p>
+			<!-- /wp:paragraph -->
 
-		<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results.","style":{"spacing":{"margin":{"top":"-20px"}}}} -->
-		<p style="margin-top:-20px"><?php esc_html_e( 'No intermediate Courses found.', 'wporg-learn' ); ?></p>
+		<!-- /wp:query-no-results -->
+
+	</div>
+	<!-- /wp:query -->
+
+	<!-- wp:heading {"style":{"spacing":{"margin":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|10"}}}} -->
+	<h2 class="wp-block-heading" style="margin-top:var(--wp--preset--spacing--60);margin-bottom:var(--wp--preset--spacing--10)"><?php echo esc_html( $content['advanced']['title'] ); ?></h2>
+	<!-- /wp:heading -->
+
+	<!-- wp:group {"style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|40"}}},"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
+	<div class="wp-block-group" style="margin-top:0;margin-bottom:var(--wp--preset--spacing--40)">
+
+		<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|charcoal-4"}}}},"textColor":"charcoal-4"} -->
+		<p class="has-charcoal-4-color has-text-color has-link-color"><?php echo esc_html( $content['advanced']['description'] ); ?></p>
 		<!-- /wp:paragraph -->
 
-	<!-- /wp:query-no-results -->
+		<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}}},"textColor":"charcoal-4"} -->
+		<p class="has-charcoal-4-color has-text-color has-link-color"><a href="<?php echo esc_url( site_url( '/courses/?wporg_learning_pathway=' . $learning_pathway_slug . '&wporg_lesson_level=advanced' ) ); ?>"><?php esc_html_e( 'See all', 'wporg-learn' ); ?></a></p>
+		<!-- /wp:paragraph -->
 
-</div>
-<!-- /wp:query -->
+	</div>
+	<!-- /wp:group -->
 
-<!-- wp:heading {"style":{"spacing":{"margin":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|10"}}}} -->
-<h2 class="wp-block-heading" style="margin-top:var(--wp--preset--spacing--60);margin-bottom:var(--wp--preset--spacing--10)"><?php echo esc_html( $content['advanced']['title'] ); ?></h2>
-<!-- /wp:heading -->
+	<!-- wp:query {"queryId":2,"query":{"perPage":3,"postType":"course","courseFeatured":false,"taxQuery":{"level":[<?php echo esc_html( $advanced_level_id ); ?>],"learning-pathway":[<?php echo esc_html( $learning_pathway_id ); ?>]},"inherit":false},"namespace":"wporg-learn/course-grid","align":"wide","className":"wporg-learn-course-grid"} -->
+	<div class="wp-block-query alignwide wporg-learn-course-grid">
 
-<!-- wp:group {"style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|40"}}},"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group" style="margin-top:0;margin-bottom:var(--wp--preset--spacing--40)">
+		<!-- wp:post-template {"style":{"spacing":{"blockGap":"var:preset|spacing|50"}},"layout":{"type":"grid","columnCount":null,"minimumColumnWidth":"330px"}} -->
 
-	<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|charcoal-4"}}}},"textColor":"charcoal-4"} -->
-	<p class="has-charcoal-4-color has-text-color has-link-color"><?php echo esc_html( $content['advanced']['description'] ); ?></p>
-	<!-- /wp:paragraph -->
+			<!-- wp:group {"style":{"border":{"width":"1px","color":"var:preset|color|light-grey-1","radius":"2px"},"spacing":{"blockGap":"0"},"dimensions":{"minHeight":"100%"}},"backgroundColor":"white","layout":{"type":"flex","orientation":"vertical"}} -->
+			<div class="wp-block-group has-border-color has-white-background-color has-background" style="border-color:var(--wp--preset--color--light-grey-1);border-width:1px;border-radius:2px;min-height:100%">
 
-	<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}}},"textColor":"charcoal-4"} -->
-	<p class="has-charcoal-4-color has-text-color has-link-color"><a href="<?php echo esc_url( site_url( '/courses/?wporg_learning_pathway=' . $learning_pathway_slug . '&wporg_lesson_level=advanced' ) ); ?>"><?php esc_html_e( 'See all', 'wporg-learn' ); ?></a></p>
-	<!-- /wp:paragraph -->
+				<!-- wp:post-featured-image {"style":{"spacing":{"margin":{"bottom":"0"}}}} /-->
 
-</div>
-<!-- /wp:group -->
+				<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"20px","right":"20px"}}},"layout":{"type":"constrained"}} -->
+				<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--20);padding-right:20px;padding-bottom:var(--wp--preset--spacing--20);padding-left:20px">
 
-<!-- wp:query {"queryId":1,"query":{"perPage":3,"postType":"course","courseFeatured":false,"taxQuery":{"level":[<?php echo esc_html( $advanced_level_id ); ?>],"learning-pathway":[<?php echo esc_html( $learning_pathway_id ); ?>]},"inherit":false},"namespace":"wporg-learn/course-grid","align":"wide","className":"wporg-learn-course-grid"} -->
-<div class="wp-block-query alignwide wporg-learn-course-grid">
+					<!-- wp:post-title {"level":3,"isLink":true,"style":{"typography":{"fontStyle":"normal","fontWeight":"600","lineHeight":1.6},"spacing":{"margin":{"bottom":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}}},"fontSize":"normal","fontFamily":"inter"} /-->
 
-	<!-- wp:post-template {"style":{"spacing":{"blockGap":"var:preset|spacing|50"}},"layout":{"type":"grid","columnCount":null,"minimumColumnWidth":"330px"}} -->
+					<!-- wp:post-excerpt {"showMoreOnNewLine":false,"excerptLength":16,"style":{"spacing":{"margin":{"top":"var:preset|spacing|10"}},"typography":{"lineHeight":1.6}}} /-->
 
-		<!-- wp:group {"style":{"border":{"width":"1px","color":"var:preset|color|light-grey-1","radius":"2px"},"spacing":{"blockGap":"0"},"dimensions":{"minHeight":"100%"}},"backgroundColor":"white","layout":{"type":"flex","orientation":"vertical"}} -->
-		<div class="wp-block-group has-border-color has-white-background-color has-background" style="border-color:var(--wp--preset--color--light-grey-1);border-width:1px;border-radius:2px;min-height:100%">
+					<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"left"}} -->
+					<div class="wp-block-group">
 
-			<!-- wp:post-featured-image {"style":{"spacing":{"margin":{"bottom":"0"}}}} /-->
+						<!-- wp:wporg-learn/learning-duration {"style":{"elements":{"link":{"color":{"text":"var:preset|color|charcoal-4"}}}},"textColor":"charcoal-4","fontSize":"small"} /-->
 
-			<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"20px","right":"20px"}}},"layout":{"type":"constrained"}} -->
-			<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--20);padding-right:20px;padding-bottom:var(--wp--preset--spacing--20);padding-left:20px">
+						<!-- wp:wporg-learn/lesson-count {"style":{"layout":{"selfStretch":"fill","flexSize":null}},"fontSize":"extra-small"} /-->
 
-				<!-- wp:post-title {"level":3,"isLink":true,"style":{"typography":{"fontStyle":"normal","fontWeight":"600","lineHeight":1.6},"spacing":{"margin":{"bottom":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}}},"fontSize":"normal","fontFamily":"inter"} /-->
+						<!-- wp:wporg-learn/course-status {"fontSize":"extra-small"} /-->
 
-				<!-- wp:post-excerpt {"showMoreOnNewLine":false,"excerptLength":16,"style":{"spacing":{"margin":{"top":"var:preset|spacing|10"}},"typography":{"lineHeight":1.6}}} /-->
-
-				<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"left"}} -->
-				<div class="wp-block-group">
-
-					<!-- wp:wporg-learn/learning-duration {"style":{"elements":{"link":{"color":{"text":"var:preset|color|charcoal-4"}}}},"textColor":"charcoal-4","fontSize":"small"} /-->
-
-					<!-- wp:wporg-learn/lesson-count {"style":{"layout":{"selfStretch":"fill","flexSize":null}},"fontSize":"extra-small"} /-->
-
-					<!-- wp:wporg-learn/course-status {"fontSize":"extra-small"} /-->
+					</div>
+					<!-- /wp:group -->
 
 				</div>
 				<!-- /wp:group -->
@@ -222,18 +232,18 @@ $content = get_learning_pathway_level_content( $learning_pathway_slug );
 			</div>
 			<!-- /wp:group -->
 
-		</div>
-		<!-- /wp:group -->
+		<!-- /wp:post-template -->
 
-	<!-- /wp:post-template -->
+		<!-- wp:query-no-results -->
 
-	<!-- wp:query-no-results -->
+			<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results.","style":{"spacing":{"margin":{"top":"-20px"}}}} -->
+			<p style="margin-top:-20px"><?php esc_html_e( 'No advanced Courses found.', 'wporg-learn' ); ?></p>
+			<!-- /wp:paragraph -->
 
-		<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results.","style":{"spacing":{"margin":{"top":"-20px"}}}} -->
-		<p style="margin-top:-20px"><?php esc_html_e( 'No advanced Courses found.', 'wporg-learn' ); ?></p>
-		<!-- /wp:paragraph -->
+		<!-- /wp:query-no-results -->
 
-	<!-- /wp:query-no-results -->
+	</div>
+	<!-- /wp:query -->
 
 </div>
-<!-- /wp:query -->
+<!-- /wp:group -->

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/taxonomy-learning-pathway-content.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/taxonomy-learning-pathway-content.php
@@ -97,8 +97,8 @@ $content = get_learning_pathway_level_content( $learning_pathway_slug );
 
 	<!-- wp:query-no-results -->
 
-		<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
-		<p><?php esc_html_e( 'No beginner Courses found.', 'wporg-learn' ); ?></p>
+		<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results.","style":{"spacing":{"margin":{"top":"-20px"}}}} -->
+		<p style="margin-top:-20px"><?php esc_html_e( 'No beginner Courses found.', 'wporg-learn' ); ?></p>
 		<!-- /wp:paragraph -->
 
 	<!-- /wp:query-no-results -->
@@ -163,8 +163,8 @@ $content = get_learning_pathway_level_content( $learning_pathway_slug );
 
 	<!-- wp:query-no-results -->
 
-		<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
-		<p><?php esc_html_e( 'No intermediate Courses found.', 'wporg-learn' ); ?></p>
+		<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results.","style":{"spacing":{"margin":{"top":"-20px"}}}} -->
+		<p style="margin-top:-20px"><?php esc_html_e( 'No intermediate Courses found.', 'wporg-learn' ); ?></p>
 		<!-- /wp:paragraph -->
 
 	<!-- /wp:query-no-results -->
@@ -229,8 +229,8 @@ $content = get_learning_pathway_level_content( $learning_pathway_slug );
 
 	<!-- wp:query-no-results -->
 
-		<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
-		<p><?php esc_html_e( 'No advanced Courses found.', 'wporg-learn' ); ?></p>
+		<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results.","style":{"spacing":{"margin":{"top":"-20px"}}}} -->
+		<p style="margin-top:-20px"><?php esc_html_e( 'No advanced Courses found.', 'wporg-learn' ); ?></p>
 		<!-- /wp:paragraph -->
 
 	<!-- /wp:query-no-results -->

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/taxonomy-learning-pathway-content.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/taxonomy-learning-pathway-content.php
@@ -81,16 +81,6 @@ $content = get_learning_pathway_level_content( $learning_pathway_slug );
 
 	<!-- /wp:query-no-results -->
 
-	<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"}} -->
-
-		<!-- wp:query-pagination-previous {"label":"Previous"} /-->
-
-		<!-- wp:query-pagination-numbers /-->
-
-		<!-- wp:query-pagination-next {"label":"Next"} /-->
-
-	<!-- /wp:query-pagination -->
-
 </div>
 <!-- /wp:query -->
 
@@ -157,16 +147,6 @@ $content = get_learning_pathway_level_content( $learning_pathway_slug );
 
 	<!-- /wp:query-no-results -->
 
-	<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"}} -->
-
-		<!-- wp:query-pagination-previous {"label":"Previous"} /-->
-
-		<!-- wp:query-pagination-numbers /-->
-
-		<!-- wp:query-pagination-next {"label":"Next"} /-->
-
-	<!-- /wp:query-pagination -->
-
 </div>
 <!-- /wp:query -->
 
@@ -232,16 +212,6 @@ $content = get_learning_pathway_level_content( $learning_pathway_slug );
 		<!-- /wp:paragraph -->
 
 	<!-- /wp:query-no-results -->
-
-	<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"}} -->
-
-		<!-- wp:query-pagination-previous {"label":"Previous"} /-->
-
-		<!-- wp:query-pagination-numbers /-->
-
-		<!-- wp:query-pagination-next {"label":"Next"} /-->
-
-	<!-- /wp:query-pagination -->
 
 </div>
 <!-- /wp:query -->

--- a/wp-content/themes/pub/wporg-learn-2024/src/learning-pathway-cards/block.php
+++ b/wp-content/themes/pub/wporg-learn-2024/src/learning-pathway-cards/block.php
@@ -64,20 +64,14 @@ function render( $attributes, $content, $block ) {
  * @return string Returns the full card markup.
  */
 function render_full_card( $learning_pathway ) {
-	$background_colors = array(
-		'user'        => '#f5fef8',
-		'designer'    => '#fef8f6',
-		'developer'   => '#fffff4',
-		'contributor' => '#fDf5fe',
-	);
-	$count             = $learning_pathway->count;
+	$count = $learning_pathway->count;
 
 	return sprintf(
 		'<!-- wp:group {"style":{"spacing":{"padding":{"top":"0","bottom":"0","left":"0","right":"0"},"blockGap":"0"}},"className":"wporg-learn-learning-pathway-card-full","layout":{"type":"flex","orientation":"vertical","flexWrap":"nowrap","justifyContent":"stretch"}} -->
 		<div class="wp-block-group wporg-learn-learning-pathway-card-full" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0">
 
-			<!-- wp:group {"className":"wporg-learn-learning-pathway-card-header","style":{"color":{"background":"%1$s"},"border":{"bottom":{"color":"var:preset|color|light-grey-1","width":"1px"}},"spacing":{"blockGap":"0"}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between","verticalAlignment":"stretch"}} -->
-			<div class="wp-block-group wporg-learn-learning-pathway-card-header has-background" style="border-bottom-color:var(--wp--preset--color--light-grey-1);border-bottom-width:1px;background-color:%1$s">
+			<!-- wp:group {"className":"wporg-learn-learning-pathway-card-header","style":{"backgroundColor":"%1$s","border":{"bottom":{"color":"var:preset|color|light-grey-1","width":"1px"}},"spacing":{"blockGap":"0"}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between","verticalAlignment":"stretch"}} -->
+			<div class="wp-block-group wporg-learn-learning-pathway-card-header has-%1$s-background-color has-background" style="border-bottom-color:var(--wp--preset--color--light-grey-1);border-bottom-width:1px;background-color:var(--wp--custom--color--%1$s)">
 
 				<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"30px","right":"0"},"blockGap":"0"},"className":"wporg-learn-learning-pathway-card-header-content","layout":{"selfStretch":"fixed","flexSize":"50%%"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
 				<div class="wp-block-group wporg-learn-learning-pathway-card-header-content" style="padding-top:var(--wp--preset--spacing--30);padding-right:0;padding-bottom:var(--wp--preset--spacing--30);padding-left:30px">
@@ -130,7 +124,7 @@ function render_full_card( $learning_pathway ) {
 
 		</div>
 		<!-- /wp:group -->',
-		esc_attr( $background_colors[ $learning_pathway->slug ] ),
+		esc_attr( $learning_pathway->slug ),
 		esc_html( $learning_pathway->name ),
 		esc_html( $learning_pathway->description ),
 		esc_url( get_stylesheet_directory_uri() . '/assets/learning-pathway-' . $learning_pathway->slug . '.svg' ),

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_taxonomy-learning-pathway.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_taxonomy-learning-pathway.scss
@@ -1,0 +1,13 @@
+.tax-learning-pathway {
+
+	@media screen and (min-width: 769px) {
+		--wp--preset--font-size--heading-1: 50px;
+	}
+
+	.wporg-learn-tax-learning-pathway-header {
+
+		@media screen and (max-width: 1024px) {
+			padding-right: unset !important;
+		}
+	}
+}

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/style.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/style.scss
@@ -7,6 +7,7 @@
 @import "course-grid";
 @import "sensei";
 @import "tag";
+@import "taxonomy-learning-pathway";
 @import "wp-components";
 @import "wporg-meeting-calendar";
 

--- a/wp-content/themes/pub/wporg-learn-2024/templates/taxonomy-learning-pathway.html
+++ b/wp-content/themes/pub/wporg-learn-2024/templates/taxonomy-learning-pathway.html
@@ -1,43 +1,25 @@
 <!-- wp:template-part {"slug":"header","className":"has-display-contents","tagName":"div"} /-->
 
-<!-- wp:group {"tagName":"main","layout":{"type":"constrained"},"className":"entry-content","style":{"spacing":{"blockGap":"0px"}}} -->
-<main class="wp-block-group entry-content">
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"},"className":"entry-content","style":{"spacing":{"blockGap":"0px"},"padding":{"bottom":"var:preset|spacing|60"}}} -->
+<main class="wp-block-group entry-content" style="padding-bottom:var(--wp--preset--spacing--60)">
 
-	<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space","top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
-	<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--edge-space)">
+	<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}},"border":{"bottom":{"color":"var:preset|color|light-grey-1"}}},"backgroundColor":"pomegrade-3","layout":{"type":"constrained"}} -->
+	<div class="wp-block-group alignfull has-pomegrade-3-background-color has-background" style="border-bottom-color:var(--wp--preset--color--light-grey-1);padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)">
 
-		<!-- wp:query-title {"type":"archive","showPrefix":false} /-->
+		<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"constrained"}} -->
+		<div class="wp-block-group">
 
-		<!-- wp:query {"queryId":9,"query":{"perPage":10,"pages":0,"offset":0,"postType":"course","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":true},"metadata":{"categories":["posts"],"patternName":"core/query-grid-posts","name":"Grid"},"layout":{"type":"constrained"}} -->
-		<div class="wp-block-query">
-			
-			<!-- wp:post-template {"layout":{"type":"grid","columnCount":3}} -->
+			<!-- wp:query-title {"type":"archive","showPrefix":false,"style":{"typography":{"fontSize":"50px"}}} /-->
 
-				<!-- wp:group {"style":{"spacing":{"padding":{"top":"30px","right":"30px","bottom":"30px","left":"30px"}}},"layout":{"inherit":false}} -->
-				<div class="wp-block-group" style="padding-top:30px;padding-right:30px;padding-bottom:30px;padding-left:30px">
-					
-					<!-- wp:post-featured-image /-->
-				
-					<!-- wp:post-title {"isLink":true} /-->
-					
-					<!-- wp:post-excerpt /-->
-					
-				</div>
-				<!-- /wp:group -->
+			<!-- wp:term-description /-->
 
-			<!-- /wp:post-template -->
-
-			<!-- wp:query-no-results -->
-
-				<!-- wp:pattern {"slug":"wporg-learn-2024/query-no-results-course"} /-->
-
-			<!-- /wp:query-no-results -->
-		
 		</div>
-		<!-- /wp:query -->
+		<!-- /wp:group -->
 
 	</div>
 	<!-- /wp:group -->
+
+	<!-- wp:pattern {"slug":"wporg-learn-2024/taxonomy-learning-pathway-content"} /-->
 
 </main>
 <!-- /wp:group -->

--- a/wp-content/themes/pub/wporg-learn-2024/templates/taxonomy-learning-pathway.html
+++ b/wp-content/themes/pub/wporg-learn-2024/templates/taxonomy-learning-pathway.html
@@ -1,7 +1,7 @@
 <!-- wp:template-part {"slug":"header","className":"has-display-contents","tagName":"div"} /-->
 
-<!-- wp:group {"tagName":"main","layout":{"type":"constrained"},"className":"entry-content","style":{"spacing":{"blockGap":"0px"},"padding":{"bottom":"var:preset|spacing|60"}}} -->
-<main class="wp-block-group entry-content" style="padding-bottom:var(--wp--preset--spacing--60)">
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"},"className":"entry-content","style":{"spacing":{"blockGap":"0px"}}} -->
+<main class="wp-block-group entry-content">
 
 	<!-- wp:pattern {"slug":"wporg-learn-2024/taxonomy-learning-pathway-content"} /-->
 

--- a/wp-content/themes/pub/wporg-learn-2024/templates/taxonomy-learning-pathway.html
+++ b/wp-content/themes/pub/wporg-learn-2024/templates/taxonomy-learning-pathway.html
@@ -3,22 +3,6 @@
 <!-- wp:group {"tagName":"main","layout":{"type":"constrained"},"className":"entry-content","style":{"spacing":{"blockGap":"0px"},"padding":{"bottom":"var:preset|spacing|60"}}} -->
 <main class="wp-block-group entry-content" style="padding-bottom:var(--wp--preset--spacing--60)">
 
-	<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}},"border":{"bottom":{"color":"var:preset|color|light-grey-1"}}},"backgroundColor":"pomegrade-3","layout":{"type":"constrained"}} -->
-	<div class="wp-block-group alignfull has-pomegrade-3-background-color has-background" style="border-bottom-color:var(--wp--preset--color--light-grey-1);padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)">
-
-		<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"constrained"}} -->
-		<div class="wp-block-group">
-
-			<!-- wp:query-title {"type":"archive","showPrefix":false,"style":{"typography":{"fontSize":"50px"}}} /-->
-
-			<!-- wp:term-description /-->
-
-		</div>
-		<!-- /wp:group -->
-
-	</div>
-	<!-- /wp:group -->
-
 	<!-- wp:pattern {"slug":"wporg-learn-2024/taxonomy-learning-pathway-content"} /-->
 
 </main>

--- a/wp-content/themes/pub/wporg-learn-2024/theme.json
+++ b/wp-content/themes/pub/wporg-learn-2024/theme.json
@@ -2,6 +2,30 @@
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"version": 2,
 	"settings": {
+		"color": {
+			"palette": [
+				{
+					"slug": "user",
+					"color": "#f5fef8",
+					"name": "User"
+				},
+				{
+					"slug": "designer",
+					"color": "#fef8f6",
+					"name": "Designer"
+				},
+				{
+					"slug": "developer",
+					"color": "#fffff4",
+					"name": "Developer"
+				},
+				{
+					"slug": "contributor",
+					"color": "#fDf5fe",
+					"name": "Contributor"
+				}
+			]
+		},
 		"custom": {
 			"alignment": {
 				"aligned-max-width": "unset"


### PR DESCRIPTION
Adds a pattern for the Learning Pathway taxonomy page (eg. /learning-pathway/designer), with the 3 sections for beginner, intermediate and advanced. 

Ideally rather than fetching data in the pattern, this would be comprised of 3 instances of a block which takes learning pathway term and experience level and returns the query loop grid, however I wasn't able to get this to work. There was a weird issue with nested rendering, possibly related to multiple queries on a taxonomy template, but I'm not sure.

Using a block would also make it easier to not render a section if there were no pathways, although I'm not sure if that's what we want so I've added no results text for now, @WordPress/meta-design thoughts? Worth noting that a page for each learning pathway will only be available in the navigation and landing page if there are at least 1 pathway available, so the screenshot for Contributors below is only for illustration purposes.

I'd like to ship this so we have something working and iterate further.

See #2456 

### Screenshots

| Desktop | Tablet | Mobile |
|-|-|-|
| ![localhost_8888_learning-pathway_designer_(Desktop) (1)](https://github.com/WordPress/Learn/assets/1017872/0d0e4bb4-f44d-490e-9329-a59f4e13bab3) | ![localhost_8888_learning-pathway_designer_(iPad) (1)](https://github.com/WordPress/Learn/assets/1017872/54d70bab-0b0e-4ed9-aa4c-ee63f53cc9fb) | ![localhost_8888_learning-pathway_designer_(Samsung Galaxy S20 Ultra) (1)](https://github.com/WordPress/Learn/assets/1017872/df4ff48f-cc7b-4779-af4f-1dd8dfc2c0f5) |


| Developer | User | Contributor |
|-|-|-|
| ![localhost_8888_learning-pathway_developer_(Desktop)](https://github.com/WordPress/Learn/assets/1017872/66bf5dd6-e143-49b0-80e1-98e88b0ad7d0) | ![localhost_8888_learning-pathway_user_(Desktop)](https://github.com/WordPress/Learn/assets/1017872/eea7acc0-56ba-4ccd-b78a-c3335ed10295) | ![localhost_8888_learning-pathway_contributor_(Desktop)](https://github.com/WordPress/Learn/assets/1017872/7c0cb27a-5d47-4d82-b233-24c85bf2b114) |

