### PR TITLE
Add query filters to taxonomy templates

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2024/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2024/functions.php
@@ -6,6 +6,7 @@ use function WPOrg_Learn\Sensei\{get_my_courses_page_url};
 
 // Block files
 require_once __DIR__ . '/src/learning-pathway-cards/index.php';
+require_once __DIR__ . '/src/learning-pathway-header/index.php';
 require_once __DIR__ . '/src/search-results-context/index.php';
 require_once __DIR__ . '/src/upcoming-online-workshops/index.php';
 require_once __DIR__ . '/src/sensei-meta-list/index.php';

--- a/wp-content/themes/pub/wporg-learn-2024/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2024/functions.php
@@ -29,6 +29,7 @@ add_filter( 'sensei_register_post_type_course', function( $args ) {
 	$args['has_archive'] = 'courses';
 	return $args;
 } );
+add_action( 'pre_get_posts', __NAMESPACE__ . '\modify_learning_pathways_query' );
 
 /**
  * Modify the single template hierarchy to use customised copies of the Sensei Course Theme templates.
@@ -277,4 +278,25 @@ function set_site_breadcrumbs( $breadcrumbs ) {
 	}
 
 	return $breadcrumbs;
+}
+
+/**
+ * Modify the main query.
+ * If the 'all' level filter is set in the query, remove it to return all posts.
+ *
+ * @param WP_Query $query The main query.
+ * @return WP_Query
+ */
+function modify_learning_pathways_query( $query ) {
+	if ( is_admin() || ! $query->is_main_query() ) {
+		return;
+	}
+
+	$level = $query->get( 'wporg_lesson_level' );
+
+	if ( 'all' === $level ) {
+		$query->set( 'wporg_lesson_level', '' );
+	}
+
+	return $query;
 }

--- a/wp-content/themes/pub/wporg-learn-2024/inc/block-config.php
+++ b/wp-content/themes/pub/wporg-learn-2024/inc/block-config.php
@@ -104,8 +104,8 @@ function get_level_options( $options ) {
 		array(
 			'post_type' => $post_type,
 			'fields' => 'ids',
-			'numberposts' => -1,
-			'status' => 'publish',
+			'posts_per_page' => -1,
+			'post_status' => 'publish',
 		)
 	);
 	$levels = get_terms(
@@ -160,8 +160,8 @@ function get_learning_pathway_level_options( $options ) {
 	$object_ids = get_posts(
 		array(
 			'fields' => 'ids',
-			'numberposts' => -1,
-			'status' => 'publish',
+			'posts_per_page' => -1,
+			'post_status' => 'publish',
 			'post_type' => 'course',
 			'tax_query' => array(
 				array(
@@ -240,8 +240,8 @@ function get_topic_options( $options ) {
 	// Get top 20 topics ordered by count, not empty, filtered by post_type.
 	$object_ids = get_posts( array(
 		'fields' => 'ids',
-		'numberposts' => -1,
-		'status' => 'publish',
+		'posts_per_page' => -1,
+		'post_status' => 'publish',
 		'post_type' => $post_type,
 	) );
 	$topics = get_terms(
@@ -296,8 +296,8 @@ function get_learning_pathway_topic_options( $options ) {
 	$object_ids = get_posts(
 		array(
 			'fields' => 'ids',
-			'numberposts' => -1,
-			'status' => 'publish',
+			'posts_per_page' => -1,
+			'post_status' => 'publish',
 			'post_type' => 'course',
 			'tax_query' => array(
 				array(

--- a/wp-content/themes/pub/wporg-learn-2024/inc/block-config.php
+++ b/wp-content/themes/pub/wporg-learn-2024/inc/block-config.php
@@ -112,13 +112,22 @@ function get_level_options( $options ) {
 		$levels = $target_element + $levels;
 	}
 
-	$selected = isset( $wp_query->query['wporg_lesson_level'] ) ? (array) $wp_query->query['wporg_lesson_level'] : array();
-	$count = count( $selected );
-	$label = sprintf(
-		/* translators: The dropdown label for filtering, %s is the selected term count. */
-		_n( 'Level <span>%s</span>', 'Level <span>%s</span>', $count, 'wporg-learn' ),
-		$count
-	);
+	$label = __( 'Level', 'wporg-learn' );
+
+	$selected_slug = $wp_query->get( 'wporg_lesson_level' );
+	if ( $selected_slug ) {
+		// Find the selected level from $levels by slug and then get the name.
+		$selected_level = array_filter(
+			$levels,
+			function ( $level ) use ( $selected_slug ) {
+				return $level->slug === $selected_slug;
+			}
+		);
+		if ( ! empty( $selected_level ) ) {
+			$selected_level = array_shift( $selected_level );
+			$label = $selected_level->name;
+		}
+	}
 
 	return array(
 		'label' => $label,
@@ -126,7 +135,7 @@ function get_level_options( $options ) {
 		'key' => 'wporg_lesson_level',
 		'action' => get_current_url(),
 		'options' => array_combine( wp_list_pluck( $levels, 'slug' ), wp_list_pluck( $levels, 'name' ) ),
-		'selected' => $selected,
+		'selected' => $selected_slug,
 	);
 }
 

--- a/wp-content/themes/pub/wporg-learn-2024/inc/block-config.php
+++ b/wp-content/themes/pub/wporg-learn-2024/inc/block-config.php
@@ -105,6 +105,10 @@ function get_level_options( $options ) {
 function get_topic_options( $options ) {
 	global $wp_query;
 	$post_type = $wp_query->query_vars['post_type'];
+	$is_learning_pathway_tax = isset( $wp_query->query_vars['wporg_learning_pathway'] );
+	if ( ! $post_type && $is_learning_pathway_tax ) {
+		$post_type = 'course';
+	}
 	// Get top 20 topics ordered by count, not empty, filtered by post_type, then sort them alphabetically.
 	$object_ids = get_posts(
 		array(
@@ -112,6 +116,15 @@ function get_topic_options( $options ) {
 			'fields' => 'ids',
 			'numberposts' => -1,
 			'status' => 'publish',
+			'tax_query' => $is_learning_pathway_tax
+				? array(
+					array(
+						'taxonomy' => 'learning-pathway',
+						'field' => 'slug',
+						'terms' => $wp_query->query_vars['wporg_learning_pathway'],
+					),
+				)
+				: array(),
 		)
 	);
 	$topics = get_terms(

--- a/wp-content/themes/pub/wporg-learn-2024/inc/block-config.php
+++ b/wp-content/themes/pub/wporg-learn-2024/inc/block-config.php
@@ -36,8 +36,8 @@ function get_current_url() {
 function create_level_options( $levels ) {
 	global $wp_query;
 
-	// If there are no levels, or less than 2, don't show the filter.
-	if ( empty( $levels ) || count( $levels ) < 2 ) {
+	// If there are no levels, don't show the filter.
+	if ( empty( $levels ) ) {
 		return array();
 	}
 

--- a/wp-content/themes/pub/wporg-learn-2024/inc/block-config.php
+++ b/wp-content/themes/pub/wporg-learn-2024/inc/block-config.php
@@ -98,11 +98,15 @@ function create_level_options( $levels ) {
  */
 function get_level_options( $options ) {
 	global $wp_query;
-	$post_type = $wp_query->query_vars['post_type'];
+
+	if ( ! isset( $wp_query->query_vars['post_type'] ) ) {
+		return array();
+	}
+
 	// Get top 10 levels ordered by count, not empty, filtered by post_type.
 	$object_ids = get_posts(
 		array(
-			'post_type' => $post_type,
+			'post_type' => $wp_query->query_vars['post_type'],
 			'fields' => 'ids',
 			'posts_per_page' => -1,
 			'post_status' => 'publish',
@@ -235,14 +239,16 @@ function create_topic_options( $topics ) {
 function get_topic_options( $options ) {
 	global $wp_query;
 
-	$post_type = $wp_query->query_vars['post_type'];
+	if ( ! isset( $wp_query->query_vars['post_type'] ) ) {
+		return array();
+	}
 
 	// Get top 20 topics ordered by count, not empty, filtered by post_type.
 	$object_ids = get_posts( array(
 		'fields' => 'ids',
 		'posts_per_page' => -1,
 		'post_status' => 'publish',
-		'post_type' => $post_type,
+		'post_type' => $wp_query->query_vars['post_type'],
 	) );
 	$topics = get_terms(
 		array(

--- a/wp-content/themes/pub/wporg-learn-2024/inc/block-config.php
+++ b/wp-content/themes/pub/wporg-learn-2024/inc/block-config.php
@@ -381,17 +381,29 @@ function modify_query( $query ) {
 function inject_other_filters( $key ) {
 	global $wp_query;
 
-	$query_vars = array( 'wporg_workshop_topic', 'wporg_lesson_level' );
-	foreach ( $query_vars as $query_var ) {
-		if ( ! isset( $wp_query->query[ $query_var ] ) ) {
+	$single_query_vars = array( 'wporg_lesson_level' );
+	foreach ( $single_query_vars as $single_query_var ) {
+		if ( ! isset( $wp_query->query[ $single_query_var ] ) ) {
 			continue;
 		}
-		if ( $key === $query_var ) {
+		if ( $key === $single_query_var ) {
 			continue;
 		}
-		$values = (array) $wp_query->query[ $query_var ];
+		$value = $wp_query->query[ $single_query_var ];
+		printf( '<input type="hidden" name="%s" value="%s" />', esc_attr( $single_query_var ), esc_attr( $value ) );
+	}
+
+	$multi_query_vars = array( 'wporg_workshop_topic' );
+	foreach ( $multi_query_vars as $multi_query_var ) {
+		if ( ! isset( $wp_query->query[ $multi_query_var ] ) ) {
+			continue;
+		}
+		if ( $key === $multi_query_var ) {
+			continue;
+		}
+		$values = (array) $wp_query->query[ $multi_query_var ];
 		foreach ( $values as $value ) {
-			printf( '<input type="hidden" name="%s[]" value="%s" />', esc_attr( $query_var ), esc_attr( $value ) );
+			printf( '<input type="hidden" name="%s[]" value="%s" />', esc_attr( $multi_query_var ), esc_attr( $value ) );
 		}
 	}
 

--- a/wp-content/themes/pub/wporg-learn-2024/inc/block-config.php
+++ b/wp-content/themes/pub/wporg-learn-2024/inc/block-config.php
@@ -131,11 +131,11 @@ function get_level_options( $options ) {
 
 	return array(
 		'label' => $label,
-		'title' => __( 'Level', 'wporg-learn' ),
+		'title' => __( 'Filter', 'wporg-learn' ),
 		'key' => 'wporg_lesson_level',
 		'action' => get_current_url(),
 		'options' => array_combine( wp_list_pluck( $levels, 'slug' ), wp_list_pluck( $levels, 'name' ) ),
-		'selected' => $selected_slug,
+		'selected' => array( $selected_slug ),
 	);
 }
 
@@ -202,7 +202,7 @@ function get_topic_options( $options ) {
 
 	return array(
 		'label' => $label,
-		'title' => __( 'Topic', 'wporg-learn' ),
+		'title' => __( 'Filter', 'wporg-learn' ),
 		'key' => 'wporg_workshop_topic',
 		'action' => get_current_url(),
 		'options' => array_combine( wp_list_pluck( $topics, 'slug' ), wp_list_pluck( $topics, 'name' ) ),
@@ -262,7 +262,7 @@ function get_language_options( $options ) {
 
 	return array(
 		'label' => $label,
-		'title' => __( 'Language', 'wporg-learn' ),
+		'title' => __( 'Filter', 'wporg-learn' ),
 		'key' => 'language',
 		'action' => get_current_url(),
 		'options' => $languages,

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/archive-content.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/archive-content.php
@@ -24,7 +24,7 @@
 	<div class="wp-block-group wporg-query-filters">
 		<!-- wp:wporg/query-filter {"key":"language"} /-->
 		<!-- wp:wporg/query-filter {"key":"topic"} /-->
-		<!-- wp:wporg/query-filter {"key":"level"} /-->
+		<!-- wp:wporg/query-filter {"key":"level","multiple":false} /-->
 	</div>
 	<!-- /wp:group -->
 

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/archive-courses-content.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/archive-courses-content.php
@@ -28,7 +28,7 @@
 	<div class="wp-block-group wporg-query-filters">
 		<!-- wp:wporg/query-filter {"key":"language"} /-->
 		<!-- wp:wporg/query-filter {"key":"topic"} /-->
-		<!-- wp:wporg/query-filter {"key":"level"} /-->
+		<!-- wp:wporg/query-filter {"key":"level","multiple":false} /-->
 	</div>
 	<!-- /wp:group -->
 

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/archive-lesson-plan-content.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/archive-lesson-plan-content.php
@@ -28,7 +28,7 @@
 	<div class="wp-block-group wporg-query-filters">
 		<!-- wp:wporg/query-filter {"key":"language"} /-->
 		<!-- wp:wporg/query-filter {"key":"topic"} /-->
-		<!-- wp:wporg/query-filter {"key":"level"} /-->
+		<!-- wp:wporg/query-filter {"key":"level","multiple":false} /-->
 	</div>
 	<!-- /wp:group -->
 

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/archive-lessons-content.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/archive-lessons-content.php
@@ -28,7 +28,7 @@
 	<div class="wp-block-group wporg-query-filters">
 		<!-- wp:wporg/query-filter {"key":"language"} /-->
 		<!-- wp:wporg/query-filter {"key":"topic"} /-->
-		<!-- wp:wporg/query-filter {"key":"level"} /-->
+		<!-- wp:wporg/query-filter {"key":"level","multiple":false} /-->
 	</div>
 	<!-- /wp:group -->
 

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/taxonomy-content.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/taxonomy-content.php
@@ -22,7 +22,7 @@ if ( isset( $wp_query->query_vars['wporg_learning_pathway'] ) ) {
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60)">
 
-	<?php if ( ! $learning_pathway_slug ) { ?>
+	<?php if ( ! isset( $learning_pathway_slug ) ) { ?>
 
 		<!-- wp:group {"style":{"spacing":{"margin":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|40"}}},"layout":{"type":"constrained","justifyContent":"left","contentSize":"730px"}} -->
 		<div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--50);margin-bottom:var(--wp--preset--spacing--40)">
@@ -90,7 +90,7 @@ if ( isset( $wp_query->query_vars['wporg_learning_pathway'] ) ) {
 		<!-- wp:query-no-results -->
 
 			<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
-			<p><?php $learning_pathway_slug ? esc_html_e( 'No pathways found.', 'wporg-learn' ) : esc_html_e( 'Nothing found.', 'wporg-learn' ); ?></p>
+			<p><?php isset( $learning_pathway_slug ) ? esc_html_e( 'No pathways found.', 'wporg-learn' ) : esc_html_e( 'Nothing found.', 'wporg-learn' ); ?></p>
 			<!-- /wp:paragraph -->
 
 		<!-- /wp:query-no-results -->

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/taxonomy-content.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/taxonomy-content.php
@@ -12,75 +12,43 @@ if ( ! is_tax() ) {
 global $wp_query;
 
 if ( isset( $wp_query->query_vars['wporg_learning_pathway'] ) ) {
-
-	$learning_pathway_object = get_term_by( 'slug', $wp_query->query_vars['wporg_learning_pathway'], 'learning-pathway' );
-
-	$learning_pathway_id = $learning_pathway_object->term_id;
-	$learning_pathway_slug = $learning_pathway_object->slug;
-	$learning_pathway_name = $learning_pathway_object->name;
-	$learning_pathway_description = $learning_pathway_object->description;
+	$learning_pathway_slug = $wp_query->query_vars['wporg_learning_pathway'];
 	?>
 
-	<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","top":"0","bottom":"0"}},"border":{"bottom":{"color":"var:preset|color|light-grey-1","width":"1px"}}},"backgroundColor":"<?php echo esc_attr( $learning_pathway_slug ); ?>","className":"wporg-learn-tax-learning-pathway-header","layout":{"type":"constrained"}} -->
-	<div class="wp-block-group alignfull has-<?php echo esc_attr( $learning_pathway_slug ); ?>-background-color has-background wporg-learn-tax-learning-pathway-header" style="border-bottom-color:var(--wp--preset--color--light-grey-1);border-bottom-width:1px;padding-top:0;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:0;padding-left:var(--wp--preset--spacing--edge-space)">
+	<!-- wp:wporg-learn/learning-pathway-header {"align":"full","learningPathwaySlug":"<?php echo esc_attr( $learning_pathway_slug ); ?>"} /-->
 
-		<!-- wp:group {"style":{"spacing":{"blockGap":"0"},"background":{"backgroundRepeat":"no-repeat","backgroundSize":"contain","backgroundPosition":"100% 50%"}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between","verticalAlignment":"stretch"}} -->
-		<div class="wp-block-group">
-			
-			<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}},"layout":{"selfStretch":"fill","flexSize":null}},"layout":{"type":"constrained"}} -->
-			<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)">
+<?php } ?>
 
-				<!-- wp:heading {"level":1,"fontSize":"heading-1","fontFamily":"eb-garamond"} -->
-				<h1 class="wp-block-heading has-eb-garamond-font-family has-heading-1-font-size"><?php echo esc_html( $learning_pathway_name ); ?></h1>
-				<!-- /wp:heading -->
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60)">
 
-				<!-- wp:paragraph {"style":{"typography":{"lineHeight":1.6}}} -->
-				<p style="line-height:1.6"><?php echo esc_html( $learning_pathway_description ); ?></p>
-				<!-- /wp:paragraph -->
+	<?php if ( ! $learning_pathway_slug ) { ?>
 
+		<!-- wp:group {"style":{"spacing":{"margin":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|40"}}},"layout":{"type":"constrained","justifyContent":"left","contentSize":"730px"}} -->
+		<div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--50);margin-bottom:var(--wp--preset--spacing--40)">
+
+			<!-- wp:query-title {"type":"archive","showPrefix":false} /-->
+
+		</div>
+		<!-- /wp:group -->
+
+		<!-- wp:group {"align":"wide","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"},"style":{"spacing":{"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}}} -->
+		<div class="wp-block-group alignwide" style="margin-top:var(--wp--preset--spacing--40);margin-bottom:var(--wp--preset--spacing--40)">
+
+			<!-- wp:search {"label":"<?php esc_attr_e( 'Search', 'wporg-learn' ); ?>","showLabel":false,"placeholder":"<?php esc_attr_e( 'Search', 'wporg-learn' ); ?>","width":290,"widthUnit":"px","buttonText":"<?php esc_attr_e( 'Search', 'wporg-learn' ); ?>","buttonPosition":"button-inside","buttonUseIcon":true} /-->
+
+			<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"flex","flexWrap":"nowrap"},"className":"wporg-query-filters"} -->
+			<div class="wp-block-group wporg-query-filters">
+				<!-- wp:wporg/query-filter {"key":"language"} /-->
+				<!-- wp:wporg/query-filter {"key":"topic"} /-->
+				<!-- wp:wporg/query-filter {"key":"level"} /-->
 			</div>
-			<!-- /wp:group -->
-
-			<!-- wp:group {"style":{"layout":{"selfStretch":"fixed","flexSize":"33%"},"background":{"backgroundImage":{"url":"<?php echo esc_url( get_stylesheet_directory_uri() . '/assets/learning-pathway-' . $learning_pathway_slug . '.svg' ); ?>","source":"file"},"backgroundPosition":"0% 50%"}},"layout":{"type":"constrained"}} -->
-			<div class="wp-block-group"></div>
 			<!-- /wp:group -->
 
 		</div>
 		<!-- /wp:group -->
 
-	</div>
-	<!-- /wp:group -->
-
-<?php } else { ?>
-
-	<!-- wp:group {"style":{"spacing":{"margin":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|40"}}},"layout":{"type":"constrained","justifyContent":"left","contentSize":"730px"}} -->
-	<div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--50);margin-bottom:var(--wp--preset--spacing--40)">
-
-		<!-- wp:query-title {"type":"archive","showPrefix":false} /-->
-
-	</div>
-	<!-- /wp:group -->
-
-<?php } ?>
-
-<!-- wp:group {"align":"wide","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"},"style":{"spacing":{"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}}} -->
-<div class="wp-block-group alignwide" style="margin-top:var(--wp--preset--spacing--40);margin-bottom:var(--wp--preset--spacing--40)">
-
-	<!-- wp:search {"label":"<?php esc_attr_e( 'Search', 'wporg-learn' ); ?>","showLabel":false,"placeholder":"<?php esc_attr_e( 'Search', 'wporg-learn' ); ?>","width":290,"widthUnit":"px","buttonText":"<?php esc_attr_e( 'Search', 'wporg-learn' ); ?>","buttonPosition":"button-inside","buttonUseIcon":true,"query":{"wporg_learning_pathway":"<?php echo esc_attr( $learning_pathway_slug ); ?>"}} /-->
-
-	<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"flex","flexWrap":"nowrap"},"className":"wporg-query-filters"} -->
-	<div class="wp-block-group wporg-query-filters">
-		<!-- wp:wporg/query-filter {"key":"language"} /-->
-		<!-- wp:wporg/query-filter {"key":"topic"} /-->
-		<!-- wp:wporg/query-filter {"key":"level"} /-->
-	</div>
-	<!-- /wp:group -->
-
-</div>
-<!-- /wp:group -->
-
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60)">
+	<?php } ?>
 
 	<!-- wp:query {"queryId":1,"query":{"perPage":12,"postType":"course","courseFeatured":false,"inherit":true},"namespace":"wporg-learn/course-grid","align":"wide","className":"wporg-learn-course-grid"} -->
 	<div class="wp-block-query alignwide wporg-learn-course-grid">
@@ -122,7 +90,7 @@ if ( isset( $wp_query->query_vars['wporg_learning_pathway'] ) ) {
 		<!-- wp:query-no-results -->
 
 			<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
-			<p><?php esc_html_e( 'No Courses found.', 'wporg-learn' ); ?></p>
+			<p><?php $learning_pathway_slug ? esc_html_e( 'No pathways found.', 'wporg-learn' ) : esc_html_e( 'Nothing found.', 'wporg-learn' ); ?></p>
 			<!-- /wp:paragraph -->
 
 		<!-- /wp:query-no-results -->

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/taxonomy-content.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/taxonomy-content.php
@@ -41,7 +41,7 @@ if ( isset( $wp_query->query_vars['wporg_learning_pathway'] ) ) {
 			<div class="wp-block-group wporg-query-filters">
 				<!-- wp:wporg/query-filter {"key":"language"} /-->
 				<!-- wp:wporg/query-filter {"key":"topic"} /-->
-				<!-- wp:wporg/query-filter {"key":"level","multiple":false} /-->
+				<!-- wp:wporg/query-filter {"key":"taxonomy-level","multiple":false} /-->
 			</div>
 			<!-- /wp:group -->
 

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/taxonomy-content.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/taxonomy-content.php
@@ -41,7 +41,7 @@ if ( isset( $wp_query->query_vars['wporg_learning_pathway'] ) ) {
 			<div class="wp-block-group wporg-query-filters">
 				<!-- wp:wporg/query-filter {"key":"language"} /-->
 				<!-- wp:wporg/query-filter {"key":"topic"} /-->
-				<!-- wp:wporg/query-filter {"key":"level"} /-->
+				<!-- wp:wporg/query-filter {"key":"level","multiple":false} /-->
 			</div>
 			<!-- /wp:group -->
 

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/taxonomy-content.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/taxonomy-content.php
@@ -1,63 +1,67 @@
 <?php
 /**
- * Title: Taxonomy Learning Pathway Content
- * Slug: wporg-learn-2024/taxonomy-learning-pathway-topic-content
+ * Title: Taxonomy Content
+ * Slug: wporg-learn-2024/taxonomy-content
  * Inserter: no
  */
 
-if ( ! is_tax( 'topic' ) ) {
-	return;
-}
-
-$topic_object = get_queried_object();
-
-if ( ! $topic_object ) {
+if ( ! is_tax() ) {
 	return;
 }
 
 global $wp_query;
 
-if ( ! isset( $wp_query->query_vars['wporg_learning_pathway'] ) ) {
-	return;
-}
+if ( isset( $wp_query->query_vars['wporg_learning_pathway'] ) ) {
 
-$learning_pathway_object = get_term_by( 'slug', $wp_query->query_vars['wporg_learning_pathway'], 'learning-pathway' );
+	$learning_pathway_object = get_term_by( 'slug', $wp_query->query_vars['wporg_learning_pathway'], 'learning-pathway' );
 
-$learning_pathway_id = $learning_pathway_object->term_id;
-$learning_pathway_slug = $learning_pathway_object->slug;
-$learning_pathway_name = $learning_pathway_object->name;
-$learning_pathway_description = $learning_pathway_object->description;
-?>
+	$learning_pathway_id = $learning_pathway_object->term_id;
+	$learning_pathway_slug = $learning_pathway_object->slug;
+	$learning_pathway_name = $learning_pathway_object->name;
+	$learning_pathway_description = $learning_pathway_object->description;
+	?>
 
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","top":"0","bottom":"0"}},"border":{"bottom":{"color":"var:preset|color|light-grey-1","width":"1px"}}},"backgroundColor":"<?php echo esc_attr( $learning_pathway_slug ); ?>","className":"wporg-learn-tax-learning-pathway-header","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull has-<?php echo esc_attr( $learning_pathway_slug ); ?>-background-color has-background wporg-learn-tax-learning-pathway-header" style="border-bottom-color:var(--wp--preset--color--light-grey-1);border-bottom-width:1px;padding-top:0;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:0;padding-left:var(--wp--preset--spacing--edge-space)">
+	<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","top":"0","bottom":"0"}},"border":{"bottom":{"color":"var:preset|color|light-grey-1","width":"1px"}}},"backgroundColor":"<?php echo esc_attr( $learning_pathway_slug ); ?>","className":"wporg-learn-tax-learning-pathway-header","layout":{"type":"constrained"}} -->
+	<div class="wp-block-group alignfull has-<?php echo esc_attr( $learning_pathway_slug ); ?>-background-color has-background wporg-learn-tax-learning-pathway-header" style="border-bottom-color:var(--wp--preset--color--light-grey-1);border-bottom-width:1px;padding-top:0;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:0;padding-left:var(--wp--preset--spacing--edge-space)">
 
-	<!-- wp:group {"style":{"spacing":{"blockGap":"0"},"background":{"backgroundRepeat":"no-repeat","backgroundSize":"contain","backgroundPosition":"100% 50%"}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between","verticalAlignment":"stretch"}} -->
-	<div class="wp-block-group">
-		
-		<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}},"layout":{"selfStretch":"fill","flexSize":null}},"layout":{"type":"constrained"}} -->
-		<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)">
+		<!-- wp:group {"style":{"spacing":{"blockGap":"0"},"background":{"backgroundRepeat":"no-repeat","backgroundSize":"contain","backgroundPosition":"100% 50%"}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between","verticalAlignment":"stretch"}} -->
+		<div class="wp-block-group">
+			
+			<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}},"layout":{"selfStretch":"fill","flexSize":null}},"layout":{"type":"constrained"}} -->
+			<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)">
 
-			<!-- wp:heading {"level":1,"fontSize":"heading-1","fontFamily":"eb-garamond"} -->
-			<h1 class="wp-block-heading has-eb-garamond-font-family has-heading-1-font-size"><?php echo esc_html( $learning_pathway_name ); ?></h1>
-			<!-- /wp:heading -->
+				<!-- wp:heading {"level":1,"fontSize":"heading-1","fontFamily":"eb-garamond"} -->
+				<h1 class="wp-block-heading has-eb-garamond-font-family has-heading-1-font-size"><?php echo esc_html( $learning_pathway_name ); ?></h1>
+				<!-- /wp:heading -->
 
-			<!-- wp:paragraph {"style":{"typography":{"lineHeight":1.6}}} -->
-			<p style="line-height:1.6"><?php echo esc_html( $learning_pathway_description ); ?></p>
-			<!-- /wp:paragraph -->
+				<!-- wp:paragraph {"style":{"typography":{"lineHeight":1.6}}} -->
+				<p style="line-height:1.6"><?php echo esc_html( $learning_pathway_description ); ?></p>
+				<!-- /wp:paragraph -->
+
+			</div>
+			<!-- /wp:group -->
+
+			<!-- wp:group {"style":{"layout":{"selfStretch":"fixed","flexSize":"33%"},"background":{"backgroundImage":{"url":"<?php echo esc_url( get_stylesheet_directory_uri() . '/assets/learning-pathway-' . $learning_pathway_slug . '.svg' ); ?>","source":"file"},"backgroundPosition":"0% 50%"}},"layout":{"type":"constrained"}} -->
+			<div class="wp-block-group"></div>
+			<!-- /wp:group -->
 
 		</div>
-		<!-- /wp:group -->
-
-		<!-- wp:group {"style":{"layout":{"selfStretch":"fixed","flexSize":"33%"},"background":{"backgroundImage":{"url":"<?php echo esc_url( get_stylesheet_directory_uri() . '/assets/learning-pathway-' . $learning_pathway_slug . '.svg' ); ?>","source":"file"},"backgroundPosition":"0% 50%"}},"layout":{"type":"constrained"}} -->
-		<div class="wp-block-group"></div>
 		<!-- /wp:group -->
 
 	</div>
 	<!-- /wp:group -->
 
-</div>
-<!-- /wp:group -->
+<?php } else { ?>
+
+	<!-- wp:group {"style":{"spacing":{"margin":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|40"}}},"layout":{"type":"constrained","justifyContent":"left","contentSize":"730px"}} -->
+	<div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--50);margin-bottom:var(--wp--preset--spacing--40)">
+
+		<!-- wp:query-title {"type":"archive","showPrefix":false} /-->
+
+	</div>
+	<!-- /wp:group -->
+
+<?php } ?>
 
 <!-- wp:group {"align":"wide","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"},"style":{"spacing":{"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}}} -->
 <div class="wp-block-group alignwide" style="margin-top:var(--wp--preset--spacing--40);margin-bottom:var(--wp--preset--spacing--40)">
@@ -77,8 +81,6 @@ $learning_pathway_description = $learning_pathway_object->description;
 
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60)">
-
-	<!-- wp:query-title {"type":"archive","showPrefix":true,"level":"2","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}}} /-->
 
 	<!-- wp:query {"queryId":1,"query":{"perPage":12,"postType":"course","courseFeatured":false,"inherit":true},"namespace":"wporg-learn/course-grid","align":"wide","className":"wporg-learn-course-grid"} -->
 	<div class="wp-block-query alignwide wporg-learn-course-grid">

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/taxonomy-learning-pathway-content.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/taxonomy-learning-pathway-content.php
@@ -27,46 +27,7 @@ $advanced_level_id = get_term_by( 'slug', 'advanced', 'level' )->term_id;
 $content = get_learning_pathway_level_content( $learning_pathway_slug );
 ?>
 
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","top":"0","bottom":"0"}},"border":{"bottom":{"color":"var:preset|color|light-grey-1","width":"1px"}}},"backgroundColor":"<?php echo esc_attr( $learning_pathway_slug ); ?>","className":"wporg-learn-tax-learning-pathway-header","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull has-<?php echo esc_attr( $learning_pathway_slug ); ?>-background-color has-background wporg-learn-tax-learning-pathway-header" style="border-bottom-color:var(--wp--preset--color--light-grey-1);border-bottom-width:1px;padding-top:0;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:0;padding-left:var(--wp--preset--spacing--edge-space)">
-
-	<!-- wp:group {"style":{"spacing":{"blockGap":"0"},"background":{"backgroundRepeat":"no-repeat","backgroundSize":"contain","backgroundPosition":"100% 50%"}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between","verticalAlignment":"stretch"}} -->
-	<div class="wp-block-group">
-		
-		<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}},"layout":{"selfStretch":"fill","flexSize":null}},"layout":{"type":"constrained"}} -->
-		<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)">
-
-			<!-- wp:query-title {"type":"archive","showPrefix":false,"fontSize":"heading-1"} /-->
-
-			<!-- wp:term-description {"style":{"typography":{"lineHeight":1.6}}} /-->
-
-		</div>
-		<!-- /wp:group -->
-
-		<!-- wp:group {"style":{"layout":{"selfStretch":"fixed","flexSize":"33%"},"background":{"backgroundImage":{"url":"<?php echo esc_url( get_stylesheet_directory_uri() . '/assets/learning-pathway-' . $learning_pathway_slug . '.svg' ); ?>","source":"file"},"backgroundPosition":"0% 50%"}},"layout":{"type":"constrained"}} -->
-		<div class="wp-block-group"></div>
-		<!-- /wp:group -->
-
-	</div>
-	<!-- /wp:group -->
-
-</div>
-<!-- /wp:group -->
-
-<!-- wp:group {"align":"wide","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"},"style":{"spacing":{"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|50"}}}} -->
-<div class="wp-block-group alignwide" style="margin-top:var(--wp--preset--spacing--40);margin-bottom:var(--wp--preset--spacing--50)">
-
-	<!-- wp:search {"label":"<?php esc_attr_e( 'Search', 'wporg-learn' ); ?>","showLabel":false,"placeholder":"<?php esc_attr_e( 'Search', 'wporg-learn' ); ?>","width":290,"widthUnit":"px","buttonText":"<?php esc_attr_e( 'Search', 'wporg-learn' ); ?>","buttonPosition":"button-inside","buttonUseIcon":true,"query":{"wporg_learning_pathway":"<?php echo esc_attr( $learning_pathway_slug ); ?>"}} /-->
-
-	<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"flex","flexWrap":"nowrap"},"className":"wporg-query-filters"} -->
-	<div class="wp-block-group wporg-query-filters">
-		<!-- wp:wporg/query-filter {"key":"topic"} /-->
-		<!-- wp:wporg/query-filter {"key":"level"} /-->
-	</div>
-	<!-- /wp:group -->
-
-</div>
-<!-- /wp:group -->
+<!-- wp:wporg-learn/learning-pathway-header {"align":"full","learningPathwaySlug":"<?php echo esc_attr( $learning_pathway_slug ); ?>"} /-->
 
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60)">

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/taxonomy-learning-pathway-content.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/taxonomy-learning-pathway-content.php
@@ -61,6 +61,7 @@ $content = get_learning_pathway_level_content( $learning_pathway_slug );
 	<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"flex","flexWrap":"nowrap"},"className":"wporg-query-filters"} -->
 	<div class="wp-block-group wporg-query-filters">
 		<!-- wp:wporg/query-filter {"key":"topic"} /-->
+		<!-- wp:wporg/query-filter {"key":"level"} /-->
 	</div>
 	<!-- /wp:group -->
 

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/taxonomy-learning-pathway-content.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/taxonomy-learning-pathway-content.php
@@ -19,6 +19,7 @@ if ( ! $learning_pathway_object ) {
 
 $learning_pathway_id = $learning_pathway_object->term_id;
 $learning_pathway_slug = $learning_pathway_object->slug;
+$learning_pathway_url = get_term_link( $learning_pathway_object );
 
 $beginner_level_id = get_term_by( 'slug', 'beginner', 'level' )->term_id;
 $intermediate_level_id = get_term_by( 'slug', 'intermediate', 'level' )->term_id;
@@ -44,7 +45,7 @@ $content = get_learning_pathway_level_content( $learning_pathway_slug );
 		<!-- /wp:paragraph -->
 
 		<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}}},"textColor":"charcoal-4"} -->
-		<p class="has-charcoal-4-color has-text-color has-link-color"><a href="<?php echo esc_url( site_url( '/courses/?wporg_learning_pathway=' . $learning_pathway_slug . '&wporg_lesson_level=beginner' ) ); ?>"><?php esc_html_e( 'See all', 'wporg-learn' ); ?></a></p>
+		<p class="has-charcoal-4-color has-text-color has-link-color"><a href="<?php echo esc_url( $learning_pathway_url . '?wporg_lesson_level=beginner' ); ?>"><?php esc_html_e( 'See all', 'wporg-learn' ); ?></a></p>
 		<!-- /wp:paragraph -->
 
 	</div>
@@ -110,7 +111,7 @@ $content = get_learning_pathway_level_content( $learning_pathway_slug );
 		<!-- /wp:paragraph -->
 
 		<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}}},"textColor":"charcoal-4"} -->
-		<p class="has-charcoal-4-color has-text-color has-link-color"><a href="<?php echo esc_url( site_url( '/courses/?wporg_learning_pathway=' . $learning_pathway_slug . '&wporg_lesson_level=intermediate' ) ); ?>"><?php esc_html_e( 'See all', 'wporg-learn' ); ?></a></p>
+		<p class="has-charcoal-4-color has-text-color has-link-color"><a href="<?php echo esc_url( $learning_pathway_url . '?wporg_lesson_level=intermediate' ); ?>"><?php esc_html_e( 'See all', 'wporg-learn' ); ?></a></p>
 		<!-- /wp:paragraph -->
 
 	</div>
@@ -176,7 +177,7 @@ $content = get_learning_pathway_level_content( $learning_pathway_slug );
 		<!-- /wp:paragraph -->
 
 		<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}}},"textColor":"charcoal-4"} -->
-		<p class="has-charcoal-4-color has-text-color has-link-color"><a href="<?php echo esc_url( site_url( '/courses/?wporg_learning_pathway=' . $learning_pathway_slug . '&wporg_lesson_level=advanced' ) ); ?>"><?php esc_html_e( 'See all', 'wporg-learn' ); ?></a></p>
+		<p class="has-charcoal-4-color has-text-color has-link-color"><a href="<?php echo esc_url( $learning_pathway_url . '?wporg_lesson_level=advanced' ); ?>"><?php esc_html_e( 'See all', 'wporg-learn' ); ?></a></p>
 		<!-- /wp:paragraph -->
 
 	</div>

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/taxonomy-learning-pathway-content.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/taxonomy-learning-pathway-content.php
@@ -53,14 +53,14 @@ $content = get_learning_pathway_level_content( $learning_pathway_slug );
 </div>
 <!-- /wp:group -->
 
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space","top":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)">
+<!-- wp:group {"align":"wide","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"},"style":{"spacing":{"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|50"}}}} -->
+<div class="wp-block-group alignwide" style="margin-top:var(--wp--preset--spacing--40);margin-bottom:var(--wp--preset--spacing--50)">
 
-	<!-- wp:group {"align":"wide","style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|50"}}}} -->
-	<div id="wporg-search" class="wp-block-group alignwide" style="margin-top:0;margin-bottom:var(--wp--preset--spacing--50)">
+	<!-- wp:search {"label":"<?php esc_attr_e( 'Search', 'wporg-learn' ); ?>","showLabel":false,"placeholder":"<?php esc_attr_e( 'Search', 'wporg-learn' ); ?>","width":290,"widthUnit":"px","buttonText":"<?php esc_attr_e( 'Search', 'wporg-learn' ); ?>","buttonPosition":"button-inside","buttonUseIcon":true,"query":{"wporg_learning_pathway":"<?php echo esc_attr( $learning_pathway_slug ); ?>"}} /-->
 
-		<!-- wp:search {"label":"<?php esc_attr_e( 'Search', 'wporg-learn' ); ?>","showLabel":false,"placeholder":"<?php esc_attr_e( 'Search', 'wporg-learn' ); ?>","width":290,"widthUnit":"px","buttonText":"<?php esc_attr_e( 'Search', 'wporg-learn' ); ?>","buttonPosition":"button-inside","buttonUseIcon":true,"query":{"wporg_learning_pathway":"<?php echo esc_attr( $learning_pathway_slug ); ?>"}} /-->
-
+	<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"flex","flexWrap":"nowrap"},"className":"wporg-query-filters"} -->
+	<div class="wp-block-group wporg-query-filters">
+		<!-- wp:wporg/query-filter {"key":"topic"} /-->
 	</div>
 	<!-- /wp:group -->
 

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/taxonomy-learning-pathway-topic-content.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/taxonomy-learning-pathway-topic-content.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Title: Taxonomy Learning Pathway Content
+ * Slug: wporg-learn-2024/taxonomy-learning-pathway-topic-content
+ * Inserter: no
+ */
+
+if ( ! is_tax( 'topic' ) ) {
+	return;
+}
+
+$topic_object = get_queried_object();
+
+if ( ! $topic_object ) {
+	return;
+}
+
+global $wp_query;
+
+if ( ! isset( $wp_query->query_vars['wporg_learning_pathway'] ) ) {
+	return;
+}
+
+$learning_pathway_object = get_term_by( 'slug', $wp_query->query_vars['wporg_learning_pathway'], 'learning-pathway' );
+
+$learning_pathway_id = $learning_pathway_object->term_id;
+$learning_pathway_slug = $learning_pathway_object->slug;
+$learning_pathway_name = $learning_pathway_object->name;
+$learning_pathway_description = $learning_pathway_object->description;
+?>
+
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","top":"0","bottom":"0"}},"border":{"bottom":{"color":"var:preset|color|light-grey-1","width":"1px"}}},"backgroundColor":"<?php echo esc_attr( $learning_pathway_slug ); ?>","className":"wporg-learn-tax-learning-pathway-header","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull has-<?php echo esc_attr( $learning_pathway_slug ); ?>-background-color has-background wporg-learn-tax-learning-pathway-header" style="border-bottom-color:var(--wp--preset--color--light-grey-1);border-bottom-width:1px;padding-top:0;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:0;padding-left:var(--wp--preset--spacing--edge-space)">
+
+	<!-- wp:group {"style":{"spacing":{"blockGap":"0"},"background":{"backgroundRepeat":"no-repeat","backgroundSize":"contain","backgroundPosition":"100% 50%"}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between","verticalAlignment":"stretch"}} -->
+	<div class="wp-block-group">
+		
+		<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}},"layout":{"selfStretch":"fill","flexSize":null}},"layout":{"type":"constrained"}} -->
+		<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)">
+
+			<!-- wp:heading {"level":1,"fontSize":"heading-1","fontFamily":"eb-garamond"} -->
+			<h1 class="wp-block-heading has-eb-garamond-font-family has-heading-1-font-size"><?php echo esc_html( $learning_pathway_name ); ?></h1>
+			<!-- /wp:heading -->
+
+			<!-- wp:paragraph {"style":{"typography":{"lineHeight":1.6}}} -->
+			<p style="line-height:1.6"><?php echo esc_html( $learning_pathway_description ); ?></p>
+			<!-- /wp:paragraph -->
+
+		</div>
+		<!-- /wp:group -->
+
+		<!-- wp:group {"style":{"layout":{"selfStretch":"fixed","flexSize":"33%"},"background":{"backgroundImage":{"url":"<?php echo esc_url( get_stylesheet_directory_uri() . '/assets/learning-pathway-' . $learning_pathway_slug . '.svg' ); ?>","source":"file"},"backgroundPosition":"0% 50%"}},"layout":{"type":"constrained"}} -->
+		<div class="wp-block-group"></div>
+		<!-- /wp:group -->
+
+	</div>
+	<!-- /wp:group -->
+
+</div>
+<!-- /wp:group -->
+
+<!-- wp:group {"align":"wide","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"},"style":{"spacing":{"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}}} -->
+<div class="wp-block-group alignwide" style="margin-top:var(--wp--preset--spacing--40);margin-bottom:var(--wp--preset--spacing--40)">
+
+	<!-- wp:search {"label":"<?php esc_attr_e( 'Search', 'wporg-learn' ); ?>","showLabel":false,"placeholder":"<?php esc_attr_e( 'Search', 'wporg-learn' ); ?>","width":290,"widthUnit":"px","buttonText":"<?php esc_attr_e( 'Search', 'wporg-learn' ); ?>","buttonPosition":"button-inside","buttonUseIcon":true,"query":{"wporg_learning_pathway":"<?php echo esc_attr( $learning_pathway_slug ); ?>"}} /-->
+
+	<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"flex","flexWrap":"nowrap"},"className":"wporg-query-filters"} -->
+	<div class="wp-block-group wporg-query-filters">
+		<!-- wp:wporg/query-filter {"key":"language"} /-->
+		<!-- wp:wporg/query-filter {"key":"topic"} /-->
+		<!-- wp:wporg/query-filter {"key":"level"} /-->
+	</div>
+	<!-- /wp:group -->
+
+</div>
+<!-- /wp:group -->
+
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60)">
+
+	<!-- wp:query-title {"type":"archive","showPrefix":true,"level":"2","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}}} /-->
+
+	<!-- wp:query {"queryId":1,"query":{"perPage":12,"postType":"course","courseFeatured":false,"inherit":true},"namespace":"wporg-learn/course-grid","align":"wide","className":"wporg-learn-course-grid"} -->
+	<div class="wp-block-query alignwide wporg-learn-course-grid">
+
+		<!-- wp:post-template {"style":{"spacing":{"blockGap":"var:preset|spacing|50"}},"layout":{"type":"grid","columnCount":null,"minimumColumnWidth":"330px"}} -->
+
+			<!-- wp:group {"style":{"border":{"width":"1px","color":"var:preset|color|light-grey-1","radius":"2px"},"spacing":{"blockGap":"0"},"dimensions":{"minHeight":"100%"}},"backgroundColor":"white","layout":{"type":"flex","orientation":"vertical"}} -->
+			<div class="wp-block-group has-border-color has-white-background-color has-background" style="border-color:var(--wp--preset--color--light-grey-1);border-width:1px;border-radius:2px;min-height:100%">
+
+				<!-- wp:post-featured-image {"style":{"spacing":{"margin":{"bottom":"0"}}}} /-->
+
+				<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"20px","right":"20px"}}},"layout":{"type":"constrained"}} -->
+				<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--20);padding-right:20px;padding-bottom:var(--wp--preset--spacing--20);padding-left:20px">
+
+					<!-- wp:post-title {"level":3,"isLink":true,"style":{"typography":{"fontStyle":"normal","fontWeight":"600","lineHeight":1.6},"spacing":{"margin":{"bottom":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}}},"fontSize":"normal","fontFamily":"inter"} /-->
+
+					<!-- wp:post-excerpt {"showMoreOnNewLine":false,"excerptLength":16,"style":{"spacing":{"margin":{"top":"var:preset|spacing|10"}},"typography":{"lineHeight":1.6}}} /-->
+
+					<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"left"}} -->
+					<div class="wp-block-group">
+
+						<!-- wp:wporg-learn/learning-duration {"style":{"elements":{"link":{"color":{"text":"var:preset|color|charcoal-4"}}}},"textColor":"charcoal-4","fontSize":"small"} /-->
+
+						<!-- wp:wporg-learn/lesson-count {"style":{"layout":{"selfStretch":"fill","flexSize":null}},"fontSize":"extra-small"} /-->
+
+						<!-- wp:wporg-learn/course-status {"fontSize":"extra-small"} /-->
+
+					</div>
+					<!-- /wp:group -->
+
+				</div>
+				<!-- /wp:group -->
+
+			</div>
+			<!-- /wp:group -->
+
+		<!-- /wp:post-template -->
+
+		<!-- wp:query-no-results -->
+
+			<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
+			<p><?php esc_html_e( 'No Courses found.', 'wporg-learn' ); ?></p>
+			<!-- /wp:paragraph -->
+
+		<!-- /wp:query-no-results -->
+
+		<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"}} -->
+
+			<!-- wp:query-pagination-previous {"label":"Previous"} /-->
+
+			<!-- wp:query-pagination-numbers /-->
+
+			<!-- wp:query-pagination-next {"label":"Next"} /-->
+
+		<!-- /wp:query-pagination -->
+
+	</div>
+	<!-- /wp:query -->
+
+</div>
+<!-- /wp:group -->

--- a/wp-content/themes/pub/wporg-learn-2024/src/learning-pathway-header/block.json
+++ b/wp-content/themes/pub/wporg-learn-2024/src/learning-pathway-header/block.json
@@ -1,0 +1,29 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "wporg-learn/learning-pathway-header",
+	"version": "0.1.0",
+	"title": "Learning Pathway Header",
+	"category": "widgets",
+	"icon": "smiley",
+	"description": "Shows the header for a Learning Pathway taxonomy page",
+	"usesContext": [],
+	"attributes": {
+		"learningPathwaySlug": {
+			"type": "string",
+			"default": ""
+		}
+	},
+	"supports": {
+		"html": false,
+		"spacing": {
+			"margin": [
+				"bottom"
+			],
+			"align": true
+		}
+	},
+	"textdomain": "wporg-learn",
+	"editorScript": "file:./index.js",
+	"style": "file:./style-index.css"
+}

--- a/wp-content/themes/pub/wporg-learn-2024/src/learning-pathway-header/block.json
+++ b/wp-content/themes/pub/wporg-learn-2024/src/learning-pathway-header/block.json
@@ -19,9 +19,12 @@
 		"spacing": {
 			"margin": [
 				"bottom"
-			],
-			"align": true
-		}
+			]
+		},
+		"align": [
+			"wide",
+			"full"
+		]
 	},
 	"textdomain": "wporg-learn",
 	"editorScript": "file:./index.js",

--- a/wp-content/themes/pub/wporg-learn-2024/src/learning-pathway-header/index.js
+++ b/wp-content/themes/pub/wporg-learn-2024/src/learning-pathway-header/index.js
@@ -1,0 +1,18 @@
+/**
+ * WordPress dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import Edit from '../shared/dynamic-edit';
+import metadata from './block.json';
+import './style.scss';
+
+registerBlockType( metadata.name, {
+	/**
+	 * @see ./edit.js
+	 */
+	edit: Edit,
+} );

--- a/wp-content/themes/pub/wporg-learn-2024/src/learning-pathway-header/index.php
+++ b/wp-content/themes/pub/wporg-learn-2024/src/learning-pathway-header/index.php
@@ -106,10 +106,6 @@ function render( $attributes, $content, $block ) {
 	<!-- /wp:group -->';
 
 	$wrapper_attributes = get_block_wrapper_attributes();
-	$align = $attributes['align'];
-	if ( $align ) {
-		$wrapper_attributes = str_replace( 'class="', 'class="align' . $align . ' ', $wrapper_attributes );
-	}
 	return sprintf(
 		'<div %1$s>%2$s</div>',
 		$wrapper_attributes,

--- a/wp-content/themes/pub/wporg-learn-2024/src/learning-pathway-header/index.php
+++ b/wp-content/themes/pub/wporg-learn-2024/src/learning-pathway-header/index.php
@@ -53,8 +53,8 @@ function render( $attributes, $content, $block ) {
 	$learning_pathway_name = $learning_pathway_object->name;
 	$learning_pathway_description = $learning_pathway_object->description;
 
-	$content = '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","top":"0","bottom":"0"}},"border":{"bottom":{"color":"var:preset|color|light-grey-1","width":"1px"}}},"backgroundColor":"' . esc_attr( $learning_pathway_slug ) . '","layout":{"type":"constrained"}} -->
-	<div class="wp-block-group alignfull has-' . esc_attr( $learning_pathway_slug ) . '-background-color has-background" style="border-bottom-color:var(--wp--preset--color--light-grey-1);border-bottom-width:1px;padding-top:0;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:0;padding-left:var(--wp--preset--spacing--edge-space)">
+	$content = '<!-- wp:group {"className":"wp-block-wporg-learn-learning-pathway-header-content","align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","top":"0","bottom":"0"}},"border":{"bottom":{"color":"var:preset|color|light-grey-1","width":"1px"}}},"backgroundColor":"' . esc_attr( $learning_pathway_slug ) . '","layout":{"type":"constrained"}} -->
+	<div class="wp-block-wporg-learn-learning-pathway-header-content wp-block-group alignfull has-' . esc_attr( $learning_pathway_slug ) . '-background-color has-background" style="border-bottom-color:var(--wp--preset--color--light-grey-1);border-bottom-width:1px;padding-top:0;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:0;padding-left:var(--wp--preset--spacing--edge-space)">
 
 		<!-- wp:group {"style":{"spacing":{"blockGap":"0"},"background":{"backgroundRepeat":"no-repeat","backgroundSize":"contain","backgroundPosition":"100% 50%"}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between","verticalAlignment":"stretch"}} -->
 		<div class="wp-block-group">

--- a/wp-content/themes/pub/wporg-learn-2024/src/learning-pathway-header/index.php
+++ b/wp-content/themes/pub/wporg-learn-2024/src/learning-pathway-header/index.php
@@ -94,7 +94,7 @@ function render( $attributes, $content, $block ) {
 			<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"flex","flexWrap":"nowrap"},"className":"wporg-query-filters"} -->
 			<div class="wp-block-group wporg-query-filters">
 				<!-- wp:wporg/query-filter {"key":"language"} /-->
-				<!-- wp:wporg/query-filter {"key":"topic"} /-->
+				<!-- wp:wporg/query-filter {"key":"learning-pathway-topic"} /-->
 				<!-- wp:wporg/query-filter {"key":"learning-pathway-level","multiple":false} /-->
 			</div>
 			<!-- /wp:group -->

--- a/wp-content/themes/pub/wporg-learn-2024/src/learning-pathway-header/index.php
+++ b/wp-content/themes/pub/wporg-learn-2024/src/learning-pathway-header/index.php
@@ -1,0 +1,118 @@
+<?php
+namespace WordPressdotorg\Theme\Learn_2024\Learning_Pathway_Header;
+
+add_action( 'init', __NAMESPACE__ . '\init' );
+
+/**
+ * Registers the block using the metadata loaded from the `block.json` file.
+ * Behind the scenes, it registers also all assets so they can be enqueued
+ * through the block editor in the corresponding context.
+ *
+ * @see https://developer.wordpress.org/reference/functions/register_block_type/
+ */
+function init() {
+	register_block_type(
+		dirname( dirname( __DIR__ ) ) . '/build/learning-pathway-header',
+		array(
+			'render_callback' => __NAMESPACE__ . '\render',
+		)
+	);
+}
+
+/**
+ * Render the block content.
+ *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ *
+ * @return string Returns the block markup.
+ */
+function render( $attributes, $content, $block ) {
+	$learning_pathway_slug = $attributes['learningPathwaySlug'];
+
+	if ( ! $learning_pathway_slug ) {
+		return '';
+	}
+
+	global $wp_query;
+
+	// If this is the learning pathway taxonomy archive page, we can use the queried object.
+	// On a different taxonomy archive page, we need to fetch the term by slug.
+	if ( isset( $wp_query->queried_object->slug ) && $wp_query->queried_object->slug === $learning_pathway_slug ) {
+		$learning_pathway_object = $wp_query->queried_object;
+	} else {
+		$learning_pathway_object = get_term_by( 'slug', $learning_pathway_slug, 'learning-pathway' );
+	}
+
+	if ( ! $learning_pathway_object ) {
+		return '';
+	}
+
+	$learning_pathway_id = $learning_pathway_object->term_id;
+	$learning_pathway_name = $learning_pathway_object->name;
+	$learning_pathway_description = $learning_pathway_object->description;
+
+	$content = '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","top":"0","bottom":"0"}},"border":{"bottom":{"color":"var:preset|color|light-grey-1","width":"1px"}}},"backgroundColor":"' . esc_attr( $learning_pathway_slug ) . '","layout":{"type":"constrained"}} -->
+	<div class="wp-block-group alignfull has-' . esc_attr( $learning_pathway_slug ) . '-background-color has-background" style="border-bottom-color:var(--wp--preset--color--light-grey-1);border-bottom-width:1px;padding-top:0;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:0;padding-left:var(--wp--preset--spacing--edge-space)">
+
+		<!-- wp:group {"style":{"spacing":{"blockGap":"0"},"background":{"backgroundRepeat":"no-repeat","backgroundSize":"contain","backgroundPosition":"100% 50%"}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between","verticalAlignment":"stretch"}} -->
+		<div class="wp-block-group">
+			
+			<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}},"layout":{"selfStretch":"fill","flexSize":null}},"layout":{"type":"constrained"}} -->
+			<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)">
+
+				<!-- wp:heading {"level":1,"fontSize":"heading-1","fontFamily":"eb-garamond"} -->
+				<h1 class="wp-block-heading has-eb-garamond-font-family has-heading-1-font-size">' . esc_html( $learning_pathway_name ) . '</h1>
+				<!-- /wp:heading -->
+
+				<!-- wp:paragraph {"style":{"typography":{"lineHeight":1.6}}} -->
+				<p style="line-height:1.6">' . esc_html( $learning_pathway_description ) . '</p>
+				<!-- /wp:paragraph -->
+
+			</div>
+			<!-- /wp:group -->
+
+			<!-- wp:group {"style":{"layout":{"selfStretch":"fixed","flexSize":"33%"},"background":{"backgroundImage":{"url":"' . esc_url( get_stylesheet_directory_uri() . '/assets/learning-pathway-' . $learning_pathway_slug . '.svg' ) . '","source":"file"},"backgroundPosition":"0% 50%"}},"layout":{"type":"constrained"}} -->
+			<div class="wp-block-group"></div>
+			<!-- /wp:group -->
+
+		</div>
+		<!-- /wp:group -->
+
+	</div>
+	<!-- /wp:group -->
+	
+	<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group alignfull" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)">
+
+		<!-- wp:group {"align":"wide","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"},"style":{"spacing":{"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}}} -->
+		<div class="wp-block-group alignwide" style="margin-top:var(--wp--preset--spacing--40);margin-bottom:var(--wp--preset--spacing--40)">
+
+			<!-- wp:search {"label":"' . __( 'Search', 'wporg-learn' ) . '","showLabel":false,"placeholder":"' . __( 'Search', 'wporg-learn' ) . '","width":290,"widthUnit":"px","buttonText":"' . __( 'Search', 'wporg-learn' ) . '","buttonPosition":"button-inside","buttonUseIcon":true,"query":{"wporg_learning_pathway":"' . esc_attr( $learning_pathway_slug ) . '"}} /-->
+
+			<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"flex","flexWrap":"nowrap"},"className":"wporg-query-filters"} -->
+			<div class="wp-block-group wporg-query-filters">
+				<!-- wp:wporg/query-filter {"key":"language"} /-->
+				<!-- wp:wporg/query-filter {"key":"topic"} /-->
+				<!-- wp:wporg/query-filter {"key":"level","multiple":false} /-->
+			</div>
+			<!-- /wp:group -->
+
+		</div>
+		<!-- /wp:group -->
+		
+	</div>
+	<!-- /wp:group -->';
+
+	$wrapper_attributes = get_block_wrapper_attributes();
+	$align = $attributes['align'];
+	if ( $align ) {
+		$wrapper_attributes = str_replace( 'class="', 'class="align' . $align . ' ', $wrapper_attributes );
+	}
+	return sprintf(
+		'<div %1$s>%2$s</div>',
+		$wrapper_attributes,
+		do_blocks( $content )
+	);
+}

--- a/wp-content/themes/pub/wporg-learn-2024/src/learning-pathway-header/index.php
+++ b/wp-content/themes/pub/wporg-learn-2024/src/learning-pathway-header/index.php
@@ -95,7 +95,7 @@ function render( $attributes, $content, $block ) {
 			<div class="wp-block-group wporg-query-filters">
 				<!-- wp:wporg/query-filter {"key":"language"} /-->
 				<!-- wp:wporg/query-filter {"key":"topic"} /-->
-				<!-- wp:wporg/query-filter {"key":"level","multiple":false} /-->
+				<!-- wp:wporg/query-filter {"key":"learning-pathway-level","multiple":false} /-->
 			</div>
 			<!-- /wp:group -->
 

--- a/wp-content/themes/pub/wporg-learn-2024/src/learning-pathway-header/index.php
+++ b/wp-content/themes/pub/wporg-learn-2024/src/learning-pathway-header/index.php
@@ -93,7 +93,6 @@ function render( $attributes, $content, $block ) {
 
 			<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"flex","flexWrap":"nowrap"},"className":"wporg-query-filters"} -->
 			<div class="wp-block-group wporg-query-filters">
-				<!-- wp:wporg/query-filter {"key":"language"} /-->
 				<!-- wp:wporg/query-filter {"key":"learning-pathway-topic"} /-->
 				<!-- wp:wporg/query-filter {"key":"learning-pathway-level","multiple":false} /-->
 			</div>

--- a/wp-content/themes/pub/wporg-learn-2024/src/learning-pathway-header/style.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/learning-pathway-header/style.scss
@@ -1,4 +1,4 @@
-.wp-block-wporg-learn-learning-pathway-header > .wp-block-group {
+.wp-block-wporg-learn-learning-pathway-header .wp-block-wporg-learn-learning-pathway-header-content {
 
 	@media screen and (max-width: 1024px) {
 		padding-right: unset !important;

--- a/wp-content/themes/pub/wporg-learn-2024/src/learning-pathway-header/style.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/learning-pathway-header/style.scss
@@ -1,0 +1,6 @@
+.wp-block-wporg-learn-learning-pathway-header > .wp-block-group {
+
+	@media screen and (max-width: 1024px) {
+		padding-right: unset !important;
+	}
+}

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_taxonomy.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_taxonomy.scss
@@ -1,7 +1,10 @@
-.tax-learning-pathway {
+.tax-learning-pathway,
+.tax-topic,
+.tax-level {
 
 	@media screen and (min-width: 769px) {
 		--wp--preset--font-size--heading-1: 50px;
+		--wp--custom--heading--level-1--typography--line-height: 1.2;
 	}
 
 	.wporg-learn-tax-learning-pathway-header {

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_taxonomy.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_taxonomy.scss
@@ -6,11 +6,4 @@
 		--wp--preset--font-size--heading-1: 50px;
 		--wp--custom--heading--level-1--typography--line-height: 1.2;
 	}
-
-	.wporg-learn-tax-learning-pathway-header {
-
-		@media screen and (max-width: 1024px) {
-			padding-right: unset !important;
-		}
-	}
 }

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/style.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/style.scss
@@ -10,7 +10,7 @@
 @import "sensei";
 @import "sidebar";
 @import "tag";
-@import "taxonomy-learning-pathway";
+@import "taxonomy";
 @import "wp-components";
 @import "wporg-meeting-calendar";
 

--- a/wp-content/themes/pub/wporg-learn-2024/templates/taxonomy-topic.html
+++ b/wp-content/themes/pub/wporg-learn-2024/templates/taxonomy-topic.html
@@ -1,0 +1,11 @@
+<!-- wp:template-part {"slug":"header","className":"has-display-contents","tagName":"div"} /-->
+
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"},"className":"entry-content","style":{"spacing":{"blockGap":"0px"}}} -->
+<main class="wp-block-group entry-content">
+
+	<!-- wp:pattern {"slug":"wporg-learn-2024/taxonomy-learning-pathway-topic-content"} /-->
+
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer"} /-->

--- a/wp-content/themes/pub/wporg-learn-2024/templates/taxonomy.html
+++ b/wp-content/themes/pub/wporg-learn-2024/templates/taxonomy.html
@@ -3,7 +3,7 @@
 <!-- wp:group {"tagName":"main","layout":{"type":"constrained"},"className":"entry-content","style":{"spacing":{"blockGap":"0px"}}} -->
 <main class="wp-block-group entry-content">
 
-	<!-- wp:pattern {"slug":"wporg-learn-2024/taxonomy-learning-pathway-topic-content"} /-->
+	<!-- wp:pattern {"slug":"wporg-learn-2024/taxonomy-content"} /-->
 
 </main>
 <!-- /wp:group -->

--- a/wp-content/themes/pub/wporg-learn-2024/theme.json
+++ b/wp-content/themes/pub/wporg-learn-2024/theme.json
@@ -176,7 +176,8 @@
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--eb-garamond)",
 					"fontSize": "36px",
-					"lineHeight": "1.3"
+					"lineHeight": "1.3",
+					"fontWeight": "400"
 				}
 			}
 		},


### PR DESCRIPTION
Adds query filters to the Learning Pathways taxonomy page.

This has ended up being much more complex than expected due to the way the template hierarchy behaves once query vars are set. For example http://localhost:8888/learning-pathway/developer/?wporg_lesson_level=beginner does not load the `taxonomy-learning-pathway.html` template, rather it loads `taxonomy.html`, so I've had to make that template conditionally render the Learning Pathways header. This is now converted to a block to avoid duplication.

The Level filter is a single select filter, so changes have been made across all templates to accomodate this. For Lesson Plans there is an existing 'Any' level term, so there is now a additional 'All' level. Without the 'All' level it isn't possible to clear the level selection. While a little confusing, 'Any' is a specific term for this taxonomy so I think it's valid to be there. To resolve this I think we should talk to the training team about deprecating the term. It's only used for Lesson Plans which are planned to also be deprecated. 

Building the list of topic and level options for each template requires different filters to be applied, so I've split these into different get functions in block_config.php

Closes #2456 

### Screenshots

| Learning Pathway page | Filtered Learning Pathway page | Lesson Plan archive |
|-|-|-|
| ![learn wordpress org_learning-pathway_user_(Desktop)](https://github.com/WordPress/Learn/assets/1017872/a83ac774-f612-4d6e-9c7f-ea67deb46e7f) | ![learn wordpress org_learning-pathway_user__wporg_lesson_level=beginner(Desktop)](https://github.com/WordPress/Learn/assets/1017872/c84dde85-dbc6-4650-a2c9-64f9e064f869) | ![learn wordpress org_lesson-plans_(Desktop) (1)](https://github.com/WordPress/Learn/assets/1017872/cb0783fc-ea51-4dd4-be22-d7c40298f020) |

### Testing
Testing in sandbox is easiest due to existing data, https://learn.wordpress.org/test/learning-pathway/developer/ or https://learn.wordpress.org/learning-pathway/user/?new-theme=1 and regression testing the other archives: Lesson Plans, Lessons, Tutorials, Courses.

The design for the filtered Learning Pathway is [here](https://www.figma.com/design/ZKaf6u8mIHkAanluWafXAp/Learn?node-id=3873-12813&m=dev).
