### PR TITLE
Add query filters to Course and Lesson archives

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2024/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2024/functions.php
@@ -8,6 +8,7 @@ use function WPOrg_Learn\Sensei\{get_my_courses_page_url};
 require_once __DIR__ . '/src/learning-pathway-cards/index.php';
 require_once __DIR__ . '/src/search-results-context/index.php';
 require_once __DIR__ . '/src/upcoming-online-workshops/index.php';
+require_once __DIR__ . '/inc/block-config.php';
 
 /**
  * Actions and filters.

--- a/wp-content/themes/pub/wporg-learn-2024/inc/block-config.php
+++ b/wp-content/themes/pub/wporg-learn-2024/inc/block-config.php
@@ -6,6 +6,7 @@
 namespace WordPressdotorg\Theme\Learn_2024\Block_Config;
 
 add_filter( 'wporg_query_filter_options_level', __NAMESPACE__ . '\get_course_level_options' );
+add_filter( 'wporg_query_filter_options_topic', __NAMESPACE__ . '\get_course_topic_options' );
 
 /**
  * Get the list of levels for the course filters.
@@ -47,3 +48,42 @@ function get_course_level_options( $options ) {
 	);
 }
 
+/**
+ * Get the list of topics for the course filters.
+ *
+ * @param array $options The options for this filter.
+ * @return array New list of topic options.
+ */
+function get_course_topic_options( $options ) {
+	global $wp_query;
+	// Get top 20 topics ordered by count, then sort them alphabetically.
+	$topics = get_terms(
+		array(
+			'taxonomy' => 'topic',
+			'orderby' => 'count',
+			'order' => 'DESC',
+			'number' => 20,
+		)
+	);
+	usort(
+		$topics,
+		function ( $a, $b ) {
+			return strcmp( strtolower( $a->name ), strtolower( $b->name ) );
+		}
+	);
+	$selected = isset( $wp_query->query['wporg_workshop_topic'] ) ? (array) $wp_query->query['wporg_workshop_topic'] : array();
+	$count = count( $selected );
+	$label = sprintf(
+		/* translators: The dropdown label for filtering, %s is the selected term count. */
+		_n( 'Topics <span>%s</span>', 'Topics <span>%s</span>', $count, 'wporg-learn' ),
+		$count
+	);
+	return array(
+		'label' => $label,
+		'title' => __( 'Topics', 'wporg-learn' ),
+		'key' => 'wporg_workshop_topic',
+		'action' => home_url( '/courses/' ),
+		'options' => array_combine( wp_list_pluck( $topics, 'slug' ), wp_list_pluck( $topics, 'name' ) ),
+		'selected' => $selected,
+	);
+}

--- a/wp-content/themes/pub/wporg-learn-2024/inc/block-config.php
+++ b/wp-content/themes/pub/wporg-learn-2024/inc/block-config.php
@@ -174,9 +174,8 @@ function get_language_options( $options ) {
 function modify_query( $query ) {
 	// Ensure this code runs only for the main query on archive pages
 	if ( ! is_admin() && $query->is_main_query() && $query->is_archive() ) {
-		$language = $_GET['language'];
-		if ( isset( $language ) && is_array( $language ) ) {
-			$languages = array_map( 'sanitize_text_field', $language );
+		if ( isset( $_GET['language'] ) && is_array( $_GET['language'] ) ) {
+			$languages = array_map( 'sanitize_text_field', $_GET['language'] );
 
 			$meta_query = array( 'relation' => 'OR' );
 

--- a/wp-content/themes/pub/wporg-learn-2024/inc/block-config.php
+++ b/wp-content/themes/pub/wporg-learn-2024/inc/block-config.php
@@ -36,12 +36,12 @@ function get_course_level_options( $options ) {
 	$count = count( $selected );
 	$label = sprintf(
 		/* translators: The dropdown label for filtering, %s is the selected term count. */
-		_n( 'Experience levels <span>%s</span>', 'Experience levels <span>%s</span>', $count, 'wporg-learn' ),
+		_n( 'Level <span>%s</span>', 'Level <span>%s</span>', $count, 'wporg-learn' ),
 		$count
 	);
 	return array(
 		'label' => $label,
-		'title' => __( 'Experience levels', 'wporg-learn' ),
+		'title' => __( 'Level', 'wporg-learn' ),
 		'key' => 'wporg_lesson_level',
 		'action' => home_url( '/courses/' ),
 		'options' => array_combine( wp_list_pluck( $levels, 'slug' ), wp_list_pluck( $levels, 'name' ) ),
@@ -76,12 +76,12 @@ function get_course_topic_options( $options ) {
 	$count = count( $selected );
 	$label = sprintf(
 		/* translators: The dropdown label for filtering, %s is the selected term count. */
-		_n( 'Topics <span>%s</span>', 'Topics <span>%s</span>', $count, 'wporg-learn' ),
+		_n( 'Topic <span>%s</span>', 'Topic <span>%s</span>', $count, 'wporg-learn' ),
 		$count
 	);
 	return array(
 		'label' => $label,
-		'title' => __( 'Topics', 'wporg-learn' ),
+		'title' => __( 'Topic', 'wporg-learn' ),
 		'key' => 'wporg_workshop_topic',
 		'action' => home_url( '/courses/' ),
 		'options' => array_combine( wp_list_pluck( $topics, 'slug' ), wp_list_pluck( $topics, 'name' ) ),

--- a/wp-content/themes/pub/wporg-learn-2024/inc/block-config.php
+++ b/wp-content/themes/pub/wporg-learn-2024/inc/block-config.php
@@ -7,6 +7,7 @@ namespace WordPressdotorg\Theme\Learn_2024\Block_Config;
 
 add_filter( 'wporg_query_filter_options_level', __NAMESPACE__ . '\get_course_level_options' );
 add_filter( 'wporg_query_filter_options_topic', __NAMESPACE__ . '\get_course_topic_options' );
+add_action( 'wporg_query_filter_in_form', __NAMESPACE__ . '\inject_other_filters' );
 
 /**
  * Get the list of levels for the course filters.
@@ -86,4 +87,31 @@ function get_course_topic_options( $options ) {
 		'options' => array_combine( wp_list_pluck( $topics, 'slug' ), wp_list_pluck( $topics, 'name' ) ),
 		'selected' => $selected,
 	);
+}
+
+/**
+ * Add in the other existing filters as hidden inputs in the filter form.
+ *
+ * Enables combining filters by building up the correct URL on submit,
+ * for example courses using a topic and a level:
+ *   ?wporg_workshop_topic[]=extending-wordpress&wporg_lesson_level[]=beginner`
+ *
+ * @param string $key The key for the current filter.
+ */
+function inject_other_filters( $key ) {
+	global $wp_query;
+
+	$query_vars = array( 'wporg_workshop_topic', 'wporg_lesson_level' );
+	foreach ( $query_vars as $query_var ) {
+		if ( ! isset( $wp_query->query[ $query_var ] ) ) {
+			continue;
+		}
+		if ( $key === $query_var ) {
+			continue;
+		}
+		$values = (array) $wp_query->query[ $query_var ];
+		foreach ( $values as $value ) {
+			printf( '<input type="hidden" name="%s[]" value="%s" />', esc_attr( $query_var ), esc_attr( $value ) );
+		}
+	}
 }

--- a/wp-content/themes/pub/wporg-learn-2024/inc/block-config.php
+++ b/wp-content/themes/pub/wporg-learn-2024/inc/block-config.php
@@ -116,7 +116,7 @@ function get_topic_options( $options ) {
  *
  * @param WP_Query $query The query.
  * @param string   $key The meta key.
- * @return mixed   The meta query values.
+ * @return array   The meta query values.
  */
 function get_meta_query_values_by_key( $query, $key ) {
 	if ( isset( $query->query_vars['meta_query'] ) ) {
@@ -223,6 +223,20 @@ function inject_other_filters( $key ) {
 		$values = (array) $wp_query->query[ $query_var ];
 		foreach ( $values as $value ) {
 			printf( '<input type="hidden" name="%s[]" value="%s" />', esc_attr( $query_var ), esc_attr( $value ) );
+		}
+	}
+
+	$meta_query_vars = array( 'language' );
+	foreach ( $meta_query_vars as $meta_query_var ) {
+		$values = (array) get_meta_query_values_by_key( $wp_query, $meta_query_var );
+		if ( empty( $values ) ) {
+			continue;
+		}
+		if ( $key === $meta_query_var ) {
+			continue;
+		}
+		foreach ( $values as $value ) {
+			printf( '<input type="hidden" name="%s[]" value="%s" />', esc_attr( $meta_query_var ), esc_attr( $value ) );
 		}
 	}
 }

--- a/wp-content/themes/pub/wporg-learn-2024/inc/block-config.php
+++ b/wp-content/themes/pub/wporg-learn-2024/inc/block-config.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Set up configuration for dynamic blocks.
+ */
+
+namespace WordPressdotorg\Theme\Learn_2024\Block_Config;
+
+add_filter( 'wporg_query_filter_options_level', __NAMESPACE__ . '\get_course_level_options' );
+
+/**
+ * Get the list of levels for the course filters.
+ *
+ * @param array $options The options for this filter.
+ * @return array New list of level options.
+ */
+function get_course_level_options( $options ) {
+	global $wp_query;
+	// Get top 10 levels ordered by count, then sort them alphabetically.
+	$levels = get_terms(
+		array(
+			'taxonomy' => 'level',
+			'orderby' => 'count',
+			'order' => 'DESC',
+			'number' => 10,
+		)
+	);
+	usort(
+		$levels,
+		function ( $a, $b ) {
+			return strcmp( strtolower( $a->name ), strtolower( $b->name ) );
+		}
+	);
+	$selected = isset( $wp_query->query['wporg_lesson_level'] ) ? (array) $wp_query->query['wporg_lesson_level'] : array();
+	$count = count( $selected );
+	$label = sprintf(
+		/* translators: The dropdown label for filtering, %s is the selected term count. */
+		_n( 'Experience levels <span>%s</span>', 'Experience levels <span>%s</span>', $count, 'wporg-learn' ),
+		$count
+	);
+	return array(
+		'label' => $label,
+		'title' => __( 'Experience levels', 'wporg-learn' ),
+		'key' => 'wporg_lesson_level',
+		'action' => home_url( '/courses/' ),
+		'options' => array_combine( wp_list_pluck( $levels, 'slug' ), wp_list_pluck( $levels, 'name' ) ),
+		'selected' => $selected,
+	);
+}
+

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/archive-courses-content.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/archive-courses-content.php
@@ -19,13 +19,20 @@
 </div>
 <!-- /wp:group -->
 
-<!-- wp:group {"align":"wide","style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|50"}}}} -->
-<div id="wporg-search" class="wp-block-group alignwide" style="margin-top:0;margin-bottom:var(--wp--preset--spacing--50)">
+<!-- wp:group {"align":"wide","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"},"style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|50"}}}} -->
+<div class="wp-block-group alignwide" style="margin-top:0;margin-bottom:var(--wp--preset--spacing--50)">
 
 	<!-- wp:search {"label":"<?php esc_attr_e( 'Search', 'wporg-learn' ); ?>","showLabel":false,"placeholder":"<?php esc_attr_e( 'Search courses', 'wporg-learn' ); ?>","width":290,"widthUnit":"px","buttonText":"<?php esc_attr_e( 'Search', 'wporg-learn' ); ?>","buttonPosition":"button-inside","buttonUseIcon":true,"query":{"post_type":"course"}} /-->
 
+	<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"flex","flexWrap":"nowrap"},"className":"wporg-query-filters"} -->
+	<div class="wp-block-group wporg-query-filters">
+		<!-- wp:wporg/query-filter {"key":"level"} /-->
+	</div>
+	<!-- /wp:group -->
+
 </div>
 <!-- /wp:group -->
+
 
 <!-- wp:query {"queryId":1,"query":{"perPage":12,"postType":"course","courseFeatured":false,"inherit":true},"namespace":"wporg-learn/course-grid","align":"wide","className":"wporg-learn-course-grid"} -->
 <div class="wp-block-query alignwide wporg-learn-course-grid">

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/archive-courses-content.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/archive-courses-content.php
@@ -27,8 +27,8 @@
 	<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"flex","flexWrap":"nowrap"},"className":"wporg-query-filters"} -->
 	<div class="wp-block-group wporg-query-filters">
 		<!-- wp:wporg/query-filter {"key":"language"} /-->
-		<!-- wp:wporg/query-filter {"key":"level"} /-->
 		<!-- wp:wporg/query-filter {"key":"topic"} /-->
+		<!-- wp:wporg/query-filter {"key":"level"} /-->
 	</div>
 	<!-- /wp:group -->
 

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/archive-courses-content.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/archive-courses-content.php
@@ -27,6 +27,7 @@
 	<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"flex","flexWrap":"nowrap"},"className":"wporg-query-filters"} -->
 	<div class="wp-block-group wporg-query-filters">
 		<!-- wp:wporg/query-filter {"key":"level"} /-->
+		<!-- wp:wporg/query-filter {"key":"topic"} /-->
 	</div>
 	<!-- /wp:group -->
 

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/archive-courses-content.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/archive-courses-content.php
@@ -26,6 +26,7 @@
 
 	<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"flex","flexWrap":"nowrap"},"className":"wporg-query-filters"} -->
 	<div class="wp-block-group wporg-query-filters">
+		<!-- wp:wporg/query-filter {"key":"language"} /-->
 		<!-- wp:wporg/query-filter {"key":"level"} /-->
 		<!-- wp:wporg/query-filter {"key":"topic"} /-->
 	</div>

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/archive-lessons-content.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/archive-lessons-content.php
@@ -19,10 +19,18 @@
 </div>
 <!-- /wp:group -->
 
-<!-- wp:group {"align":"wide","style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|50"}}}} -->
-<div id="wporg-search" class="wp-block-group alignwide" style="margin-top:0;margin-bottom:var(--wp--preset--spacing--50)">
+<!-- wp:group {"align":"wide","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"},"style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|50"}}}} -->
+<div class="wp-block-group alignwide" style="margin-top:0;margin-bottom:var(--wp--preset--spacing--50)">
 
 	<!-- wp:search {"label":"<?php esc_attr_e( 'Search', 'wporg-learn' ); ?>","showLabel":false,"placeholder":"<?php esc_attr_e( 'Search lessons', 'wporg-learn' ); ?>","width":290,"widthUnit":"px","buttonText":"<?php esc_attr_e( 'Search', 'wporg-learn' ); ?>","buttonPosition":"button-inside","buttonUseIcon":true,"query":{"post_type":"lesson"}} /-->
+
+	<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"flex","flexWrap":"nowrap"},"className":"wporg-query-filters"} -->
+	<div class="wp-block-group wporg-query-filters">
+		<!-- wp:wporg/query-filter {"key":"language"} /-->
+		<!-- wp:wporg/query-filter {"key":"topic"} /-->
+		<!-- wp:wporg/query-filter {"key":"level"} /-->
+	</div>
+	<!-- /wp:group -->
 
 </div>
 <!-- /wp:group -->


### PR DESCRIPTION
Closes #2396 
Closes #2417 

Adds query filters to the Course and Lesson archives. The implementation is mostly copied from Showcase. The main difference here is that we need to filter Lessons by Language, which is post meta.

I've added this Language filter on the Course archive too, as I think it's more likely that it will be set there than on individual courses, and [noted this on Figma](https://www.figma.com/design/ZKaf6u8mIHkAanluWafXAp?node-id=3473-44005&m=dev#830155785).

I haven't added the Lesson Duration filter yet as I'm not sure how it should work, and I've created a new [issue](https://github.com/WordPress/Learn/issues/2510).

### Screenshots

#### Courses

| Desktop | Tablet | Mobile |
|-|-|-|
| ![localhost_8888_courses__language%5B%5D=en_NZ(Desktop)](https://github.com/WordPress/Learn/assets/1017872/cc83b363-7788-4209-90f6-ffd734cf21b8) | ![localhost_8888_courses__language%5B%5D=en_NZ(iPad)](https://github.com/WordPress/Learn/assets/1017872/16d94ddd-6fef-4ca5-8cd9-f9230336f5d7) | ![localhost_8888_courses__language%5B%5D=en_NZ(Samsung Galaxy S20 Ultra)](https://github.com/WordPress/Learn/assets/1017872/8dcdb69d-ddac-460e-966a-bccaa58eca50) |

#### Lessons

| Desktop | Tablet | Mobile |
|-|-|-|
| ![localhost_8888_lessons__wporg_lesson_level%5B%5D=beginner(Desktop)](https://github.com/WordPress/Learn/assets/1017872/2b062fda-3efd-417f-b303-33811dc6a82f) | ![localhost_8888_lessons__wporg_lesson_level%5B%5D=beginner(iPad)](https://github.com/WordPress/Learn/assets/1017872/c81ec0b6-0039-463d-ac07-6d8c194676ea) | ![localhost_8888_lessons__wporg_lesson_level%5B%5D=beginner(Samsung Galaxy S20 Ultra)](https://github.com/WordPress/Learn/assets/1017872/2ce03fa9-e844-4b0f-8907-7c41bdebfdcc) |
