### PR TITLE
Update search template

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2024/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2024/functions.php
@@ -11,6 +11,7 @@ require_once __DIR__ . '/src/search-results-context/index.php';
 require_once __DIR__ . '/src/upcoming-online-workshops/index.php';
 require_once __DIR__ . '/src/sensei-meta-list/index.php';
 require_once __DIR__ . '/inc/block-config.php';
+require_once __DIR__ . '/inc/query.php';
 
 /**
  * Actions and filters.
@@ -29,7 +30,6 @@ add_filter( 'sensei_register_post_type_course', function( $args ) {
 	$args['has_archive'] = 'courses';
 	return $args;
 } );
-add_action( 'pre_get_posts', __NAMESPACE__ . '\modify_learning_pathways_query' );
 
 /**
  * Modify the single template hierarchy to use customised copies of the Sensei Course Theme templates.
@@ -278,25 +278,4 @@ function set_site_breadcrumbs( $breadcrumbs ) {
 	}
 
 	return $breadcrumbs;
-}
-
-/**
- * Modify the main query.
- * If the 'all' level filter is set in the query, remove it to return all posts.
- *
- * @param WP_Query $query The main query.
- * @return WP_Query
- */
-function modify_learning_pathways_query( $query ) {
-	if ( is_admin() || ! $query->is_main_query() ) {
-		return;
-	}
-
-	$level = $query->get( 'wporg_lesson_level' );
-
-	if ( 'all' === $level ) {
-		$query->set( 'wporg_lesson_level', '' );
-	}
-
-	return $query;
 }

--- a/wp-content/themes/pub/wporg-learn-2024/inc/block-config.php
+++ b/wp-content/themes/pub/wporg-learn-2024/inc/block-config.php
@@ -14,7 +14,6 @@ add_filter( 'wporg_query_filter_options_learning-pathway-level', __NAMESPACE__ .
 add_filter( 'wporg_query_filter_options_topic', __NAMESPACE__ . '\get_topic_options' );
 add_filter( 'wporg_query_filter_options_taxonomy-topic', __NAMESPACE__ . '\get_taxonomy_topic_options' );
 add_filter( 'wporg_query_filter_options_learning-pathway-topic', __NAMESPACE__ . '\get_learning_pathway_topic_options' );
-add_action( 'pre_get_posts', __NAMESPACE__ . '\modify_query' );
 add_action( 'wporg_query_filter_in_form', __NAMESPACE__ . '\inject_other_filters' );
 
 /**
@@ -385,39 +384,6 @@ function get_language_options( $options ) {
 		'options' => $languages,
 		'selected' => $selected,
 	);
-}
-
-/**
- * Modify the query by adding meta query for language if set.
- *
- * @param WP_Query $query The query object.
- */
-function modify_query( $query ) {
-	// Ensure this code runs only for the main query on archive pages
-	if ( ! is_admin() && $query->is_main_query() && $query->is_archive() ) {
-		if ( isset( $_GET['language'] ) && is_array( $_GET['language'] ) ) {
-			$languages = array_map( 'sanitize_text_field', $_GET['language'] );
-
-			$meta_query = array( 'relation' => 'OR' );
-
-			$meta_query[] = array(
-				'key'     => 'language',
-				'value'   => $languages,
-				'compare' => 'IN',
-			);
-
-			// If 'en_US' is included, include posts with no language defined
-			// as this is the default value for the meta field.
-			if ( in_array( 'en_US', $languages ) ) {
-				$meta_query[] = array(
-					'key'     => 'language',
-					'compare' => 'NOT EXISTS',
-				);
-			}
-
-			$query->set( 'meta_query', $meta_query );
-		}
-	}
 }
 
 /**

--- a/wp-content/themes/pub/wporg-learn-2024/inc/query.php
+++ b/wp-content/themes/pub/wporg-learn-2024/inc/query.php
@@ -6,7 +6,7 @@
 namespace WordPressdotorg\Theme\Learn_2024\Query;
 
 add_action( 'pre_get_posts', __NAMESPACE__ . '\modify_archive_queries' );
-add_action( 'pre_get_posts', __NAMESPACE__ . '\modify_learning_pathways_query' );
+add_action( 'pre_get_posts', __NAMESPACE__ . '\modify_level_query' );
 add_action( 'pre_get_posts', __NAMESPACE__ . '\modify_search_query' );
 
 
@@ -50,7 +50,7 @@ function modify_archive_queries( $query ) {
  * @param WP_Query $query The main query.
  * @return WP_Query
  */
-function modify_learning_pathways_query( $query ) {
+function modify_level_query( $query ) {
 	if ( is_admin() || ! $query->is_main_query() ) {
 		return;
 	}

--- a/wp-content/themes/pub/wporg-learn-2024/inc/query.php
+++ b/wp-content/themes/pub/wporg-learn-2024/inc/query.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Set up query modifications.
+ */
+
+namespace WordPressdotorg\Theme\Learn_2024\Query;
+
+add_action( 'pre_get_posts', __NAMESPACE__ . '\modify_archive_queries' );
+add_action( 'pre_get_posts', __NAMESPACE__ . '\modify_learning_pathways_query' );
+
+/**
+ * Modify the query by adding meta query for language if set.
+ *
+ * @param WP_Query $query The query object.
+ */
+function modify_archive_queries( $query ) {
+	// Ensure this code runs only for the main query on archive pages and search results.
+	if ( ! is_admin() && $query->is_main_query() && ( $query->is_archive() || $query->is_search() ) ) {
+		if ( isset( $_GET['language'] ) && is_array( $_GET['language'] ) ) {
+			$languages = array_map( 'sanitize_text_field', $_GET['language'] );
+
+			$meta_query = array( 'relation' => 'OR' );
+
+			$meta_query[] = array(
+				'key'     => 'language',
+				'value'   => $languages,
+				'compare' => 'IN',
+			);
+
+			// If 'en_US' is included, include posts with no language defined
+			// as this is the default value for the meta field.
+			if ( in_array( 'en_US', $languages ) ) {
+				$meta_query[] = array(
+					'key'     => 'language',
+					'compare' => 'NOT EXISTS',
+				);
+			}
+
+			$query->set( 'meta_query', $meta_query );
+		}
+	}
+}
+
+/**
+ * Modify the main query.
+ * If the 'all' level filter is set in the query, remove it to return all posts.
+ *
+ * @param WP_Query $query The main query.
+ * @return WP_Query
+ */
+function modify_learning_pathways_query( $query ) {
+	if ( is_admin() || ! $query->is_main_query() ) {
+		return;
+	}
+
+	$level = $query->get( 'wporg_lesson_level' );
+
+	if ( 'all' === $level ) {
+		$query->set( 'wporg_lesson_level', '' );
+	}
+
+	return $query;
+}

--- a/wp-content/themes/pub/wporg-learn-2024/inc/query.php
+++ b/wp-content/themes/pub/wporg-learn-2024/inc/query.php
@@ -7,6 +7,8 @@ namespace WordPressdotorg\Theme\Learn_2024\Query;
 
 add_action( 'pre_get_posts', __NAMESPACE__ . '\modify_archive_queries' );
 add_action( 'pre_get_posts', __NAMESPACE__ . '\modify_learning_pathways_query' );
+add_action( 'pre_get_posts', __NAMESPACE__ . '\modify_search_query' );
+
 
 /**
  * Modify the query by adding meta query for language if set.
@@ -58,6 +60,34 @@ function modify_learning_pathways_query( $query ) {
 	if ( 'all' === $level ) {
 		$query->set( 'wporg_lesson_level', '' );
 	}
+
+	return $query;
+}
+
+/**
+ * Get a list of the searchable Learn post types.
+ *
+ * @return array The searchable post types.
+ */
+function get_searchable_post_types() {
+	return array( 'course', 'lesson', 'quiz', 'meeting', 'page', 'post', 'lesson-plan' );
+}
+
+/**
+ * Modify the search query to filter to only Learn post types if no post type is set.
+ *
+ * @param WP_Query $query The search query.
+ */
+function modify_search_query( $query ) {
+	if ( is_admin() || ! $query->is_search() ) {
+		return;
+	}
+
+	if ( isset( $query->query_vars['post_type'] ) ) {
+		return $query;
+	}
+
+	$query->set( 'post_type', get_searchable_post_types() );
 
 	return $query;
 }

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/search-content.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/search-content.php
@@ -7,47 +7,73 @@
 
 ?>
 
-<!-- wp:query {"queryId":0,"query":{"inherit":true,"perPage":25},"align":"wide"} -->
-<div class="wp-block-query alignwide">
+<!-- wp:group {"align":"wide","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"},"style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|50"}}}} -->
+<div class="wp-block-group alignwide" style="margin-top:0;margin-bottom:var(--wp--preset--spacing--50)">
 
-	<!-- wp:group {"className":"align-left","layout":{"type":"constrained","contentSize":"","justifyContent":"left"},"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}}} -->
-	<div class="wp-block-group align-left" style="margin-bottom:var(--wp--preset--spacing--40)">
+	<!-- wp:search {"label":"<?php esc_attr_e( 'Search', 'wporg-learn' ); ?>","showLabel":false,"placeholder":"<?php esc_attr_e( 'Search learning resources', 'wporg-learn' ); ?>","width":255,"widthUnit":"px","buttonText":"<?php esc_attr_e( 'Search', 'wporg-learn' ); ?>","buttonPosition":"button-inside","buttonUseIcon":true,"className":"is-style-secondary-search-control wporg-filtered-search-form"} /-->
 
-		<!-- wp:group {"align":"wide","className":"wporg-search-controls","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between","verticalAlignment":"top"},"style":{"spacing":{"margin":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20"}}}} -->
-		<div id="wporg-search" class="wp-block-group alignwide wporg-search-controls" style="margin-top:var(--wp--preset--spacing--20);margin-bottom:var(--wp--preset--spacing--20)">
-	
-			<!-- wp:search {"label":"<?php esc_attr_e( 'Search', 'wporg-learn' ); ?>","showLabel":false,"placeholder":"<?php esc_attr_e( 'Search learning resources', 'wporg-learn' ); ?>","width":232,"widthUnit":"px","buttonText":"<?php esc_attr_e( 'Search', 'wporg-learn' ); ?>","buttonPosition":"button-inside","buttonUseIcon":true,"className":"is-style-secondary-search-control wporg-filtered-search-form"} /-->
-		
+</div>
+<!-- /wp:group -->
+
+<!-- wp:wporg-learn/search-results-context {"style":{"spacing":{"padding":{"bottom":"var:preset|spacing|20"}},"elements":{"link":{"color":{"text":"var:preset|color|charcoal-4"}}}},"textColor":"charcoal-4","fontSize":"small"} /-->
+
+<!-- wp:query {"queryId":1,"query":{"perPage":12,"postType":"course","courseFeatured":false,"inherit":true},"namespace":"wporg-learn/course-grid","align":"wide","className":"wporg-learn-course-grid"} -->
+<div class="wp-block-query alignwide wporg-learn-course-grid">
+
+	<!-- wp:post-template {"style":{"spacing":{"blockGap":"var:preset|spacing|50"}},"layout":{"type":"grid","columnCount":null,"minimumColumnWidth":"330px"}} -->
+
+		<!-- wp:group {"style":{"border":{"width":"1px","color":"var:preset|color|light-grey-1","radius":"2px"},"spacing":{"blockGap":"0"},"dimensions":{"minHeight":"100%"}},"backgroundColor":"white","layout":{"type":"flex","orientation":"vertical"}} -->
+		<div class="wp-block-group has-border-color has-white-background-color has-background" style="border-color:var(--wp--preset--color--light-grey-1);border-width:1px;border-radius:2px;min-height:100%">
+
+			<!-- wp:post-featured-image {"style":{"spacing":{"margin":{"bottom":"0"}}}} /-->
+
+			<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"20px","right":"20px"}}},"layout":{"type":"constrained"}} -->
+			<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--20);padding-right:20px;padding-bottom:var(--wp--preset--spacing--20);padding-left:20px">
+
+				<!-- wp:post-title {"level":3,"isLink":true,"style":{"typography":{"fontStyle":"normal","fontWeight":"600","lineHeight":1.6},"spacing":{"margin":{"bottom":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}}},"fontSize":"normal","fontFamily":"inter"} /-->
+
+				<!-- wp:post-excerpt {"showMoreOnNewLine":false,"excerptLength":16,"style":{"spacing":{"margin":{"top":"var:preset|spacing|10"}},"typography":{"lineHeight":1.6}}} /-->
+
+				<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"left"}} -->
+				<div class="wp-block-group">
+
+					<!-- wp:wporg-learn/learning-duration {"style":{"elements":{"link":{"color":{"text":"var:preset|color|charcoal-4"}}}},"textColor":"charcoal-4","fontSize":"small"} /-->
+
+					<!-- wp:wporg-learn/lesson-count {"style":{"layout":{"selfStretch":"fill","flexSize":null}},"fontSize":"extra-small"} /-->
+
+					<!-- wp:wporg-learn/course-status {"fontSize":"extra-small"} /-->
+
+				</div>
+				<!-- /wp:group -->
+
+			</div>
+			<!-- /wp:group -->
+
 		</div>
 		<!-- /wp:group -->
 
-		<!-- wp:wporg-learn/search-results-context {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20"}},"elements":{"link":{"color":{"text":"var:preset|color|charcoal-4"}}}},"textColor":"charcoal-4","fontSize":"small"} /-->
+	<!-- /wp:post-template -->
 
-		<!-- wp:post-template {"align":"wide"} -->
+	<!-- wp:query-no-results -->
 
-			<!-- wp:post-title {"isLink":true} /-->
+		<!-- wp:heading {"level":1,"fontFamily":"eb-garamond"} -->
+		<h1 class="wp-block-heading has-eb-garamond-font-family"><?php esc_html_e( 'No results found', 'wporg-learn' ); ?></h1>
+		<!-- /wp:heading -->
 
-			<!-- wp:post-excerpt /-->
+		<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
+		<p><?php esc_html_e( 'Try a different search, or clearing filters.', 'wporg-learn' ); ?></p>
+		<!-- /wp:paragraph -->
 
-		<!-- /wp:post-template -->
-
-		<!-- wp:query-no-results -->
-		
-			<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results.","style":{"spacing":{"margin":{"top":"var:preset|spacing|40"}}}} -->
-			<p style="margin-top:var(--wp--preset--spacing--40)"><?php esc_attr_e( 'Sorry, but nothing matched your search terms.', 'wporg-learn' ); ?></p>
-			<!-- /wp:paragraph -->
-
-		<!-- /wp:query-no-results -->
-	
-	</div>
-	<!-- /wp:group -->
+	<!-- /wp:query-no-results -->
 
 	<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"}} -->
+
 		<!-- wp:query-pagination-previous {"label":"Previous"} /-->
 
 		<!-- wp:query-pagination-numbers /-->
 
 		<!-- wp:query-pagination-next {"label":"Next"} /-->
+
 	<!-- /wp:query-pagination -->
 
 </div>

--- a/wp-content/themes/pub/wporg-learn-2024/templates/search.html
+++ b/wp-content/themes/pub/wporg-learn-2024/templates/search.html
@@ -3,7 +3,13 @@
 <!-- wp:group {"tagName":"main","layout":{"type":"constrained","justifyContent":"left"},"style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}}} -->
 <main class="wp-block-group alignfull" style="padding-left:var(--wp--preset--spacing--edge-space);padding-right:var(--wp--preset--spacing--edge-space)">
 
-	<!-- wp:pattern {"slug":"wporg-learn-2024/search-content"} /-->
+	<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space","top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--edge-space)">
+
+		<!-- wp:pattern {"slug":"wporg-learn-2024/search-content"} /-->
+
+	</div>
+	<!-- /wp:group -->
 
 </main>
 <!-- /wp:group -->


### PR DESCRIPTION
Adds a cards grid of results, and a no results message. 

Limits the post types included in searches to the Learn content types: `'course', 'lesson', 'quiz', 'meeting', 'page', 'post', 'lesson-plan'`

Filters will be added in a subsequent PR.

See #2437 

### Screenshots

| Desktop | Tablet | Mobile |
|-|-|-|
| ![learn wordpress org__s=theme json(Desktop)](https://github.com/WordPress/Learn/assets/1017872/740993aa-f6ae-4fb8-887d-d54ad6de3585) | ![learn wordpress org__s=theme json(iPad)](https://github.com/WordPress/Learn/assets/1017872/c4943e3f-6fd7-4e2b-aae6-a68c99e0ae18) | ![learn wordpress org__s=theme json(Samsung Galaxy S20 Ultra)](https://github.com/WordPress/Learn/assets/1017872/02d8364d-8581-4747-99f1-32cb2283ed68) |
