### PR TITLE
Add single course page

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2024/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2024/functions.php
@@ -8,6 +8,7 @@ use function WPOrg_Learn\Sensei\{get_my_courses_page_url};
 require_once __DIR__ . '/src/learning-pathway-cards/index.php';
 require_once __DIR__ . '/src/search-results-context/index.php';
 require_once __DIR__ . '/src/upcoming-online-workshops/index.php';
+require_once __DIR__ . '/src/sensei-meta-list/index.php';
 require_once __DIR__ . '/inc/block-config.php';
 
 /**

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/sidebar-meta-info.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/sidebar-meta-info.php
@@ -10,15 +10,17 @@
 <!-- wp:group {"align":"full","className":"wporg-learn-sidebar-meta-info","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull wporg-learn-sidebar-meta-info">
 
+	<!-- wp:sensei-lms/course-progress {"defaultBarColor":"blueberry-1"} /-->
+
 	<!-- wp:sensei-lms/button-take-course {"align":"full","borderRadius":2,"className":"is-style-default"} -->
 	<div class="wp-block-sensei-lms-button-take-course is-style-default wp-block-sensei-button wp-block-button has-text-align-full">
 	<button class="wp-block-button__link" style="border-radius:2px">Take this Course</button>
 	</div>
 	<!-- /wp:sensei-lms/button-take-course -->
 
-	<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
+	<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"},"className":""wporg-learn-sidebar-playground"} -->
 	<div class="wp-block-buttons"><!-- wp:button {"textAlign":"center","width":100,"style":{"border":{"radius":"2px"},"spacing":{"padding":{"left":"13px","right":"13px","top":"16px","bottom":"16px"}},"typography":{"lineHeight":0,"fontStyle":"normal","fontWeight":"400"}},"className":"aligncenter is-style-outline","fontSize":"normal","fontFamily":"inter"} -->
-	<div class="wp-block-button has-custom-width wp-block-button__width-100 has-custom-font-size aligncenter is-style-outline has-inter-font-family has-normal-font-size" style="font-style:normal;font-weight:400;line-height:0"><a class="wp-block-button__link has-text-align-center wp-element-button" href="https://wordpress.org/playground/demo/?step=playground&amp;theme=twentytwentythree" style="border-radius:2px;padding-top:16px;padding-right:13px;padding-bottom:16px;padding-left:13px" target="_blank" rel="noreferrer noopener">Practice on a private demo site</a></div>
+	<div class="wp-block-button has-custom-width wp-block-button__width-100 has-custom-font-size aligncenter is-style-outline has-inter-font-family has-normal-font-size wporg-learn-sidebar-playground" style="font-style:normal;font-weight:400;line-height:0"><a class="wp-block-button__link has-text-align-center wp-element-button" href="https://wordpress.org/playground/demo/?step=playground&amp;theme=twentytwentythree" style="border-radius:2px;padding-top:16px;padding-right:13px;padding-bottom:16px;padding-left:13px" target="_blank" rel="noreferrer noopener">Practice on a private demo site</a></div>
 	<!-- /wp:button --></div>
 	<!-- /wp:buttons -->
 

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/sidebar-meta-info.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/sidebar-meta-info.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Title: Sidebar Meta Info
+ * Slug: wporg-learn-2024/sidebar-meta-info
+ * Inserter: no
+ */
+
+?>
+
+<!-- wp:group {"align":"full","className":"wporg-learn-sidebar-meta-info","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull wporg-learn-sidebar-meta-info"><!-- wp:sensei-lms/button-take-course {"align":"full","borderRadius":2,"className":"is-style-default"} -->
+
+	<!-- wp:sensei-lms/button-take-course {"align":"full","borderRadius":2,"className":"is-style-default"} -->
+	<div class="wp-block-sensei-lms-button-take-course is-style-default wp-block-sensei-button wp-block-button has-text-align-full">
+	<button class="wp-block-button__link" style="border-radius:2px">Take this Course</button>
+	</div>
+	<!-- /wp:sensei-lms/button-take-course -->
+
+	<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
+	<div class="wp-block-buttons"><!-- wp:button {"textAlign":"center","width":100,"style":{"border":{"radius":"2px"},"spacing":{"padding":{"left":"32px","right":"32px","top":"17px","bottom":"17px"}},"typography":{"lineHeight":1.6,"fontStyle":"normal","fontWeight":"400"}},"className":"aligncenter is-style-outline","fontSize":"normal","fontFamily":"inter"} -->
+	<div class="wp-block-button has-custom-width wp-block-button__width-100 has-custom-font-size aligncenter is-style-outline has-inter-font-family has-normal-font-size" style="font-style:normal;font-weight:400;line-height:1.6"><a class="wp-block-button__link has-text-align-center wp-element-button" href="https://wordpress.org/playground/demo/?step=playground&amp;theme=twentytwentythree" style="border-radius:2px;padding-top:17px;padding-right:32px;padding-bottom:17px;padding-left:32px" target="_blank" rel="noreferrer noopener">Practice on a private demo site</a></div>
+	<!-- /wp:button --></div>
+	<!-- /wp:buttons -->
+
+	<!-- wp:wporg-learn/course-data /-->
+
+	<!-- wp:paragraph -->
+	<p id="suggestions"><strong>Suggestions</strong></p>
+	<!-- /wp:paragraph -->
+
+	<!-- wp:paragraph -->
+	<p>Found a typo, grammar error or outdated screenshot? <a href="https://learn.wordpress.org/report-content-errors/">Contact us</a></p>
+	<!-- /wp:paragraph -->
+
+	<!-- wp:paragraph -->
+	<p id="suggestions"><strong>License</strong></p>
+	<!-- /wp:paragraph -->
+
+	<!-- wp:paragraph -->
+	<p>This work is licensed under a <a href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>.</p>
+	<!-- /wp:paragraph -->
+
+</div>
+<!-- /wp:group -->

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/sidebar-meta-info.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/sidebar-meta-info.php
@@ -22,7 +22,7 @@
 	<!-- /wp:paragraph -->
 	<?php endif; ?>
 
-	<!-- wp:sensei-lms/course-progress {"defaultBarColor":"blueberry-1"} /-->
+	<!-- wp:sensei-lms/course-progress {"barColor":"blueberry-1","barBackgroundColor":"blueberry-3","height":8,"className":"wporg-learn-sidebar-course-progress"} /-->
 
 	<!-- wp:sensei-lms/button-take-course {"align":"full","borderRadius":2,"className":"is-style-default"} -->
 	<div class="wp-block-sensei-lms-button-take-course is-style-default wp-block-sensei-button wp-block-button has-text-align-full">

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/sidebar-meta-info.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/sidebar-meta-info.php
@@ -8,7 +8,7 @@
 ?>
 
 <!-- wp:group {"align":"full","className":"wporg-learn-sidebar-meta-info","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull wporg-learn-sidebar-meta-info"><!-- wp:sensei-lms/button-take-course {"align":"full","borderRadius":2,"className":"is-style-default"} -->
+<div class="wp-block-group alignfull wporg-learn-sidebar-meta-info">
 
 	<!-- wp:sensei-lms/button-take-course {"align":"full","borderRadius":2,"className":"is-style-default"} -->
 	<div class="wp-block-sensei-lms-button-take-course is-style-default wp-block-sensei-button wp-block-button has-text-align-full">
@@ -17,8 +17,8 @@
 	<!-- /wp:sensei-lms/button-take-course -->
 
 	<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
-	<div class="wp-block-buttons"><!-- wp:button {"textAlign":"center","width":100,"style":{"border":{"radius":"2px"},"spacing":{"padding":{"left":"32px","right":"32px","top":"17px","bottom":"17px"}},"typography":{"lineHeight":1.6,"fontStyle":"normal","fontWeight":"400"}},"className":"aligncenter is-style-outline","fontSize":"normal","fontFamily":"inter"} -->
-	<div class="wp-block-button has-custom-width wp-block-button__width-100 has-custom-font-size aligncenter is-style-outline has-inter-font-family has-normal-font-size" style="font-style:normal;font-weight:400;line-height:1.6"><a class="wp-block-button__link has-text-align-center wp-element-button" href="https://wordpress.org/playground/demo/?step=playground&amp;theme=twentytwentythree" style="border-radius:2px;padding-top:17px;padding-right:32px;padding-bottom:17px;padding-left:32px" target="_blank" rel="noreferrer noopener">Practice on a private demo site</a></div>
+	<div class="wp-block-buttons"><!-- wp:button {"textAlign":"center","width":100,"style":{"border":{"radius":"2px"},"spacing":{"padding":{"left":"13px","right":"13px","top":"16px","bottom":"16px"}},"typography":{"lineHeight":0,"fontStyle":"normal","fontWeight":"400"}},"className":"aligncenter is-style-outline","fontSize":"normal","fontFamily":"inter"} -->
+	<div class="wp-block-button has-custom-width wp-block-button__width-100 has-custom-font-size aligncenter is-style-outline has-inter-font-family has-normal-font-size" style="font-style:normal;font-weight:400;line-height:0"><a class="wp-block-button__link has-text-align-center wp-element-button" href="https://wordpress.org/playground/demo/?step=playground&amp;theme=twentytwentythree" style="border-radius:2px;padding-top:16px;padding-right:13px;padding-bottom:16px;padding-left:13px" target="_blank" rel="noreferrer noopener">Practice on a private demo site</a></div>
 	<!-- /wp:button --></div>
 	<!-- /wp:buttons -->
 

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/sidebar-meta-info.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/sidebar-meta-info.php
@@ -22,7 +22,7 @@
 	<!-- /wp:button --></div>
 	<!-- /wp:buttons -->
 
-	<!-- wp:wporg-learn/course-data /-->
+	<!-- wp:wporg-learn/sensei-meta-list {"type":"course","fontSize":"normal"} /-->
 
 	<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"400","lineHeight":"34px"}},"fontSize":"large","fontFamily":"inter"} -->
 	<p class="has-inter-font-family has-large-font-size" id="suggestions" style="font-style:normal;font-weight:400;line-height:34px">Suggestions</p>

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/sidebar-meta-info.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/sidebar-meta-info.php
@@ -54,7 +54,7 @@
 
 	<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"400,"lineHeight":"26px"},"spacing":{"margin":{"bottom":"40px"}}},"fontSize":"normal","fontFamily":"inter"} -->
 	<p class="has-inter-font-family has-normal-font-size" style="margin-bottom:40px;font-style:normal;font-weight:400;line-height:26px">
-		<?php esc_html_e( 'Found a typo, grammar error or outdated screenshot? ', 'wporg-learn' ); ?><a href="https://learn.wordpress.org/report-content-errors/"><?php esc_html_e( 'Contact us', 'wporg-learn' ); ?></a>
+		<?php esc_html_e( 'Found a typo, grammar error or outdated screenshot? ', 'wporg-learn' ); ?><a href="https://learn.wordpress.org/report-content-feedback/"><?php esc_html_e( 'Contact us', 'wporg-learn' ); ?></a>
 	</p>
 	<!-- /wp:paragraph -->
 

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/sidebar-meta-info.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/sidebar-meta-info.php
@@ -14,7 +14,11 @@
 
 	<?php if ( Sensei_Course::is_user_enrolled( get_the_ID() ) ) : ?>
 	<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}},"typography":{"fontStyle":"normal","fontWeight":"400","lineHeight":26px}},"textColor":"blueberry-1","fontSize":"normal","fontFamily":"inter","className":""wporg-learn-sidebar-all-courses"} -->
-	<p class="has-blueberry-1-color has-text-color has-link-color has-inter-font-family has-normal-font-size wporg-learn-sidebar-all-courses" style="font-style:normal;font-weight:400;line-height:26px"><a href="<?php echo esc_url( get_my_courses_page_url() ); ?>">All My Courses</a></p>
+	<p class="has-blueberry-1-color has-text-color has-link-color has-inter-font-family has-normal-font-size wporg-learn-sidebar-all-courses" style="font-style:normal;font-weight:400;line-height:26px">
+		<a href="<?php echo esc_url( get_my_courses_page_url() ); ?>">
+			<?php esc_html_e( 'All My Courses', 'wporg-learn' ); ?>
+		</a>
+	</p>
 	<!-- /wp:paragraph -->
 	<?php endif; ?>
 
@@ -22,32 +26,48 @@
 
 	<!-- wp:sensei-lms/button-take-course {"align":"full","borderRadius":2,"className":"is-style-default"} -->
 	<div class="wp-block-sensei-lms-button-take-course is-style-default wp-block-sensei-button wp-block-button has-text-align-full">
-	<button class="wp-block-button__link" style="border-radius:2px">Take this Course</button>
+		<button class="wp-block-button__link" style="border-radius:2px">
+			<?php esc_html_e( 'Take this Course', 'wporg-learn' ); ?>
+		</button>
 	</div>
 	<!-- /wp:sensei-lms/button-take-course -->
 
 	<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"},"className":""wporg-learn-sidebar-playground"} -->
-	<div class="wp-block-buttons"><!-- wp:button {"textAlign":"center","width":100,"style":{"border":{"radius":"2px"},"spacing":{"padding":{"left":"13px","right":"13px","top":"16px","bottom":"16px"}},"typography":{"lineHeight":0,"fontStyle":"normal","fontWeight":"400"}},"className":"aligncenter is-style-outline","fontSize":"normal","fontFamily":"inter"} -->
-	<div class="wp-block-button has-custom-width wp-block-button__width-100 has-custom-font-size aligncenter is-style-outline has-inter-font-family has-normal-font-size wporg-learn-sidebar-playground" style="font-style:normal;font-weight:400;line-height:0"><a class="wp-block-button__link has-text-align-center wp-element-button" href="https://wordpress.org/playground/demo/?step=playground&amp;theme=twentytwentythree" style="border-radius:2px;padding-top:16px;padding-right:13px;padding-bottom:16px;padding-left:13px" target="_blank" rel="noreferrer noopener">Practice on a private demo site</a></div>
-	<!-- /wp:button --></div>
+	<div class="wp-block-buttons">
+		<!-- wp:button {"textAlign":"center","width":100,"style":{"border":{"radius":"2px"},"spacing":{"padding":{"left":"13px","right":"13px","top":"16px","bottom":"16px"}},"typography":{"lineHeight":0,"fontStyle":"normal","fontWeight":"400"}},"className":"aligncenter is-style-outline","fontSize":"normal","fontFamily":"inter"} -->
+		<div class="wp-block-button has-custom-width wp-block-button__width-100 has-custom-font-size aligncenter is-style-outline has-inter-font-family has-normal-font-size wporg-learn-sidebar-playground" style="font-style:normal;font-weight:400;line-height:0">
+			<a class="wp-block-button__link has-text-align-center wp-element-button" href="https://wordpress.org/playground/demo/?step=playground&amp;theme=twentytwentythree" style="border-radius:2px;padding-top:16px;padding-right:13px;padding-bottom:16px;padding-left:13px" target="_blank" rel="noreferrer noopener">
+				<?php esc_html_e( 'Practice on a private demo site', 'wporg-learn' ); ?>
+			</a>
+		</div>
+		<!-- /wp:button -->
+	</div>
 	<!-- /wp:buttons -->
 
 	<!-- wp:wporg-learn/sensei-meta-list {"type":"course","fontSize":"normal"} /-->
 
 	<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"400","lineHeight":"34px"}},"fontSize":"large","fontFamily":"inter"} -->
-	<p class="has-inter-font-family has-large-font-size" id="suggestions" style="font-style:normal;font-weight:400;line-height:34px">Suggestions</p>
+	<p class="has-inter-font-family has-large-font-size" id="suggestions" style="font-style:normal;font-weight:400;line-height:34px">
+		<?php esc_html_e( 'Suggestions', 'wporg-learn' ); ?>
+	</p>
 	<!-- /wp:paragraph -->
 
 	<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"400,"lineHeight":"26px"},"spacing":{"margin":{"bottom":"40px"}}},"fontSize":"normal","fontFamily":"inter"} -->
-	<p class="has-inter-font-family has-normal-font-size" style="margin-bottom:40px;font-style:normal;font-weight:400;line-height:26px">Found a typo, grammar error or outdated screenshot? <a href="https://learn.wordpress.org/report-content-errors/">Contact us</a></p>
+	<p class="has-inter-font-family has-normal-font-size" style="margin-bottom:40px;font-style:normal;font-weight:400;line-height:26px">
+		<?php esc_html_e( 'Found a typo, grammar error or outdated screenshot? ', 'wporg-learn' ); ?><a href="https://learn.wordpress.org/report-content-errors/"><?php esc_html_e( 'Contact us', 'wporg-learn' ); ?></a>
+	</p>
 	<!-- /wp:paragraph -->
 
 	<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"400","lineHeight":"34px"}},"fontSize":"large","fontFamily":"inter"} -->
-	<p class="has-inter-font-family has-large-font-size" id="suggestions" style="font-style:normal;font-weight:400;line-height:34px">License</p>
+	<p class="has-inter-font-family has-large-font-size" id="suggestions" style="font-style:normal;font-weight:400;line-height:34px">
+		<?php esc_html_e( 'License', 'wporg-learn' ); ?>
+	</p>
 	<!-- /wp:paragraph -->
 
 	<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"400,"lineHeight":"26px"}},"fontSize":"normal","fontFamily":"inter"} -->
-	<p class="has-inter-font-family has-normal-font-size" style="font-style:normal;font-weight:400;line-height:26px">This work is licensed under a <a href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>.</p>
+	<p class="has-inter-font-family has-normal-font-size" style="font-style:normal;font-weight:400;line-height:26px">
+		<?php esc_html_e( 'This work is licensed under a ', 'wporg-learn' ); ?><a href="http://creativecommons.org/licenses/by-sa/4.0/"><?php esc_html_e( 'Creative Commons Attribution-ShareAlike 4.0 International License', 'wporg-learn' ); ?></a>.
+	</p>
 	<!-- /wp:paragraph -->
 
 </div>

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/sidebar-meta-info.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/sidebar-meta-info.php
@@ -24,20 +24,20 @@
 
 	<!-- wp:wporg-learn/course-data /-->
 
-	<!-- wp:paragraph -->
-	<p id="suggestions"><strong>Suggestions</strong></p>
+	<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"400","lineHeight":"34px"}},"fontSize":"large","fontFamily":"inter"} -->
+	<p class="has-inter-font-family has-large-font-size" id="suggestions" style="font-style:normal;font-weight:400;line-height:34px">Suggestions</p>
 	<!-- /wp:paragraph -->
 
-	<!-- wp:paragraph -->
-	<p>Found a typo, grammar error or outdated screenshot? <a href="https://learn.wordpress.org/report-content-errors/">Contact us</a></p>
+	<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"400,"lineHeight":"26px"},"spacing":{"margin":{"bottom":"40px"}}},"fontSize":"normal","fontFamily":"inter"} -->
+	<p class="has-inter-font-family has-normal-font-size" style="margin-bottom:40px;font-style:normal;font-weight:400;line-height:26px">Found a typo, grammar error or outdated screenshot? <a href="https://learn.wordpress.org/report-content-errors/">Contact us</a></p>
 	<!-- /wp:paragraph -->
 
-	<!-- wp:paragraph -->
-	<p id="suggestions"><strong>License</strong></p>
+	<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"400","lineHeight":"34px"}},"fontSize":"large","fontFamily":"inter"} -->
+	<p class="has-inter-font-family has-large-font-size" id="suggestions" style="font-style:normal;font-weight:400;line-height:34px">License</p>
 	<!-- /wp:paragraph -->
 
-	<!-- wp:paragraph -->
-	<p>This work is licensed under a <a href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>.</p>
+	<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"400,"lineHeight":"26px"}},"fontSize":"normal","fontFamily":"inter"} -->
+	<p class="has-inter-font-family has-normal-font-size" style="font-style:normal;font-weight:400;line-height:26px">This work is licensed under a <a href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>.</p>
 	<!-- /wp:paragraph -->
 
 </div>

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/sidebar-meta-info.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/sidebar-meta-info.php
@@ -5,10 +5,18 @@
  * Inserter: no
  */
 
+ use function WPOrg_Learn\Sensei\{get_my_courses_page_url}
+
 ?>
 
 <!-- wp:group {"align":"full","className":"wporg-learn-sidebar-meta-info","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull wporg-learn-sidebar-meta-info">
+
+	<?php if ( Sensei_Course::is_user_enrolled( get_the_ID() ) ) : ?>
+	<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}},"typography":{"fontStyle":"normal","fontWeight":"400","lineHeight":26px}},"textColor":"blueberry-1","fontSize":"normal","fontFamily":"inter","className":""wporg-learn-sidebar-all-courses"} -->
+	<p class="has-blueberry-1-color has-text-color has-link-color has-inter-font-family has-normal-font-size wporg-learn-sidebar-all-courses" style="font-style:normal;font-weight:400;line-height:26px"><a href="<?php echo esc_url( get_my_courses_page_url() ); ?>">All My Courses</a></p>
+	<!-- /wp:paragraph -->
+	<?php endif; ?>
 
 	<!-- wp:sensei-lms/course-progress {"defaultBarColor":"blueberry-1"} /-->
 

--- a/wp-content/themes/pub/wporg-learn-2024/src/sensei-meta-list/block.json
+++ b/wp-content/themes/pub/wporg-learn-2024/src/sensei-meta-list/block.json
@@ -25,7 +25,7 @@
 			"lineHeight": true
 		}
 	},
-	"usesContext": [ "postId" ],
+	"usesContext": [ "postId", "postType" ],
 	"editorScript": "file:./index.js",
 	"style": "file:./style-index.css"
 }

--- a/wp-content/themes/pub/wporg-learn-2024/src/sensei-meta-list/block.json
+++ b/wp-content/themes/pub/wporg-learn-2024/src/sensei-meta-list/block.json
@@ -1,0 +1,31 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "wporg-learn/sensei-meta-list",
+	"version": "0.1.0",
+	"title": "Sensei Meta List",
+	"category": "design",
+	"icon": "",
+	"description": "Display the site meta data of a learn or course as a list.",
+	"textdomain": "wporg-learn",
+	"supports": {
+		"align": true,
+		"html": false,
+		"color": {
+			"text": true,
+			"background": true,
+			"link": true
+		},
+		"spacing": {
+			"margin": true,
+			"padding": true
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true
+		}
+	},
+	"usesContext": [ "postId" ],
+	"editorScript": "file:./index.js",
+	"style": "file:./style-index.css"
+}

--- a/wp-content/themes/pub/wporg-learn-2024/src/sensei-meta-list/index.js
+++ b/wp-content/themes/pub/wporg-learn-2024/src/sensei-meta-list/index.js
@@ -1,0 +1,19 @@
+/**
+ * WordPress dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import Edit from '../shared/dynamic-edit';
+import metadata from './block.json';
+import './style.scss';
+
+registerBlockType( metadata.name, {
+	/**
+	 * @see ./edit.js
+	 */
+	edit: Edit,
+	save: () => null,
+} );

--- a/wp-content/themes/pub/wporg-learn-2024/src/sensei-meta-list/index.php
+++ b/wp-content/themes/pub/wporg-learn-2024/src/sensei-meta-list/index.php
@@ -64,6 +64,9 @@ function render( $attributes, $content, $block ) {
 		// Get the average number of days it takes to complete a course
 		$average_days = $course_service->get_average_days_to_completion( array( $course_id ) );
 
+		// Get the last updated time
+		$last_updated = get_last_updated_time( $course_id );
+
 		// Set up array of data to be used
 		$meta_fields = array(
 			array(
@@ -80,6 +83,11 @@ function render( $attributes, $content, $block ) {
 				'label' => __( 'Average days to completion', 'wporg-learn' ),
 				'value' => $average_days,
 				'key'   => 'average-days',
+			),
+			array(
+				'label' => __( 'Last updated', 'wporg-learn' ),
+				'value' => $last_updated,
+				'key'   => 'last-updated',
 			),
 		);
 	}
@@ -102,4 +110,27 @@ function render( $attributes, $content, $block ) {
 		$wrapper_attributes,
 		join( '', $list_items )
 	);
+}
+
+/**
+ * Get the last updated time for a course.
+ *
+ * @param int $course_id The ID of the course.
+ *
+ * @return string The last updated time.
+ */
+function get_last_updated_time( $course_id ) {
+	$last_updated_time = get_post_modified_time( 'U', false, $course_id );
+	$current_time = current_time( 'timestamp' );
+
+	$time_diff = human_time_diff( $last_updated_time, $current_time );
+
+	// If the time difference is greater than 30 days, display the specific date
+	if ( $current_time - $last_updated_time > 30 * DAY_IN_SECONDS ) {
+		$last_updated = get_post_modified_time( 'M jS, Y', false, $course_id );
+	} else {
+		$last_updated = sprintf( '%s ago', $time_diff );
+	}
+
+	return $last_updated;
 }

--- a/wp-content/themes/pub/wporg-learn-2024/src/sensei-meta-list/index.php
+++ b/wp-content/themes/pub/wporg-learn-2024/src/sensei-meta-list/index.php
@@ -45,7 +45,7 @@ function render( $attributes, $content, $block ) {
 
 	$list_items = array();
 
-	if ( get_post_type() === 'course' ) {
+	if ( 'course' === $block->context['postType'] ) {
 		$course_service = new Sensei_Reports_Overview_Service_Courses();
 		$course_id = $block->context['postId'];
 

--- a/wp-content/themes/pub/wporg-learn-2024/src/sensei-meta-list/index.php
+++ b/wp-content/themes/pub/wporg-learn-2024/src/sensei-meta-list/index.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Block Name: Sensei Meta List
+ * Description: Display the site meta data of a learn or course as a list.
+ *
+ * @package wporg
+ */
+
+namespace WordPressdotorg\Theme\Learn_2024\Sensei_Meta_List;
+
+use Sensei_Utils;
+use Sensei_Reports_Overview_Service_Courses;
+
+add_action( 'init', __NAMESPACE__ . '\init' );
+
+/**
+ * Registers the block using the metadata loaded from the `block.json` file.
+ * Behind the scenes, it registers also all assets so they can be enqueued
+ * through the block editor in the corresponding context.
+ *
+ * @see https://developer.wordpress.org/reference/functions/register_block_type/
+ */
+function init() {
+	register_block_type(
+		dirname( dirname( __DIR__ ) ) . '/build/sensei-meta-list',
+		array(
+			'render_callback' => __NAMESPACE__ . '\render',
+		)
+	);
+}
+
+/**
+ * Render the block content.
+ *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ *
+ * @return string Returns the block markup.
+ */
+function render( $attributes, $content, $block ) {
+	if ( ! isset( $block->context['postId'] ) ) {
+		return '';
+	}
+
+	$list_items = array();
+
+	if ( get_post_type() === 'course' ) {
+		$course_service = new Sensei_Reports_Overview_Service_Courses();
+		$course_id = $block->context['postId'];
+
+		// Get the total number of learners enrolled in the course
+		$learners = Sensei_Utils::sensei_check_for_activity(
+			array(
+				'type'     => 'sensei_course_status',
+				'status'   => 'in-progress',
+				'post__in' => $course_id,
+			)
+		);
+
+		// Get the average grade across all learners
+		$average_grade = round( $course_service->get_courses_average_grade( array( $course_id ) ), 0 );
+
+		// Get the average number of days it takes to complete a course
+		$average_days = $course_service->get_average_days_to_completion( array( $course_id ) );
+
+		// Set up array of data to be used
+		$meta_fields = array(
+			array(
+				'label' => __( 'Enrolled learners', 'wporg-learn' ),
+				'value' => $learners,
+				'key'   => 'learners',
+			),
+			array(
+				'label' => __( 'Average final grade', 'wporg-learn' ),
+				'value' => $average_grade . '%',
+				'key'   => 'average-grade',
+			),
+			array(
+				'label' => __( 'Average days to completion', 'wporg-learn' ),
+				'value' => $average_days,
+				'key'   => 'average-days',
+			),
+		);
+	}
+
+	foreach ( $meta_fields as $field ) {
+		$list_items[] = sprintf(
+			'<tr class="is-meta-%1$s">
+				<th scope="row">%2$s</th>
+				<td>%3$s</td>
+			</tr>',
+			$field['key'],
+			$field['label'],
+			wp_kses_post( $field['value'] )
+		);
+	}
+
+	$wrapper_attributes = get_block_wrapper_attributes();
+	return sprintf(
+		'<div %s><table>%s</table></div>',
+		$wrapper_attributes,
+		join( '', $list_items )
+	);
+}

--- a/wp-content/themes/pub/wporg-learn-2024/src/sensei-meta-list/style.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/sensei-meta-list/style.scss
@@ -1,0 +1,55 @@
+.wp-block-wporg-learn-sensei-meta-list {
+	margin-block-start: 40px;
+	margin-block-end: 40px;
+
+	table {
+		margin: 0;
+		padding: 0;
+		width: 100%;
+		border-spacing: 0;
+		border-collapse: collapse;
+	}
+
+	tr {
+		vertical-align: baseline;
+
+		&:not(:last-of-type) {
+			border-bottom: 1px solid var(--wp--preset--color--light-grey-1);
+		}
+
+		th,
+		td {
+			padding-top: var(--wp--preset--spacing--10);
+			padding-bottom: var(--wp--preset--spacing--10);
+		}
+
+		th {
+			font-weight: 400;
+			text-align: start;
+			min-width: 100px;
+		}
+
+		td {
+			text-align: end;
+			white-space: nowrap;
+		}
+
+		@media (max-width: 380px) {
+			display: block;
+
+			th,
+			td {
+				display: block;
+			}
+
+			th {
+				padding-bottom: 0;
+			}
+
+			td {
+				text-align: start;
+				padding-top: 0;
+			}
+		}
+	}
+}

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
@@ -98,8 +98,17 @@ body.sensei {
 		a {
 			text-decoration: none;
 		}
+	}
 
-		+ * {
+	.wporg-learn-sidebar-course-progress {
+		margin-top: 16px;
+		margin-bottom: 40px;
+		display: flex;
+		flex-direction: column;
+
+		.sensei-progress-bar__label {
+			order: 1;
+			margin-bottom: 0;
 			margin-top: 16px;
 		}
 	}

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
@@ -80,36 +80,3 @@ body.sensei {
 	margin: unset;
 	padding: unset;
 }
-
-.wporg-learn-sidebar-meta-info {
-	> .wp-block-sensei-lms-button-take-course {
-		margin-bottom: var(--wp--preset--spacing--20);
-
-		button {
-			line-height: 1;
-		}
-	}
-
-	.wporg-learn-sidebar-playground  a {
-		line-height: 1;
-	}
-
-	.wporg-learn-sidebar-all-courses {
-		a {
-			text-decoration: none;
-		}
-	}
-
-	.wporg-learn-sidebar-course-progress {
-		margin-top: 16px;
-		margin-bottom: 40px;
-		display: flex;
-		flex-direction: column;
-
-		.sensei-progress-bar__label {
-			order: 1;
-			margin-bottom: 0;
-			margin-top: 16px;
-		}
-	}
-}

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
@@ -80,3 +80,27 @@ body.sensei {
 	margin: unset;
 	padding: unset;
 }
+
+.wporg-learn-sidebar-meta-info {
+	> .wp-block-sensei-lms-button-take-course {
+		margin-bottom: var(--wp--preset--spacing--20);
+
+		button {
+			line-height: 1;
+		}
+	}
+
+	.wporg-learn-sidebar-playground  a {
+		line-height: 1;
+	}
+
+	.wporg-learn-sidebar-all-courses {
+		a {
+			text-decoration: none;
+		}
+
+		+ * {
+			margin-top: 16px;
+		}
+	}
+}

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sidebar.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sidebar.scss
@@ -1,0 +1,32 @@
+.wporg-learn-sidebar-meta-info {
+	> .wp-block-sensei-lms-button-take-course {
+		margin-bottom: var(--wp--preset--spacing--20);
+
+		button {
+			line-height: 1;
+		}
+	}
+
+	.wporg-learn-sidebar-playground  a {
+		line-height: 1;
+	}
+
+	.wporg-learn-sidebar-all-courses {
+		a {
+			text-decoration: none;
+		}
+	}
+
+	.wporg-learn-sidebar-course-progress {
+		margin-top: 16px;
+		margin-bottom: 40px;
+		display: flex;
+		flex-direction: column;
+
+		.sensei-progress-bar__label {
+			order: 1;
+			margin-bottom: 0;
+			margin-top: 16px;
+		}
+	}
+}

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/style.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/style.scss
@@ -8,6 +8,7 @@
 @import "jetpack";
 @import "local-nav";
 @import "sensei";
+@import "sidebar";
 @import "tag";
 @import "taxonomy-learning-pathway";
 @import "wp-components";

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/style.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/style.scss
@@ -49,4 +49,8 @@ body {
 			line-height: 1;
 		}
 	}
+
+	.wporg-learn-sidebar-playground  a {
+		line-height: 1;
+	}
 }

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/style.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/style.scss
@@ -53,4 +53,14 @@ body {
 	.wporg-learn-sidebar-playground  a {
 		line-height: 1;
 	}
+
+	.wporg-learn-sidebar-all-courses {
+		a {
+			text-decoration: none;
+		}
+
+		+ * {
+			margin-top: 16px;
+		}
+	}
 }

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/style.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/style.scss
@@ -39,3 +39,14 @@ body {
 		padding-top: unset !important;
 	}
 }
+
+.wporg-learn-sidebar-meta-info {
+	.wp-block-sensei-lms-button-take-course {
+		margin-top: 0;
+		margin-bottom: var(--wp--preset--spacing--20);
+
+		> button {
+			line-height: 1;
+		}
+	}
+}

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/style.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/style.scss
@@ -39,28 +39,3 @@ body {
 		padding-top: unset !important;
 	}
 }
-
-.wporg-learn-sidebar-meta-info {
-	.wp-block-sensei-lms-button-take-course {
-		margin-top: 0;
-		margin-bottom: var(--wp--preset--spacing--20);
-
-		> button {
-			line-height: 1;
-		}
-	}
-
-	.wporg-learn-sidebar-playground  a {
-		line-height: 1;
-	}
-
-	.wporg-learn-sidebar-all-courses {
-		a {
-			text-decoration: none;
-		}
-
-		+ * {
-			margin-top: 16px;
-		}
-	}
-}

--- a/wp-content/themes/pub/wporg-learn-2024/templates/single-course.html
+++ b/wp-content/themes/pub/wporg-learn-2024/templates/single-course.html
@@ -13,9 +13,33 @@
 	<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space","top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
 	<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--edge-space)">
 
-		<!-- wp:post-title {"level":1,"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|30"}}}} /-->
+		<!-- wp:post-title {"level":1,"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}}} /-->
 	
-		<!-- wp:post-content {"layout":{"inherit":true}} /-->
+		<!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"left":"var:preset|spacing|40"}}}} -->
+		<div class="wp-block-columns alignwide">
+		
+			<!-- wp:column {"width":"75%","layout":{"type":"constrained","justifyContent":"left"}} -->
+			<div class="wp-block-column" style="flex-basis:75%">
+
+				<!-- wp:post-content {"layout":{"inherit":true}} /-->
+
+			</div>
+			<!-- /wp:column -->
+
+			<!-- wp:column {"width":"25%"} -->
+			<div class="wp-block-column" style="flex-basis:25%">
+
+				<!-- wp:sensei-lms/button-take-course {"align":"full","borderRadius":2,"className":"is-style-default"} -->
+				<div class="wp-block-sensei-lms-button-take-course is-style-default wp-block-sensei-button wp-block-button has-text-align-full">
+					<button class="wp-block-button__link" style="border-radius:2px">Take this Course</button>
+				</div>
+				<!-- /wp:sensei-lms/button-take-course -->
+
+			</div>
+			<!-- /wp:column -->
+
+			</div>
+		<!-- /wp:columns -->
 
 	</div>
 	<!-- /wp:group -->

--- a/wp-content/themes/pub/wporg-learn-2024/templates/single-course.html
+++ b/wp-content/themes/pub/wporg-learn-2024/templates/single-course.html
@@ -28,36 +28,8 @@
 
 			<!-- wp:column {"width":"25%"} -->
 			<div class="wp-block-column" style="flex-basis:25%">
-
-				<!-- wp:sensei-lms/button-take-course {"align":"full","borderRadius":2,"className":"is-style-default"} -->
-				<div class="wp-block-sensei-lms-button-take-course is-style-default wp-block-sensei-button wp-block-button has-text-align-full">
-					<button class="wp-block-button__link" style="border-radius:2px">Take this Course</button>
-				</div>
-				<!-- /wp:sensei-lms/button-take-course -->
-
-				<!-- wp:buttons -->
-				<div class="wp-block-buttons"><!-- wp:button {"width":100,"style":{"border":{"radius":"2px"}},"className":"aligncenter is-style-outline"} -->
-				<div class="wp-block-button has-custom-width wp-block-button__width-100 aligncenter is-style-outline"><a class="wp-block-button__link wp-element-button" href="https://wordpress.org/playground/demo/?step=playground&amp;theme=twentytwentythree" style="border-radius:2px" target="_blank" rel="noreferrer noopener">Practice on a private demo site</a></div>
-				<!-- /wp:button --></div>
-				<!-- /wp:buttons -->
 				
-				<!-- wp:wporg-learn/course-data /-->
-				
-				<!-- wp:paragraph -->
-				<p id="suggestions"><strong>Suggestions</strong></p>
-				<!-- /wp:paragraph -->
-				
-				<!-- wp:paragraph -->
-				<p>Found a typo, grammar error or outdated screenshot? <a href="https://learn.wordpress.org/report-content-errors/">Contact us</a></p>
-				<!-- /wp:paragraph -->
-				
-				<!-- wp:paragraph -->
-				<p id="suggestions"><strong>License</strong></p>
-				<!-- /wp:paragraph -->
-				
-				<!-- wp:paragraph -->
-				<p>This work is licensed under a <a href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>.</p>
-				<!-- /wp:paragraph -->
+				<!-- wp:pattern {"slug":"wporg-learn-2024/sidebar-meta-info"} /-->
 				
 			</div>
 			<!-- /wp:column -->

--- a/wp-content/themes/pub/wporg-learn-2024/templates/single-course.html
+++ b/wp-content/themes/pub/wporg-learn-2024/templates/single-course.html
@@ -10,8 +10,8 @@
 <!-- wp:group {"tagName":"main","layout":{"type":"constrained"},"className":"entry-content","style":{"spacing":{"blockGap":"0px"}}} -->
 <main class="wp-block-group entry-content">
 
-	<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space","top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
-	<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--edge-space)">
+	<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space","top":"var:preset|spacing|40","bottom":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--edge-space)">
 
 		<!-- wp:post-title {"level":1,"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}}} /-->
 	

--- a/wp-content/themes/pub/wporg-learn-2024/templates/single-course.html
+++ b/wp-content/themes/pub/wporg-learn-2024/templates/single-course.html
@@ -35,6 +35,30 @@
 				</div>
 				<!-- /wp:sensei-lms/button-take-course -->
 
+				<!-- wp:buttons -->
+				<div class="wp-block-buttons"><!-- wp:button {"width":100,"style":{"border":{"radius":"2px"}},"className":"aligncenter is-style-outline"} -->
+				<div class="wp-block-button has-custom-width wp-block-button__width-100 aligncenter is-style-outline"><a class="wp-block-button__link wp-element-button" href="https://wordpress.org/playground/demo/?step=playground&amp;theme=twentytwentythree" style="border-radius:2px" target="_blank" rel="noreferrer noopener">Practice on a private demo site</a></div>
+				<!-- /wp:button --></div>
+				<!-- /wp:buttons -->
+				
+				<!-- wp:wporg-learn/course-data /-->
+				
+				<!-- wp:paragraph -->
+				<p id="suggestions"><strong>Suggestions</strong></p>
+				<!-- /wp:paragraph -->
+				
+				<!-- wp:paragraph -->
+				<p>Found a typo, grammar error or outdated screenshot? <a href="https://learn.wordpress.org/report-content-errors/">Contact us</a></p>
+				<!-- /wp:paragraph -->
+				
+				<!-- wp:paragraph -->
+				<p id="suggestions"><strong>License</strong></p>
+				<!-- /wp:paragraph -->
+				
+				<!-- wp:paragraph -->
+				<p>This work is licensed under a <a href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>.</p>
+				<!-- /wp:paragraph -->
+				
 			</div>
 			<!-- /wp:column -->
 


### PR DESCRIPTION
Closes #2388

This PR implements the single course page according to the design. A block (sensei-meta-list) was created for the meta list instead of using the one (`wporg-learn/course-data`) in the wporg-learn plugin because modifying it would affect the current theme. This also allows for updating the way of adding a block. The "last updated" format follows the [design](https://www.figma.com/design/ZKaf6u8mIHkAanluWafXAp/Learn?node-id=3615-13603&m=dev), displaying different stages accordingly.

The order of the text and the progress bar is different. When checking the original code, there is no option for changing the order. There are still ways to achieve it, but before that, do we want to change the order for this or the current one is acceptable?
And I'm curious if the current style of lessons in the screenshot is ok or if it has already been taken into consideration and should be changed to match the design. The screenshot style seems consistent, but perhaps this has already been discussed. @fcoveram 

## Screenshots

| | Desktop | Tablet | Mobile |
|-|-|-|-|
| user is not enrolled | ![Screenshot 2024-06-10 at 08 34 58](https://github.com/WordPress/Learn/assets/18050944/18c95d29-1f60-45ec-8f28-2cf20ed60c58) | ![Screenshot 2024-06-10 at 08 35 14](https://github.com/WordPress/Learn/assets/18050944/c554517f-849a-499b-8762-b0ec0331a039) | ![Screenshot 2024-06-10 at 08 36 23](https://github.com/WordPress/Learn/assets/18050944/9b80ed48-d787-4a05-80b0-947dc707fb77) |
| user is enrolled | ![Screenshot 2024-06-10 at 08 48 01](https://github.com/WordPress/Learn/assets/18050944/6064208e-03c5-4aff-90e6-325cefe86516) | ![Screenshot 2024-06-10 at 08 48 12](https://github.com/WordPress/Learn/assets/18050944/d88bef3b-17bb-4231-aec8-6cc89c81e6dd) | ![Screenshot 2024-06-10 at 08 39 22](https://github.com/WordPress/Learn/assets/18050944/1faf7e4d-562a-4f89-b14e-e5cd81620dd8) |  

## Note

When creating the [Lesson Learn page](https://github.com/WordPress/Learn/issues/2448), the new block added here should be utilized, adding logic to check the learn post type and apply the appropriate logic.