### PR TITLE
Add locale suggestion banner

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2024/parts/header.html
+++ b/wp-content/themes/pub/wporg-learn-2024/parts/header.html
@@ -15,3 +15,7 @@
 	<!-- wp:navigation {"menuSlug":"learn","icon":"menu","overlayBackgroundColor":"charcoal-2","overlayTextColor":"white","layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small"} /-->
 
 <!-- /wp:wporg/local-navigation-bar -->
+
+<!-- wp:wporg/language-suggest {"align":"full","style":{"color":{"background":"#ebebeb"}}} -->
+<div class="wp-block-wporg-language-suggest alignfull has-background" style="background-color:#ebebeb"></div>
+<!-- /wp:wporg/language-suggest -->

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/front-page-header.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/front-page-header.php
@@ -34,5 +34,9 @@
 	</div>
 	<!-- /wp:group -->
 
+	<!-- wp:wporg/language-suggest {"align":"full","style":{"color":{"background":"#ebebeb"}}} -->
+	<div class="wp-block-wporg-language-suggest alignfull has-background" style="background-color:#ebebeb"></div>
+	<!-- /wp:wporg/language-suggest -->
+
 </div>
 <!-- /wp:group -->


### PR DESCRIPTION
Closes #2428

This PR adds a locale suggestion banner to the header and front page header.

Related PRs: 
https://github.com/WordPress/wporg-mu-plugins/pull/626
[meta.trac.wordpress.org/ticket/7675](https://meta.trac.wordpress.org/ticket/7675)

## Screenshots

| Locale | Homepage | Other page |
|-|-|-|
| en-us | ![Screenshot 2024-06-14 at 07 07 49](https://github.com/WordPress/Learn/assets/18050944/1aeb3540-ccc6-4f9f-b762-2bd7aeabf7aa) | ![Screenshot 2024-06-14 at 07 07 25](https://github.com/WordPress/Learn/assets/18050944/b949a585-71c7-4bc1-829b-85bb109d9d0c) |
| ja | ![Screenshot 2024-06-14 at 07 06 26](https://github.com/WordPress/Learn/assets/18050944/7cc5b92e-bfd3-4423-bc71-d97a58ad4625) | ![Screenshot 2024-06-14 at 07 07 02](https://github.com/WordPress/Learn/assets/18050944/888eabee-2156-484f-a1b6-29ee76601a84) | 
| zh-tw | ![Screenshot 2024-06-14 at 07 04 10](https://github.com/WordPress/Learn/assets/18050944/cb151e0d-5bdf-488d-a81f-903511d64a45) | ![Screenshot 2024-06-14 at 07 13 48](https://github.com/WordPress/Learn/assets/18050944/af2f13ba-2812-4d4f-bdcc-e7deffba156e) |
