### PR TITLE
Add breadcrumbs to templates

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2024/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2024/functions.php
@@ -235,14 +235,12 @@ function set_site_breadcrumbs( $breadcrumbs ) {
 	$post_type = get_post_type();
 
 	if ( is_archive() ) {
+		// Archive page: Change the title of the second breadcrumb from the first post title to the archive title.
 		if ( isset( $breadcrumbs[1] ) ) {
-			// Change the title of the second breadcrumb from the post title to the post type.
 			$breadcrumbs[1]['title'] = get_the_archive_title();
 		}
-	}
-
-	// Add the archive of a post type to the breadcrumbs.
-	if ( is_singular() && 'page' !== $post_type && 'post' !== $post_type ) {
+	} elseif ( is_singular() && 'page' !== $post_type && 'post' !== $post_type ) {
+		// CPT single page: Insert the archive breadcrumb into the second position.
 		$post_type_object = get_post_type_object( $post_type );
 		$archive_title = $post_type_object->labels->name;
 		$archive_url = get_post_type_archive_link( $post_type );
@@ -252,9 +250,9 @@ function set_site_breadcrumbs( $breadcrumbs ) {
 			'title' => $archive_title,
 		);
 
-		// Insert the post type into the second position.
 		array_splice( $breadcrumbs, 1, 0, array( $archive_breadcrumb ) );
 
+		// If it's a lesson, change the second breadcrumb from archive title (ie. 'Courses') to the course title.
 		if ( is_singular( 'lesson' ) ) {
 			$lesson_course_id = get_post_meta( get_the_ID(), '_lesson_course', true );
 
@@ -271,19 +269,19 @@ function set_site_breadcrumbs( $breadcrumbs ) {
 
 			$breadcrumbs[1] = $lesson_course_breadcrumb;
 		}
-	}
+	} else {
+		// Page: Add the ancestors of the current page to the breadcrumbs.
+		$ancestors = get_post_ancestors( get_the_ID() );
+		foreach ( $ancestors as $ancestor ) {
+			$ancestor_post = get_post( $ancestor );
 
-	// Add the ancestors of the current page to the breadcrumbs.
-	$ancestors = get_post_ancestors( get_the_ID() );
-	foreach ( $ancestors as $ancestor ) {
-		$ancestor_post = get_post( $ancestor );
+			$ancestor_breadcrumb = array(
+				'url' => get_permalink( $ancestor_post ),
+				'title' => get_the_title( $ancestor_post ),
+			);
 
-		$ancestor_breadcrumb = array(
-			'url' => get_permalink( $ancestor_post ),
-			'title' => get_the_title( $ancestor_post ),
-		);
-
-		array_splice( $breadcrumbs, 1, 0, array( $ancestor_breadcrumb ) );
+			array_splice( $breadcrumbs, 1, 0, array( $ancestor_breadcrumb ) );
+		}
 	}
 
 	return $breadcrumbs;

--- a/wp-content/themes/pub/wporg-learn-2024/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2024/functions.php
@@ -252,13 +252,23 @@ function set_site_breadcrumbs( $breadcrumbs ) {
 
 		array_splice( $breadcrumbs, 1, 0, array( $archive_breadcrumb ) );
 
-		// If it's a lesson, change the second breadcrumb from archive title (ie. 'Courses') to the course title.
+		// If it's a lesson single page, change the second breadcrumb to the course archive
+		// and insert the lesson course breadcrumb into the third position.
 		if ( is_singular( 'lesson' ) ) {
 			$lesson_course_id = get_post_meta( get_the_ID(), '_lesson_course', true );
 
 			if ( empty( $lesson_course_id ) ) {
 				return $breadcrumbs;
 			}
+
+			$post_type_object = get_post_type_object( 'course' );
+			$archive_title = $post_type_object->labels->name;
+			$archive_url = get_post_type_archive_link( $post_type );
+
+			$archive_breadcrumb = array(
+				'url' => $archive_url,
+				'title' => $archive_title,
+			);
 
 			$lesson_course_title = get_the_title( $lesson_course_id );
 			$lesson_course_link = get_permalink( $lesson_course_id );
@@ -267,7 +277,8 @@ function set_site_breadcrumbs( $breadcrumbs ) {
 				'title' => $lesson_course_title,
 			);
 
-			$breadcrumbs[1] = $lesson_course_breadcrumb;
+			$breadcrumbs[1] = $archive_breadcrumb;
+			array_splice( $breadcrumbs, 2, 0, array( $lesson_course_breadcrumb ) );
 		}
 	} else {
 		// Page: Add the ancestors of the current page to the breadcrumbs.

--- a/wp-content/themes/pub/wporg-learn-2024/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2024/functions.php
@@ -242,7 +242,7 @@ function set_site_breadcrumbs( $breadcrumbs ) {
 	}
 
 	// Add the post type archive to the breadcrumbs.
-	if ( is_singular() && 'page' !== $post_type ) {
+	if ( is_singular() && 'page' !== $post_type && 'post' !== $post_type ) {
 		$archive_url = get_post_type_archive_link( $post_type );
 
 		$archive_breadcrumb = array(

--- a/wp-content/themes/pub/wporg-learn-2024/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2024/functions.php
@@ -233,15 +233,11 @@ function set_site_breadcrumbs( $breadcrumbs ) {
 	}
 
 	$post_type = get_post_type();
-	// Pluralize the post type lesson and course.
-	if ( 'lesson' === $post_type || 'course' === $post_type ) {
-		$post_type = $post_type . 's';
-	}
 
 	if ( is_archive() ) {
 		if ( isset( $breadcrumbs[1] ) ) {
 			// Change the title of the second breadcrumb from the post title to the post type.
-			$breadcrumbs[1]['title'] = ucwords( $post_type );
+			$breadcrumbs[1]['title'] = ucwords( pluralize_post_type( $post_type ) );
 		}
 	}
 
@@ -251,7 +247,7 @@ function set_site_breadcrumbs( $breadcrumbs ) {
 
 		$archive_breadcrumb = array(
 			'url' => $archive_url,
-			'title' => ucwords( $post_type ),
+			'title' => ucwords( pluralize_post_type( $post_type ) ),
 		);
 
 		// Insert the post type into the second position.
@@ -272,4 +268,20 @@ function set_site_breadcrumbs( $breadcrumbs ) {
 	}
 
 	return $breadcrumbs;
+}
+
+/**
+ * Pluralize the designated post types.
+ *
+ * @param string $post_type The post type.
+ *
+ * @return string The pluralized post type.
+ */
+function pluralize_post_type( $post_type ) {
+	// Pluralize the post type lesson and course.
+	if ( 'lesson' === $post_type || 'course' === $post_type ) {
+		$post_type = $post_type . 's';
+	}
+
+	return $post_type;
 }

--- a/wp-content/themes/pub/wporg-learn-2024/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2024/functions.php
@@ -223,7 +223,7 @@ function get_learning_pathway_level_content( $learning_pathway ) {
  * @return array
  */
 function set_site_breadcrumbs( $breadcrumbs ) {
-	if ( is_tax( 'learning-pathway' ) ) {
+	if ( is_tax( 'learning-pathway' ) || is_page( 'learning-pathways' ) ) {
 		return array();
 	}
 

--- a/wp-content/themes/pub/wporg-learn-2024/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2024/functions.php
@@ -254,6 +254,23 @@ function set_site_breadcrumbs( $breadcrumbs ) {
 
 		// Insert the post type into the second position.
 		array_splice( $breadcrumbs, 1, 0, array( $archive_breadcrumb ) );
+
+		if ( is_singular( 'lesson' ) ) {
+			$lesson_course_id = get_post_meta( get_the_ID(), '_lesson_course', true );
+
+			if ( empty( $lesson_course_id ) ) {
+				return $breadcrumbs;
+			}
+
+			$lesson_course_title = get_the_title( $lesson_course_id );
+			$lesson_course_link = get_permalink( $lesson_course_id );
+			$lesson_course_breadcrumb = array(
+				'url' => $lesson_course_link,
+				'title' => $lesson_course_title,
+			);
+
+			$breadcrumbs[1] = $lesson_course_breadcrumb;
+		}
 	}
 
 	// Add the ancestors of the current page to the breadcrumbs.

--- a/wp-content/themes/pub/wporg-learn-2024/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2024/functions.php
@@ -227,5 +227,10 @@ function set_site_breadcrumbs( $breadcrumbs ) {
 		return array();
 	}
 
+	if ( isset( $breadcrumbs[0] ) ) {
+		// Change the title of the first breadcrumb to 'Home'
+		$breadcrumbs[0]['title'] = 'Home';
+	}
+
 	return $breadcrumbs;
 }

--- a/wp-content/themes/pub/wporg-learn-2024/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2024/functions.php
@@ -14,6 +14,7 @@ require_once __DIR__ . '/src/upcoming-online-workshops/index.php';
  */
 add_action( 'after_setup_theme', __NAMESPACE__ . '\setup' );
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
+add_filter( 'wporg_block_site_breadcrumbs', __NAMESPACE__ . '\set_site_breadcrumbs' );
 add_filter( 'wporg_block_navigation_menus', __NAMESPACE__ . '\add_site_navigation_menus' );
 add_filter( 'single_template_hierarchy', __NAMESPACE__ . '\modify_single_template' );
 remove_filter( 'template_include', array( 'Sensei_Templates', 'template_loader' ), 10, 1 );
@@ -212,4 +213,19 @@ function get_learning_pathway_level_content( $learning_pathway ) {
 	);
 
 	return $content[ $learning_pathway ];
+}
+
+/**
+ * Filters breadcrumb items for the site-breadcrumb block.
+ *
+ * @param array $breadcrumbs
+ *
+ * @return array
+ */
+function set_site_breadcrumbs( $breadcrumbs ) {
+	if ( is_tax( 'learning-pathway' ) ) {
+		return array();
+	}
+
+	return $breadcrumbs;
 }

--- a/wp-content/themes/pub/wporg-learn-2024/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2024/functions.php
@@ -245,5 +245,17 @@ function set_site_breadcrumbs( $breadcrumbs ) {
 		}
 	}
 
+	if ( is_singular() && 'page' !== $post_type ) {
+		$archive_url = get_post_type_archive_link( $post_type );
+
+		$archive_breadcrumb = array(
+			'url' => $archive_url,
+			'title' => ucwords( $post_type ),
+		);
+
+		// Insert the post type into the second position.
+		array_splice( $breadcrumbs, 1, 0, array( $archive_breadcrumb ) );
+	}
+
 	return $breadcrumbs;
 }

--- a/wp-content/themes/pub/wporg-learn-2024/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2024/functions.php
@@ -223,10 +223,6 @@ function get_learning_pathway_level_content( $learning_pathway ) {
  * @return array
  */
 function set_site_breadcrumbs( $breadcrumbs ) {
-	if ( is_tax( 'learning-pathway' ) || is_page( 'learning-pathways' ) ) {
-		return array();
-	}
-
 	if ( isset( $breadcrumbs[0] ) ) {
 		// Change the title of the first breadcrumb to 'Home'.
 		$breadcrumbs[0]['title'] = 'Home';
@@ -234,12 +230,7 @@ function set_site_breadcrumbs( $breadcrumbs ) {
 
 	$post_type = get_post_type();
 
-	if ( is_archive() ) {
-		// Archive page: Change the title of the second breadcrumb from the first post title to the archive title.
-		if ( isset( $breadcrumbs[1] ) ) {
-			$breadcrumbs[1]['title'] = get_the_archive_title();
-		}
-	} elseif ( is_singular() && 'page' !== $post_type && 'post' !== $post_type ) {
+	if ( is_singular() && 'page' !== $post_type && 'post' !== $post_type ) {
 		// CPT single page: Insert the archive breadcrumb into the second position.
 		$post_type_object = get_post_type_object( $post_type );
 		$archive_title = $post_type_object->labels->name;
@@ -279,19 +270,6 @@ function set_site_breadcrumbs( $breadcrumbs ) {
 
 			$breadcrumbs[1] = $archive_breadcrumb;
 			array_splice( $breadcrumbs, 2, 0, array( $lesson_course_breadcrumb ) );
-		}
-	} else {
-		// Page: Add the ancestors of the current page to the breadcrumbs.
-		$ancestors = get_post_ancestors( get_the_ID() );
-		foreach ( $ancestors as $ancestor ) {
-			$ancestor_post = get_post( $ancestor );
-
-			$ancestor_breadcrumb = array(
-				'url' => get_permalink( $ancestor_post ),
-				'title' => get_the_title( $ancestor_post ),
-			);
-
-			array_splice( $breadcrumbs, 1, 0, array( $ancestor_breadcrumb ) );
 		}
 	}
 

--- a/wp-content/themes/pub/wporg-learn-2024/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2024/functions.php
@@ -228,8 +228,21 @@ function set_site_breadcrumbs( $breadcrumbs ) {
 	}
 
 	if ( isset( $breadcrumbs[0] ) ) {
-		// Change the title of the first breadcrumb to 'Home'
+		// Change the title of the first breadcrumb to 'Home'.
 		$breadcrumbs[0]['title'] = 'Home';
+	}
+
+	$post_type = get_post_type();
+	// Pluralize the post type lesson and course.
+	if ( 'lesson' === $post_type || 'course' === $post_type ) {
+		$post_type = $post_type . 's';
+	}
+
+	if ( is_archive() ) {
+		if ( isset( $breadcrumbs[1] ) ) {
+			// Change the title of the second breadcrumb from the post title to the post type.
+			$breadcrumbs[1]['title'] = ucwords( $post_type );
+		}
 	}
 
 	return $breadcrumbs;

--- a/wp-content/themes/pub/wporg-learn-2024/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2024/functions.php
@@ -237,17 +237,19 @@ function set_site_breadcrumbs( $breadcrumbs ) {
 	if ( is_archive() ) {
 		if ( isset( $breadcrumbs[1] ) ) {
 			// Change the title of the second breadcrumb from the post title to the post type.
-			$breadcrumbs[1]['title'] = ucwords( pluralize_post_type( $post_type ) );
+			$breadcrumbs[1]['title'] = get_the_archive_title();
 		}
 	}
 
-	// Add the post type archive to the breadcrumbs.
+	// Add the archive of a post type to the breadcrumbs.
 	if ( is_singular() && 'page' !== $post_type && 'post' !== $post_type ) {
+		$post_type_object = get_post_type_object( $post_type );
+		$archive_title = $post_type_object->labels->name;
 		$archive_url = get_post_type_archive_link( $post_type );
 
 		$archive_breadcrumb = array(
 			'url' => $archive_url,
-			'title' => ucwords( pluralize_post_type( $post_type ) ),
+			'title' => $archive_title,
 		);
 
 		// Insert the post type into the second position.
@@ -268,20 +270,4 @@ function set_site_breadcrumbs( $breadcrumbs ) {
 	}
 
 	return $breadcrumbs;
-}
-
-/**
- * Pluralize the designated post types.
- *
- * @param string $post_type The post type.
- *
- * @return string The pluralized post type.
- */
-function pluralize_post_type( $post_type ) {
-	// Pluralize the post type lesson and course.
-	if ( 'lesson' === $post_type || 'course' === $post_type ) {
-		$post_type = $post_type . 's';
-	}
-
-	return $post_type;
 }

--- a/wp-content/themes/pub/wporg-learn-2024/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2024/functions.php
@@ -245,6 +245,7 @@ function set_site_breadcrumbs( $breadcrumbs ) {
 		}
 	}
 
+	// Add the post type archive to the breadcrumbs.
 	if ( is_singular() && 'page' !== $post_type ) {
 		$archive_url = get_post_type_archive_link( $post_type );
 
@@ -255,6 +256,19 @@ function set_site_breadcrumbs( $breadcrumbs ) {
 
 		// Insert the post type into the second position.
 		array_splice( $breadcrumbs, 1, 0, array( $archive_breadcrumb ) );
+	}
+
+	// Add the ancestors of the current page to the breadcrumbs.
+	$ancestors = get_post_ancestors( get_the_ID() );
+	foreach ( $ancestors as $ancestor ) {
+		$ancestor_post = get_post( $ancestor );
+
+		$ancestor_breadcrumb = array(
+			'url' => get_permalink( $ancestor_post ),
+			'title' => get_the_title( $ancestor_post ),
+		);
+
+		array_splice( $breadcrumbs, 1, 0, array( $ancestor_breadcrumb ) );
 	}
 
 	return $breadcrumbs;

--- a/wp-content/themes/pub/wporg-learn-2024/parts/header.html
+++ b/wp-content/themes/pub/wporg-learn-2024/parts/header.html
@@ -15,11 +15,3 @@
 	<!-- wp:navigation {"menuSlug":"learn","icon":"menu","overlayBackgroundColor":"charcoal-2","overlayTextColor":"white","layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small"} /-->
 
 <!-- /wp:wporg/local-navigation-bar -->
-
-<!-- wp:group {"className":"wporg-breadcrumbs","align":"full","style":{"spacing":{"padding":{"top":"18px","bottom":"18px","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"backgroundColor":"white","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
-<div class="wporg-breadcrumbs wp-block-group alignfull has-white-background-color has-background" style="padding-top:18px;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:18px;padding-left:var(--wp--preset--spacing--edge-space)">
-	
-	<!-- wp:wporg/site-breadcrumbs {"fontSize":"small"} /-->
-
-</div>
-<!-- /wp:group -->

--- a/wp-content/themes/pub/wporg-learn-2024/parts/header.html
+++ b/wp-content/themes/pub/wporg-learn-2024/parts/header.html
@@ -15,3 +15,11 @@
 	<!-- wp:navigation {"menuSlug":"learn","icon":"menu","overlayBackgroundColor":"charcoal-2","overlayTextColor":"white","layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small"} /-->
 
 <!-- /wp:wporg/local-navigation-bar -->
+
+<!-- wp:group {"className":"wporg-breadcrumbs","align":"full","style":{"spacing":{"padding":{"top":"18px","bottom":"18px","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"backgroundColor":"white","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
+<div class="wporg-breadcrumbs wp-block-group alignfull has-white-background-color has-background" style="padding-top:18px;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:18px;padding-left:var(--wp--preset--spacing--edge-space)">
+	
+	<!-- wp:wporg/site-breadcrumbs {"fontSize":"small"} /-->
+
+</div>
+<!-- /wp:group -->

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/sensei-lesson-header.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/sensei-lesson-header.php
@@ -14,17 +14,9 @@
 	<!-- wp:group {"style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space","top":"0px","bottom":"0px"}}},"className":"sensei-course-theme-header-content","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
 	<div class="wp-block-group sensei-course-theme-header-content" style="padding-top:0px;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:0px;padding-left:var(--wp--preset--spacing--edge-space)">
 
-		<!-- wp:group {"style":{"spacing":{"blockGap":"15px"}},"layout":{"type":"flex","flexWrap":"wrap"}} -->
-		<div class="wp-block-group">
-
-			<!-- wp:site-title {"level":2,"style":{"elements":{"link":{"color":{"text":"var:preset|color|charcoal-4"}}},"typography":{"fontStyle":"normal","fontWeight":"400"}},"textColor":"charcoal-4","fontSize":"small"} /-->
-
-			<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|light-grey-1"}}}},"textColor":"light-grey-1"} -->
-			<p class="has-light-grey-1-color has-text-color has-link-color" aria-hidden="true">/</p>
-			<!-- /wp:paragraph -->
-
-			<!-- wp:sensei-lms/course-title {"style":{"typography":{"fontStyle":"normal","fontWeight":"400"},"spacing":{"margin":{"top":"0"},"padding":{"right":"0","left":"0"}}},"fontSize":"small"} /-->
-
+		<!-- wp:group {"className":"wporg-breadcrumbs","align":"full","style":{"spacing":{"padding":{"top":"18px","bottom":"18px","right":"var:preset|spacing|edge-space"}}},"backgroundColor":"white","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
+		<div class="wporg-breadcrumbs wp-block-group alignfull has-white-background-color has-background" style="padding-top:18px;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:18px;">
+			<!-- wp:wporg/site-breadcrumbs {"fontSize":"small"} /-->
 		</div>
 		<!-- /wp:group -->
 

--- a/wp-content/themes/pub/wporg-learn-2024/templates/single-course.html
+++ b/wp-content/themes/pub/wporg-learn-2024/templates/single-course.html
@@ -1,5 +1,12 @@
 <!-- wp:template-part {"slug":"header","className":"has-display-contents","tagName":"div"} /-->
 
+<!-- wp:group {"className":"wporg-breadcrumbs","align":"full","style":{"spacing":{"padding":{"top":"18px","bottom":"18px","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"backgroundColor":"white","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
+<div class="wporg-breadcrumbs wp-block-group alignfull has-white-background-color has-background" style="padding-top:18px;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:18px;padding-left:var(--wp--preset--spacing--edge-space)">
+	<!-- wp:wporg/site-breadcrumbs {"fontSize":"small"} /-->
+</div>
+<!-- /wp:group -->
+
+
 <!-- wp:group {"tagName":"main","layout":{"type":"constrained"},"className":"entry-content","style":{"spacing":{"blockGap":"0px"}}} -->
 <main class="wp-block-group entry-content">
 


### PR DESCRIPTION
Add breadcrumbs to the sites, except for Home and the Learning Pathway taxonomy. See [design](https://www.figma.com/design/ZKaf6u8mIHkAanluWafXAp/Learn?node-id=3199-20648&m=dev).

Closes #2442

I noticed in the design there's a `Learn WordPress` breadcrumb, which link does it link to? It appears to be redundant with 'Home'. @WordPress/meta-design 
![image](https://github.com/WordPress/Learn/assets/18050944/fb9b9ced-4754-4511-b814-a0655a8b4603)

## Screenshots

| post type | screenshot |
|-|-|
| **Home** | ![Screenshot 2024-06-04 at 00 17 08](https://github.com/WordPress/Learn/assets/18050944/17acb74b-29f0-4f32-9d52-813ebe3b7d66) |
| **Post** | ![Screenshot 2024-06-04 at 00 56 43](https://github.com/WordPress/Learn/assets/18050944/ba86ae51-f321-4e8c-9910-10bb4499937d) |
| **My Course** | ![Screenshot 2024-06-04 at 00 27 47](https://github.com/WordPress/Learn/assets/18050944/8af7b95e-0501-4f7b-a242-02165455d0ac) |
| **Online Workshops** | ![Screenshot 2024-06-04 at 00 27 23](https://github.com/WordPress/Learn/assets/18050944/97cd3b2a-531f-44c0-a0a1-eeb28179e9fb) |
| **Apply to Faciliate** | ![Screenshot 2024-06-04 at 00 27 30](https://github.com/WordPress/Learn/assets/18050944/699aa0a6-6b41-4535-b4ca-1fd211aedc3c) |
| **Grandchild Page** | ![Screenshot 2024-06-04 at 00 27 39](https://github.com/WordPress/Learn/assets/18050944/b6fa3343-d5f9-4e9d-957f-341e0b293fa5) |
| **Contribute** | ![Screenshot 2024-06-04 at 00 27 13](https://github.com/WordPress/Learn/assets/18050944/28d1ac24-ca8c-446b-a5f9-94b2af591de0) |
| **Lessons Archive** | ![Screenshot 2024-06-04 at 00 27 00](https://github.com/WordPress/Learn/assets/18050944/51bb4565-c8bb-4531-825e-d98ad3c8704c) |
| **Courses Archive** | ![Screenshot 2024-06-04 at 00 17 32](https://github.com/WordPress/Learn/assets/18050944/378a8a07-65cb-482c-bbc8-f3807777b439) |
| **Single Course** | ![Screenshot 2024-06-04 at 00 17 45](https://github.com/WordPress/Learn/assets/18050944/70562520-6e96-429b-a678-c2fcc75942ae) |
| **Learning Pathways** (got some issues rendering image here in the local env, but yeah this is the learning pathways) | ![Screenshot 2024-06-04 at 00 17 20](https://github.com/WordPress/Learn/assets/18050944/cd74fc92-d893-4a95-a5fd-74656128da57) |

