### PR TITLE
Activate wporg-learn plugin at env setup

### DIFF
--- a/bin/index.sh
+++ b/bin/index.sh
@@ -27,4 +27,4 @@ npm run wp-env run cli wp theme activate pub/wporg-learn-2024
 npm run wp-env run cli wp rewrite structure '/%postname%/'
 
 # Import content
-# npm run wp-env run cli php bin/import-test-content.php
+npm run wp-env run cli php bin/import-test-content.php

--- a/bin/index.sh
+++ b/bin/index.sh
@@ -27,4 +27,4 @@ npm run wp-env run cli wp theme activate pub/wporg-learn-2024
 npm run wp-env run cli wp rewrite structure '/%postname%/'
 
 # Import content
-# npm run wp-env run cli "php bin/import-test-content.php"
+# npm run wp-env run cli php bin/import-test-content.php

--- a/bin/index.sh
+++ b/bin/index.sh
@@ -15,7 +15,7 @@ npm run wp-env run cli wp db import wp-content/uploads/wporg_events.sql
 npm run wp-env run cli wp db import wp-content/uploads/wporg_locales.sql
 
 # Activate plugins
-npm run wp-env run cli wp plugin activate edit-flow jetpack wordpress-importer sensei-lms gutenberg locale-detection code-syntax-block
+npm run wp-env run cli wp plugin activate edit-flow jetpack wordpress-importer sensei-lms gutenberg locale-detection code-syntax-block wporg-learn
 
 # Activate jetpack modules
 npm run wp-env run cli wp jetpack module activate contact-form

--- a/package.json
+++ b/package.json
@@ -22,9 +22,10 @@
 		]
 	},
 	"scripts": {
-		"build": "yarn workspaces run build",
-		"create": "composer install && yarn setup:tools && yarn workspace wporg-learn-2024 run build && yarn run install:env",
-		"create:old": "composer install && yarn setup:tools && yarn workspaces run build && yarn run install:env:old",
+		"build": "yarn workspace wporg-learn-2024 run build && yarn workspace wporg-learn-plugin run build",
+		"build:old": "yarn workspace wporg-learn-theme run build && yarn workspace wporg-learn-plugin run build",
+		"create": "composer install && yarn setup:tools && yarn build && yarn run install:env",
+		"create:old": "composer install && yarn setup:tools && yarn build:old && yarn run install:env:old",
 		"format:php": "composer run format",
 		"install:env": "./bin/index.sh",
 		"install:env:old": "./bin/index.old.sh",


### PR DESCRIPTION
Activate the `wporg-learn` plugin at the environment setup, as it's a theme's dependency.

Fix the import content command by removing double quotes. 

Fixes #2495 