### PR TITLE
Add single Lesson Plan page

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2024/patterns/sidebar-meta-info.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/sidebar-meta-info.php
@@ -5,14 +5,16 @@
  * Inserter: no
  */
 
- use function WPOrg_Learn\Sensei\{get_my_courses_page_url};
+use function WPOrg_Learn\Sensei\{get_my_courses_page_url};
+$current_post = get_post();
+$current_post_type = get_post_type();
 
 ?>
 
 <!-- wp:group {"align":"full","className":"wporg-learn-sidebar-meta-info","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull wporg-learn-sidebar-meta-info">
 
-	<?php if ( 'course' === get_post_type() ) : ?>
+	<?php if ( 'course' === $current_post_type ) : ?>
 		<?php if ( Sensei_Course::is_user_enrolled( get_the_ID() ) ) : ?>
 		<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}},"typography":{"fontStyle":"normal","fontWeight":"400","lineHeight":26px}},"textColor":"blueberry-1","fontSize":"normal","fontFamily":"inter","className":""wporg-learn-sidebar-all-courses"} -->
 		<p class="has-blueberry-1-color has-text-color has-link-color has-inter-font-family has-normal-font-size wporg-learn-sidebar-all-courses" style="font-style:normal;font-weight:400;line-height:26px">
@@ -34,7 +36,33 @@
 		<!-- /wp:sensei-lms/button-take-course -->
 	<?php endif; ?>
 
-	<?php if ( 'lesson-plan' === get_post_type() ) : ?>
+	<?php if ( 'lesson-plan' === $current_post_type ) : ?>
+		<?php if ( $current_post->slides_view_url || $current_post->slides_download_url ) : ?>
+			<!-- wp:buttons {"style":{"spacing":{"blockGap":"0","margin":{"bottom":"40px"}}},"layout":{"type":"flex","justifyContent":"center"}} -->
+			<div class="wp-block-buttons" style="margin-bottom:40px">
+				<?php if ( $current_post->slides_view_url ) : ?>
+					<!-- wp:button {"textAlign":"center","width":100,"style":{"border":{"radius":"2px"},"spacing":{"padding":{"left":"13px","right":"13px","top":"16px","bottom":"16px"}},"typography":{"lineHeight":0,"fontStyle":"normal","fontWeight":"400"}},"className":"aligncenter is-style-text","fontSize":"normal","fontFamily":"inter"} -->
+					<div class="wp-block-button has-custom-width wp-block-button__width-100 has-custom-font-size aligncenter is-style-text has-inter-font-family has-normal-font-size" style="font-style:normal;font-weight:400;line-height:0">
+						<a class="wp-block-button__link has-text-align-center wp-element-button" href="<?php echo esc_attr( $current_post->slides_view_url ); ?>" style="border-radius:2px;padding-top:16px;padding-right:13px;padding-bottom:16px;padding-left:13px" target="_blank" rel="noreferrer noopener">
+							<?php esc_html_e( 'View slides', 'wporg-learn' ); ?>
+							<span aria-hidden="true" class="wp-exclude-emoji">↗</span>
+						</a>				
+					</div>
+					<!-- /wp:button -->
+				<?php endif; ?>
+				<?php if ( $current_post->slides_download_url ) : ?>
+					<!-- wp:button {"textAlign":"center","width":100,"style":{"border":{"radius":"2px"},"spacing":{"padding":{"left":"13px","right":"13px","top":"16px","bottom":"16px"}},"typography":{"lineHeight":0,"fontStyle":"normal","fontWeight":"400"}},"className":"aligncenter is-style-text","fontSize":"normal","fontFamily":"inter"} -->
+					<div class="wp-block-button has-custom-width wp-block-button__width-100 has-custom-font-size aligncenter is-style-text has-inter-font-family has-normal-font-size" style="font-style:normal;font-weight:400;line-height:0">
+						<a class="wp-block-button__link has-text-align-center wp-element-button" href="<?php echo esc_attr( $current_post->slides_download_url ); ?>" style="border-radius:2px;padding-top:16px;padding-right:13px;padding-bottom:16px;padding-left:13px" target="_blank" rel="noreferrer noopener">
+							<?php esc_html_e( 'Download slides', 'wporg-learn' ); ?>
+							<span aria-hidden="true" class="wp-exclude-emoji">↗</span>
+						</a>				
+					</div>
+					<!-- /wp:button -->
+				<?php endif; ?>
+			</div>
+			<!-- /wp:buttons -->
+		<?php endif; ?>
 		<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
 		<div class="wp-block-buttons">
 			<!-- wp:button {"textAlign":"center","width":100,"style":{"border":{"radius":"2px"},"spacing":{"padding":{"left":"13px","right":"13px","top":"16px","bottom":"16px"}},"typography":{"lineHeight":0,"fontStyle":"normal","fontWeight":"400"}},"className":"aligncenter is-style-fill","fontSize":"normal","fontFamily":"inter"} -->

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/sidebar-meta-info.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/sidebar-meta-info.php
@@ -12,25 +12,41 @@
 <!-- wp:group {"align":"full","className":"wporg-learn-sidebar-meta-info","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull wporg-learn-sidebar-meta-info">
 
-	<?php if ( Sensei_Course::is_user_enrolled( get_the_ID() ) ) : ?>
-	<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}},"typography":{"fontStyle":"normal","fontWeight":"400","lineHeight":26px}},"textColor":"blueberry-1","fontSize":"normal","fontFamily":"inter","className":""wporg-learn-sidebar-all-courses"} -->
-	<p class="has-blueberry-1-color has-text-color has-link-color has-inter-font-family has-normal-font-size wporg-learn-sidebar-all-courses" style="font-style:normal;font-weight:400;line-height:26px">
-		<a href="<?php echo esc_url( get_my_courses_page_url() ); ?>">
-			<?php esc_html_e( 'All My Courses', 'wporg-learn' ); ?>
-		</a>
-	</p>
-	<!-- /wp:paragraph -->
+	<?php if ( 'course' === get_post_type() ) : ?>
+		<?php if ( Sensei_Course::is_user_enrolled( get_the_ID() ) ) : ?>
+		<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}},"typography":{"fontStyle":"normal","fontWeight":"400","lineHeight":26px}},"textColor":"blueberry-1","fontSize":"normal","fontFamily":"inter","className":""wporg-learn-sidebar-all-courses"} -->
+		<p class="has-blueberry-1-color has-text-color has-link-color has-inter-font-family has-normal-font-size wporg-learn-sidebar-all-courses" style="font-style:normal;font-weight:400;line-height:26px">
+			<a href="<?php echo esc_url( get_my_courses_page_url() ); ?>">
+				<?php esc_html_e( 'All My Courses', 'wporg-learn' ); ?>
+			</a>
+		</p>
+		<!-- /wp:paragraph -->
+		<?php endif; ?>
+
+		<!-- wp:sensei-lms/course-progress {"barColor":"blueberry-1","barBackgroundColor":"blueberry-3","height":8,"className":"wporg-learn-sidebar-course-progress"} /-->
+
+		<!-- wp:sensei-lms/button-take-course {"align":"full","borderRadius":2,"className":"is-style-default"} -->
+		<div class="wp-block-sensei-lms-button-take-course is-style-default wp-block-sensei-button wp-block-button has-text-align-full">
+			<button class="wp-block-button__link" style="border-radius:2px">
+				<?php esc_html_e( 'Take this Course', 'wporg-learn' ); ?>
+			</button>
+		</div>
+		<!-- /wp:sensei-lms/button-take-course -->
 	<?php endif; ?>
 
-	<!-- wp:sensei-lms/course-progress {"barColor":"blueberry-1","barBackgroundColor":"blueberry-3","height":8,"className":"wporg-learn-sidebar-course-progress"} /-->
-
-	<!-- wp:sensei-lms/button-take-course {"align":"full","borderRadius":2,"className":"is-style-default"} -->
-	<div class="wp-block-sensei-lms-button-take-course is-style-default wp-block-sensei-button wp-block-button has-text-align-full">
-		<button class="wp-block-button__link" style="border-radius:2px">
-			<?php esc_html_e( 'Take this Course', 'wporg-learn' ); ?>
-		</button>
-	</div>
-	<!-- /wp:sensei-lms/button-take-course -->
+	<?php if ( 'lesson-plan' === get_post_type() ) : ?>
+		<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
+		<div class="wp-block-buttons">
+			<!-- wp:button {"textAlign":"center","width":100,"style":{"border":{"radius":"2px"},"spacing":{"padding":{"left":"13px","right":"13px","top":"16px","bottom":"16px"}},"typography":{"lineHeight":0,"fontStyle":"normal","fontWeight":"400"}},"className":"aligncenter is-style-fill","fontSize":"normal","fontFamily":"inter"} -->
+			<div class="wp-block-button has-custom-width wp-block-button__width-100 has-custom-font-size aligncenter is-style-fill has-inter-font-family has-normal-font-size" style="font-style:normal;font-weight:400;line-height:0">
+				<a class="wp-block-button__link has-text-align-center wp-element-button" onclick="window.print()" style="border-radius:2px;padding-top:16px;padding-right:13px;padding-bottom:16px;padding-left:13px" target="_blank" rel="noreferrer noopener">
+					<?php esc_html_e( 'Print Lesson Plan', 'wporg-learn' ); ?>
+				</a>				
+			</div>
+			<!-- /wp:button -->
+		</div>
+		<!-- /wp:buttons -->
+	<?php endif; ?>
 
 	<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
 	<div class="wp-block-buttons">

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/sidebar-meta-info.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/sidebar-meta-info.php
@@ -5,7 +5,7 @@
  * Inserter: no
  */
 
- use function WPOrg_Learn\Sensei\{get_my_courses_page_url}
+ use function WPOrg_Learn\Sensei\{get_my_courses_page_url};
 
 ?>
 
@@ -32,10 +32,10 @@
 	</div>
 	<!-- /wp:sensei-lms/button-take-course -->
 
-	<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"},"className":""wporg-learn-sidebar-playground"} -->
+	<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
 	<div class="wp-block-buttons">
 		<!-- wp:button {"textAlign":"center","width":100,"style":{"border":{"radius":"2px"},"spacing":{"padding":{"left":"13px","right":"13px","top":"16px","bottom":"16px"}},"typography":{"lineHeight":0,"fontStyle":"normal","fontWeight":"400"}},"className":"aligncenter is-style-outline","fontSize":"normal","fontFamily":"inter"} -->
-		<div class="wp-block-button has-custom-width wp-block-button__width-100 has-custom-font-size aligncenter is-style-outline has-inter-font-family has-normal-font-size wporg-learn-sidebar-playground" style="font-style:normal;font-weight:400;line-height:0">
+		<div class="wp-block-button has-custom-width wp-block-button__width-100 has-custom-font-size aligncenter is-style-outline has-inter-font-family has-normal-font-size" style="font-style:normal;font-weight:400;line-height:0">
 			<a class="wp-block-button__link has-text-align-center wp-element-button" href="https://wordpress.org/playground/demo/?step=playground&amp;theme=twentytwentythree" style="border-radius:2px;padding-top:16px;padding-right:13px;padding-bottom:16px;padding-left:13px" target="_blank" rel="noreferrer noopener">
 				<?php esc_html_e( 'Practice on a private demo site', 'wporg-learn' ); ?>
 			</a>

--- a/wp-content/themes/pub/wporg-learn-2024/src/sensei-meta-list/index.php
+++ b/wp-content/themes/pub/wporg-learn-2024/src/sensei-meta-list/index.php
@@ -90,6 +90,42 @@ function render( $attributes, $content, $block ) {
 				'key'   => 'last-updated',
 			),
 		);
+	} else if ( 'lesson-plan' === $block->context['postType'] ) {
+		$lesson_plan_id = $block->context['postId'];
+
+		$duration = get_post_taxonomy_terms_links( $lesson_plan_id, 'duration' );
+		$audience = get_post_taxonomy_terms_links( $lesson_plan_id, 'audience' );
+		$level = get_post_taxonomy_terms_links( $lesson_plan_id, 'level' );
+		$instruction_type = get_post_taxonomy_terms_links( $lesson_plan_id, 'instruction_type' );
+		$last_updated = get_last_updated_time( $lesson_plan_id );
+
+		$meta_fields = array(
+			array(
+				'label' => __( 'Duration', 'wporg-learn' ),
+				'value' => $duration,
+				'key'   => 'duration',
+			),
+			array(
+				'label' => __( 'Audience', 'wporg-learn' ),
+				'value' => $audience,
+				'key'   => 'audience',
+			),
+			array(
+				'label' => __( 'Level', 'wporg-learn' ),
+				'value' => $level,
+				'key'   => 'level',
+			),
+			array(
+				'label' => __( 'Type', 'wporg-learn' ),
+				'value' => $instruction_type,
+				'key'   => 'type',
+			),
+			array(
+				'label' => __( 'Last updated', 'wporg-learn' ),
+				'value' => $last_updated,
+				'key'   => 'last-updated',
+			),
+		);
 	}
 
 	foreach ( $meta_fields as $field ) {
@@ -113,24 +149,48 @@ function render( $attributes, $content, $block ) {
 }
 
 /**
- * Get the last updated time for a course.
+ * Get the last updated time for a post.
  *
- * @param int $course_id The ID of the course.
+ * @param int $post_id The ID of a post.
  *
  * @return string The last updated time.
  */
-function get_last_updated_time( $course_id ) {
-	$last_updated_time = get_post_modified_time( 'U', false, $course_id );
+function get_last_updated_time( $post_id ) {
+	$last_updated_time = get_post_modified_time( 'U', false, $post_id );
 	$current_time = current_time( 'timestamp' );
 
 	$time_diff = human_time_diff( $last_updated_time, $current_time );
 
 	// If the time difference is greater than 30 days, display the specific date
 	if ( $current_time - $last_updated_time > 30 * DAY_IN_SECONDS ) {
-		$last_updated = get_post_modified_time( 'M jS, Y', false, $course_id );
+		$last_updated = get_post_modified_time( 'M jS, Y', false, $post_id );
 	} else {
 		$last_updated = sprintf( '%s ago', $time_diff );
 	}
 
 	return $last_updated;
+}
+
+/**
+ * Returns the taxonomy terms associated with a given post as HTML links.
+ *
+ * @param int $post_id Id of the post.
+ *
+ * @return array
+ */
+function get_post_taxonomy_terms_links( $post_id, $tax ) {
+	$terms = get_the_terms( $post_id, $tax );
+
+	$output = '';
+
+	if ( ! is_wp_error( $terms ) && ! empty( $terms ) ) {
+		foreach ( $terms as $term ) {
+			$term_name = $term->name;
+			$term_link = get_term_link( $term );
+
+			$output .= ( $output ? ', ' : '' ) . '<a href="' . $term_link . '">' . esc_html( $term_name ) . '</a>';
+		}
+	}
+
+	return $output;
 }

--- a/wp-content/themes/pub/wporg-learn-2024/src/sensei-meta-list/index.php
+++ b/wp-content/themes/pub/wporg-learn-2024/src/sensei-meta-list/index.php
@@ -97,6 +97,7 @@ function render( $attributes, $content, $block ) {
 		$audience = get_post_taxonomy_terms_links( $lesson_plan_id, 'audience' );
 		$level = get_post_taxonomy_terms_links( $lesson_plan_id, 'level' );
 		$instruction_type = get_post_taxonomy_terms_links( $lesson_plan_id, 'instruction_type' );
+		$wporg_wp_version = get_post_taxonomy_terms_links( $lesson_plan_id, 'wporg_wp_version' );
 		$last_updated = get_last_updated_time( $lesson_plan_id );
 
 		$meta_fields = array(
@@ -118,6 +119,11 @@ function render( $attributes, $content, $block ) {
 			array(
 				'label' => __( 'Type', 'wporg-learn' ),
 				'value' => $instruction_type,
+				'key'   => 'type',
+			),
+			array(
+				'label' => __( 'WordPress Version', 'wporg-learn' ),
+				'value' => $wporg_wp_version,
 				'key'   => 'type',
 			),
 			array(

--- a/wp-content/themes/pub/wporg-learn-2024/src/sensei-meta-list/style.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/sensei-meta-list/style.scss
@@ -2,6 +2,10 @@
 	margin-block-start: 40px;
 	margin-block-end: 40px;
 
+	a {
+		text-decoration: none;
+	}
+
 	table {
 		margin: 0;
 		padding: 0;

--- a/wp-content/themes/pub/wporg-learn-2024/src/sensei-meta-list/style.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/sensei-meta-list/style.scss
@@ -35,7 +35,6 @@
 
 		td {
 			text-align: end;
-			white-space: nowrap;
 		}
 
 		@media (max-width: 380px) {

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sidebar.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sidebar.scss
@@ -7,7 +7,7 @@
 		}
 	}
 
-	.wporg-learn-sidebar-playground  a {
+	.wp-block-buttons  a {
 		line-height: 1;
 	}
 

--- a/wp-content/themes/pub/wporg-learn-2024/templates/single-lesson-plan.html
+++ b/wp-content/themes/pub/wporg-learn-2024/templates/single-lesson-plan.html
@@ -1,0 +1,45 @@
+<!-- wp:template-part {"slug":"header","className":"has-display-contents","tagName":"div"} /-->
+
+<!-- wp:group {"className":"wporg-breadcrumbs","align":"full","style":{"spacing":{"padding":{"top":"23px","bottom":"23px","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"backgroundColor":"white","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
+<div class="wporg-breadcrumbs wp-block-group alignfull has-white-background-color has-background" style="padding-top:23px;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:23px;padding-left:var(--wp--preset--spacing--edge-space)">
+	<!-- wp:wporg/site-breadcrumbs {"fontSize":"small"} /-->
+</div>
+<!-- /wp:group -->
+
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"},"className":"entry-content","style":{"spacing":{"blockGap":"0px"}}} -->
+<main class="wp-block-group entry-content">
+
+	<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space","top":"var:preset|spacing|30","bottom":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--edge-space)">
+
+		<!-- wp:post-title {"level":1,"style":{"spacing":{"margin":{"bottom":"40px"}}}} /-->
+	
+		<!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"left":"var:preset|spacing|40"}}}} -->
+		<div class="wp-block-columns alignwide">
+		
+			<!-- wp:column {"width":"75%","layout":{"type":"constrained","justifyContent":"left"}} -->
+			<div class="wp-block-column" style="flex-basis:75%">
+
+				<!-- wp:post-content {"layout":{"inherit":true}} /-->
+
+			</div>
+			<!-- /wp:column -->
+
+			<!-- wp:column {"width":"25%"} -->
+			<div class="wp-block-column" style="flex-basis:25%">
+				
+				<!-- wp:pattern {"slug":"wporg-learn-2024/sidebar-meta-info"} /-->
+				
+			</div>
+			<!-- /wp:column -->
+
+			</div>
+		<!-- /wp:columns -->
+
+	</div>
+	<!-- /wp:group -->
+
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer"} /-->


### PR DESCRIPTION
Closes #2448

Add a single lesson page template.
The design of "View Slides" is pending [discussion](https://github.com/WordPress/Learn/issues/2448#issuecomment-2185013762).

## Screenshots

<img width="1728" alt="Screenshot 2024-06-24 at 01 12 18" src="https://github.com/WordPress/Learn/assets/18050944/c1cc1228-573a-4243-b30d-74d78820f430">
<img width="1725" alt="image" src="https://github.com/WordPress/Learn/assets/18050944/9cf7dd7e-7353-4a90-850e-a8280fc5abca">



