### PR TITLE
Fix accessibility of page landmarks

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2024/parts/footer.html
+++ b/wp-content/themes/pub/wporg-learn-2024/parts/footer.html
@@ -1,3 +1,3 @@
 <!-- wp:pattern {"slug":"wporg-learn-2024/footer-content"} /-->
 
-<!-- wp:wporg/global-footer /-->
+<!-- wp:wporg/global-footer {"tagName":"div"} /-->

--- a/wp-content/themes/pub/wporg-learn-2024/templates/archive-course.html
+++ b/wp-content/themes/pub/wporg-learn-2024/templates/archive-course.html
@@ -14,4 +14,4 @@
 </main>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer","tagName":"div"} /-->
+<!-- wp:template-part {"slug":"footer"} /-->

--- a/wp-content/themes/pub/wporg-learn-2024/templates/archive-lesson.html
+++ b/wp-content/themes/pub/wporg-learn-2024/templates/archive-lesson.html
@@ -14,4 +14,4 @@
 </main>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer","tagName":"div"} /-->
+<!-- wp:template-part {"slug":"footer"} /-->

--- a/wp-content/themes/pub/wporg-learn-2024/templates/archive.html
+++ b/wp-content/themes/pub/wporg-learn-2024/templates/archive.html
@@ -16,4 +16,4 @@
 </main>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer","tagName":"div"} /-->
+<!-- wp:template-part {"slug":"footer"} /-->

--- a/wp-content/themes/pub/wporg-learn-2024/templates/front-page.html
+++ b/wp-content/themes/pub/wporg-learn-2024/templates/front-page.html
@@ -14,4 +14,4 @@
 </main>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer","tagName":"div"} /-->
+<!-- wp:template-part {"slug":"footer"} /-->

--- a/wp-content/themes/pub/wporg-learn-2024/templates/index.html
+++ b/wp-content/themes/pub/wporg-learn-2024/templates/index.html
@@ -1,3 +1,3 @@
 <!-- wp:template-part {"slug":"header","className":"has-display-contents","tagName":"div"} /-->
 index
-<!-- wp:template-part {"slug":"footer","tagName":"div"} /-->
+<!-- wp:template-part {"slug":"footer"} /-->

--- a/wp-content/themes/pub/wporg-learn-2024/templates/page-learning-pathways.html
+++ b/wp-content/themes/pub/wporg-learn-2024/templates/page-learning-pathways.html
@@ -18,4 +18,4 @@
 </main>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer","tagName":"div"} /-->
+<!-- wp:template-part {"slug":"footer"} /-->

--- a/wp-content/themes/pub/wporg-learn-2024/templates/page-online-workshops.html
+++ b/wp-content/themes/pub/wporg-learn-2024/templates/page-online-workshops.html
@@ -16,4 +16,4 @@
 </main>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer","tagName":"div"} /-->
+<!-- wp:template-part {"slug":"footer"} /-->

--- a/wp-content/themes/pub/wporg-learn-2024/templates/page.html
+++ b/wp-content/themes/pub/wporg-learn-2024/templates/page.html
@@ -16,4 +16,4 @@
 </main>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer","tagName":"div"} /-->
+<!-- wp:template-part {"slug":"footer"} /-->

--- a/wp-content/themes/pub/wporg-learn-2024/templates/single-course.html
+++ b/wp-content/themes/pub/wporg-learn-2024/templates/single-course.html
@@ -16,4 +16,4 @@
 </main>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer","tagName":"div"} /-->
+<!-- wp:template-part {"slug":"footer"} /-->

--- a/wp-content/themes/pub/wporg-learn-2024/templates/single.html
+++ b/wp-content/themes/pub/wporg-learn-2024/templates/single.html
@@ -16,4 +16,4 @@
 </main>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer","tagName":"div"} /-->
+<!-- wp:template-part {"slug":"footer"} /-->

--- a/wp-content/themes/pub/wporg-learn-2024/templates/taxonomy-learning-pathway.html
+++ b/wp-content/themes/pub/wporg-learn-2024/templates/taxonomy-learning-pathway.html
@@ -8,4 +8,4 @@
 </main>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer","tagName":"div"} /-->
+<!-- wp:template-part {"slug":"footer"} /-->


### PR DESCRIPTION
Fixes the page landmarks so that the `main` and `footer` landmarks are adjacent, which is ideal for accessibility.

See https://wordpress.slack.com/archives/C01KC5VDQBC/p1717552327365119?thread_ts=1717455021.461299&cid=C01KC5VDQBC

Depends on https://github.com/WordPress/wporg-mu-plugins/pull/620

Fixes #2501 