### PR TITLE
Add My courses template

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2024/inc/block-config.php
+++ b/wp-content/themes/pub/wporg-learn-2024/inc/block-config.php
@@ -423,18 +423,9 @@ function get_student_course_options( $options ) {
 	$key = get_student_course_filter_query_var_name();
 
 	$options = array(
-		'all' => (object) array(
-			'slug' => 'all',
-			'name' => __( 'All', 'wporg-learn' ),
-		),
-		'active' => (object) array(
-			'slug' => 'active',
-			'name' => __( 'Active', 'wporg-learn' ),
-		),
-		'completed' => (object) array(
-			'slug' => 'completed',
-			'name' => __( 'Completed', 'wporg-learn' ),
-		),
+		'all' => __( 'All', 'wporg-learn' ),
+		'active' => __( 'Active', 'wporg-learn' ),
+		'completed' => __( 'Completed', 'wporg-learn' ),
 	);
 
 	$selected_slug = $wp_query->get( $key );
@@ -442,13 +433,13 @@ function get_student_course_options( $options ) {
 		// Find the selected option from $options by slug and then get the name.
 		$selected_option = array_filter(
 			$options,
-			function ( $option ) use ( $selected_slug ) {
-				return $option->slug === $selected_slug;
-			}
+			function ( $option, $slug ) use ( $selected_slug ) {
+				return $slug === $selected_slug;
+			},
+			ARRAY_FILTER_USE_BOTH
 		);
 		if ( ! empty( $selected_option ) ) {
-			$selected_option = array_shift( $selected_option );
-			$label = $selected_option->name;
+			$label = array_shift( $selected_option );
 		}
 	} else {
 		$selected_slug = 'all';
@@ -460,7 +451,7 @@ function get_student_course_options( $options ) {
 		'title' => __( 'Completion status', 'wporg-learn' ),
 		'key' => $key,
 		'action' => get_current_url(),
-		'options' => array_combine( wp_list_pluck( $options, 'slug' ), wp_list_pluck( $options, 'name' ) ),
+		'options' => $options,
 		'selected' => array( $selected_slug ),
 	);
 }

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/my-courses-content.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/my-courses-content.php
@@ -30,65 +30,49 @@
 <!-- /wp:group -->
 
 <!-- wp:query {"queryId":0,"query":{"postType":"course","perPage":12,"offset":0,"inherit":false,"sticky":"","pages":0,"order":"desc","orderBy":"date","author":"","search":"","exclude":[]},"className":"wp-block-sensei-lms-course-list wp-block-sensei-lms-course-list\u002d\u002dis-list-view wporg-learn-course-grid"} -->
-<div class="wp-block-query wp-block-sensei-lms-course-list wp-block-sensei-lms-course-list--is-list-view wporg-learn-course-grid">
+<div class="wp-block-query wp-block-sensei-lms-course-list wp-block-sensei-lms-course-list--is-list-view wporg-learn-course-grid"><!-- wp:post-template {"style":{"spacing":{"blockGap":"var:preset|spacing|50"}},"layout":{"type":"grid","columnCount":null,"minimumColumnWidth":"330px"}} -->
+<!-- wp:group {"style":{"border":{"width":"1px","color":"var:preset|color|light-grey-1","radius":"2px"},"spacing":{"blockGap":"0"},"dimensions":{"minHeight":"100%"}},"backgroundColor":"white","layout":{"type":"flex","orientation":"vertical"}} -->
+<div class="wp-block-group has-border-color has-white-background-color has-background" style="border-color:var(--wp--preset--color--light-grey-1);border-width:1px;border-radius:2px;min-height:100%"><!-- wp:post-featured-image {"isLink":true,"height":"","align":"center"} /-->
 
-	<!-- wp:post-template {"style":{"spacing":{"blockGap":"var:preset|spacing|50"}},"layout":{"type":"grid","columnCount":null,"minimumColumnWidth":"330px"}} -->
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"20px","right":"20px"},"blockGap":"var:preset|spacing|10"},"layout":{"selfStretch":"fill","flexSize":null}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
+<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--20);padding-right:20px;padding-bottom:var(--wp--preset--spacing--20);padding-left:20px"><!-- wp:post-title {"level":3,"isLink":true,"style":{"typography":{"fontStyle":"normal","fontWeight":"600","lineHeight":1.6},"spacing":{"margin":{"bottom":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}}},"fontSize":"normal","fontFamily":"inter"} /-->
 
-		<!-- wp:group {"style":{"border":{"width":"1px","color":"var:preset|color|light-grey-1","radius":"2px"},"spacing":{"blockGap":"0"},"dimensions":{"minHeight":"100%"}},"backgroundColor":"white","layout":{"type":"flex","orientation":"vertical"}} -->
-		<div class="wp-block-group has-border-color has-white-background-color has-background" style="border-color:var(--wp--preset--color--light-grey-1);border-width:1px;border-radius:2px;min-height:100%">
+<!-- wp:post-excerpt {"showMoreOnNewLine":false,"excerptLength":16,"style":{"typography":{"lineHeight":1.6},"layout":{"selfStretch":"fill","flexSize":null}}} /-->
 
-			<!-- wp:post-featured-image {"isLink":true,"height":"","align":"center"} /-->
+<!-- wp:sensei-lms/course-progress {"barColor":"blueberry-1","defaultBarColor":"blueberry-1","barBackgroundColor":"blueberry-3","height":8,"className":"wporg-learn-sidebar-course-progress"} /-->
 
-			<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"20px","right":"20px"}}},"layout":{"type":"constrained"}} -->
-			<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--20);padding-right:20px;padding-bottom:var(--wp--preset--spacing--20);padding-left:20px">
+<!-- wp:spacer {"height":"0px","style":{"layout":{"selfStretch":"fixed","flexSize":"0px"}}} -->
+<div style="height:0px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
 
-				<!-- wp:post-title {"level":3,"isLink":true,"style":{"typography":{"fontStyle":"normal","fontWeight":"600","lineHeight":1.6},"spacing":{"margin":{"bottom":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}}},"fontSize":"normal","fontFamily":"inter"} /-->
+<!-- wp:sensei-lms/course-actions -->
+<!-- wp:sensei-lms/button-take-course {"align":"left"} -->
+<div class="wp-block-sensei-lms-button-take-course is-style-default wp-block-sensei-button wp-block-button has-text-align-left"><button class="wp-block-button__link">Start Course</button></div>
+<!-- /wp:sensei-lms/button-take-course -->
 
-				<!-- wp:post-excerpt {"showMoreOnNewLine":false,"excerptLength":16,"style":{"spacing":{"margin":{"top":"var:preset|spacing|10"}},"typography":{"lineHeight":1.6}}} /-->
+<!-- wp:sensei-lms/button-continue-course {"align":"left"} -->
+<div class="wp-block-sensei-lms-button-continue-course is-style-default wp-block-sensei-button wp-block-button has-text-align-left"><a class="wp-block-button__link">Continue</a></div>
+<!-- /wp:sensei-lms/button-continue-course -->
 
-				<!-- wp:sensei-lms/course-progress {"barColor":"blueberry-1","barBackgroundColor":"blueberry-3","height":8,"className":"wporg-learn-sidebar-course-progress"} /-->
+<!-- wp:sensei-lms/button-view-results {"align":"left","className":"is-style-default"} -->
+<div class="wp-block-sensei-lms-button-view-results is-style-default wp-block-sensei-button wp-block-button has-text-align-left"><a class="wp-block-button__link">Visit Results</a></div>
+<!-- /wp:sensei-lms/button-view-results -->
+<!-- /wp:sensei-lms/course-actions --></div>
+<!-- /wp:group --></div>
+<!-- /wp:group -->
+<!-- /wp:post-template -->
 
-				<!-- wp:sensei-lms/course-actions -->
+<!-- wp:query-no-results -->
+<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
+<p>No courses found.</p>
+<!-- /wp:paragraph -->
+<!-- /wp:query-no-results -->
 
-					<!-- wp:sensei-lms/button-take-course {"align":"right"} -->
-					<div class="wp-block-sensei-lms-button-take-course is-style-default wp-block-sensei-button wp-block-button has-text-align-right"><button class="wp-block-button__link"><?php esc_html_e( 'Start Course', 'wporg-learn' ); ?></button></div>
-					<!-- /wp:sensei-lms/button-take-course -->
+<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"}} -->
+<!-- wp:query-pagination-previous {"label":"Previous"} /-->
 
-					<!-- wp:sensei-lms/button-continue-course {"align":"right"} -->
-					<div class="wp-block-sensei-lms-button-continue-course is-style-default wp-block-sensei-button wp-block-button has-text-align-right"><a class="wp-block-button__link"><?php esc_html_e( 'Continue', 'wporg-learn' ); ?></a></div>
-					<!-- /wp:sensei-lms/button-continue-course -->
+<!-- wp:query-pagination-numbers /-->
 
-					<!-- wp:sensei-lms/button-view-results {"align":"right","className":"is-style-default"} -->
-					<div class="wp-block-sensei-lms-button-view-results is-style-default wp-block-sensei-button wp-block-button has-text-align-right"><a class="wp-block-button__link"><?php esc_html_e( 'Visit Results', 'wporg-learn' ); ?></a></div>
-					<!-- /wp:sensei-lms/button-view-results -->
-
-				<!-- /wp:sensei-lms/course-actions -->
-
-			</div>
-			<!-- /wp:group -->
-
-		</div>
-		<!-- /wp:group -->
-
-	<!-- /wp:post-template -->
-
-	<!-- wp:query-no-results -->
-
-		<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
-		<p><?php esc_html_e( 'No Courses found.', 'wporg-learn' ); ?></p>
-		<!-- /wp:paragraph -->
-
-	<!-- /wp:query-no-results -->
-
-	<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"}} -->
-
-		<!-- wp:query-pagination-previous {"label":"Previous"} /-->
-
-		<!-- wp:query-pagination-numbers /-->
-
-		<!-- wp:query-pagination-next {"label":"Next"} /-->
-
-	<!-- /wp:query-pagination -->
-
-</div>
+<!-- wp:query-pagination-next {"label":"Next"} /-->
+<!-- /wp:query-pagination --></div>
 <!-- /wp:query -->

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/my-courses-content.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/my-courses-content.php
@@ -30,49 +30,69 @@
 <!-- /wp:group -->
 
 <!-- wp:query {"queryId":0,"query":{"postType":"course","perPage":12,"offset":0,"inherit":false,"sticky":"","pages":0,"order":"desc","orderBy":"date","author":"","search":"","exclude":[]},"className":"wp-block-sensei-lms-course-list wp-block-sensei-lms-course-list\u002d\u002dis-list-view wporg-learn-course-grid"} -->
-<div class="wp-block-query wp-block-sensei-lms-course-list wp-block-sensei-lms-course-list--is-list-view wporg-learn-course-grid"><!-- wp:post-template {"style":{"spacing":{"blockGap":"var:preset|spacing|50"}},"layout":{"type":"grid","columnCount":null,"minimumColumnWidth":"330px"}} -->
-<!-- wp:group {"style":{"border":{"width":"1px","color":"var:preset|color|light-grey-1","radius":"2px"},"spacing":{"blockGap":"0"},"dimensions":{"minHeight":"100%"}},"backgroundColor":"white","layout":{"type":"flex","orientation":"vertical"}} -->
-<div class="wp-block-group has-border-color has-white-background-color has-background" style="border-color:var(--wp--preset--color--light-grey-1);border-width:1px;border-radius:2px;min-height:100%"><!-- wp:post-featured-image {"isLink":true,"height":"","align":"center"} /-->
+<div class="wp-block-query wp-block-sensei-lms-course-list wp-block-sensei-lms-course-list--is-list-view wporg-learn-course-grid">
+	
+	<!-- wp:post-template {"style":{"spacing":{"blockGap":"var:preset|spacing|50"}},"layout":{"type":"grid","columnCount":null,"minimumColumnWidth":"330px"}} -->
 
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"20px","right":"20px"},"blockGap":"var:preset|spacing|10"},"layout":{"selfStretch":"fill","flexSize":null}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
-<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--20);padding-right:20px;padding-bottom:var(--wp--preset--spacing--20);padding-left:20px"><!-- wp:post-title {"level":3,"isLink":true,"style":{"typography":{"fontStyle":"normal","fontWeight":"600","lineHeight":1.6},"spacing":{"margin":{"bottom":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}}},"fontSize":"normal","fontFamily":"inter"} /-->
+		<!-- wp:group {"style":{"border":{"width":"1px","color":"var:preset|color|light-grey-1","radius":"2px"},"spacing":{"blockGap":"0"},"dimensions":{"minHeight":"100%"}},"backgroundColor":"white","layout":{"type":"flex","orientation":"vertical"}} -->
+		<div class="wp-block-group has-border-color has-white-background-color has-background" style="border-color:var(--wp--preset--color--light-grey-1);border-width:1px;border-radius:2px;min-height:100%">
 
-<!-- wp:post-excerpt {"showMoreOnNewLine":false,"excerptLength":16,"style":{"typography":{"lineHeight":1.6},"layout":{"selfStretch":"fill","flexSize":null}}} /-->
+			<!-- wp:post-featured-image {"isLink":true,"height":"","align":"center"} /-->
 
-<!-- wp:sensei-lms/course-progress {"barColor":"blueberry-1","defaultBarColor":"blueberry-1","barBackgroundColor":"blueberry-3","height":8,"className":"wporg-learn-sidebar-course-progress"} /-->
+			<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"20px","right":"20px"},"blockGap":"var:preset|spacing|10"},"layout":{"selfStretch":"fill","flexSize":null}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
+			<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--20);padding-right:20px;padding-bottom:var(--wp--preset--spacing--20);padding-left:20px">
 
-<!-- wp:spacer {"height":"0px","style":{"layout":{"selfStretch":"fixed","flexSize":"0px"}}} -->
-<div style="height:0px" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
+				<!-- wp:post-title {"level":3,"isLink":true,"style":{"typography":{"fontStyle":"normal","fontWeight":"600","lineHeight":1.6},"spacing":{"margin":{"bottom":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}}},"fontSize":"normal","fontFamily":"inter"} /-->
 
-<!-- wp:sensei-lms/course-actions -->
-<!-- wp:sensei-lms/button-take-course {"align":"left"} -->
-<div class="wp-block-sensei-lms-button-take-course is-style-default wp-block-sensei-button wp-block-button has-text-align-left"><button class="wp-block-button__link">Start Course</button></div>
-<!-- /wp:sensei-lms/button-take-course -->
+				<!-- wp:post-excerpt {"showMoreOnNewLine":false,"excerptLength":16,"style":{"typography":{"lineHeight":1.6},"layout":{"selfStretch":"fill","flexSize":null}}} /-->
 
-<!-- wp:sensei-lms/button-continue-course {"align":"left"} -->
-<div class="wp-block-sensei-lms-button-continue-course is-style-default wp-block-sensei-button wp-block-button has-text-align-left"><a class="wp-block-button__link">Continue</a></div>
-<!-- /wp:sensei-lms/button-continue-course -->
+				<!-- wp:sensei-lms/course-progress {"barColor":"blueberry-1","defaultBarColor":"blueberry-1","barBackgroundColor":"blueberry-3","height":8,"className":"wporg-learn-sidebar-course-progress"} /-->
 
-<!-- wp:sensei-lms/button-view-results {"align":"left","className":"is-style-default"} -->
-<div class="wp-block-sensei-lms-button-view-results is-style-default wp-block-sensei-button wp-block-button has-text-align-left"><a class="wp-block-button__link">Visit Results</a></div>
-<!-- /wp:sensei-lms/button-view-results -->
-<!-- /wp:sensei-lms/course-actions --></div>
-<!-- /wp:group --></div>
-<!-- /wp:group -->
-<!-- /wp:post-template -->
+				<!-- wp:spacer {"height":"0px","style":{"layout":{"selfStretch":"fixed","flexSize":"0px"}}} -->
+				<div style="height:0px" aria-hidden="true" class="wp-block-spacer"></div>
+				<!-- /wp:spacer -->
 
-<!-- wp:query-no-results -->
-<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
-<p>No courses found.</p>
-<!-- /wp:paragraph -->
-<!-- /wp:query-no-results -->
+				<!-- wp:sensei-lms/course-actions -->
 
-<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"}} -->
-<!-- wp:query-pagination-previous {"label":"Previous"} /-->
+					<!-- wp:sensei-lms/button-take-course {"align":"left"} -->
+					<div class="wp-block-sensei-lms-button-take-course is-style-default wp-block-sensei-button wp-block-button has-text-align-left"><button class="wp-block-button__link"><?php esc_html_e( 'Start Course', 'wporg-learn' ); ?></button></div>
+					<!-- /wp:sensei-lms/button-take-course -->
 
-<!-- wp:query-pagination-numbers /-->
+					<!-- wp:sensei-lms/button-continue-course {"align":"left"} -->
+					<div class="wp-block-sensei-lms-button-continue-course is-style-default wp-block-sensei-button wp-block-button has-text-align-left"><a class="wp-block-button__link"><?php esc_html_e( 'Continue', 'wporg-learn' ); ?></a></div>
+					<!-- /wp:sensei-lms/button-continue-course -->
 
-<!-- wp:query-pagination-next {"label":"Next"} /-->
-<!-- /wp:query-pagination --></div>
+					<!-- wp:sensei-lms/button-view-results {"align":"left","className":"is-style-default"} -->
+					<div class="wp-block-sensei-lms-button-view-results is-style-default wp-block-sensei-button wp-block-button has-text-align-left"><a class="wp-block-button__link"><?php esc_html_e( 'Visit Results', 'wporg-learn' ); ?></a></div>
+					<!-- /wp:sensei-lms/button-view-results -->
+					
+				<!-- /wp:sensei-lms/course-actions -->
+
+			</div>
+			<!-- /wp:group -->
+
+		</div>
+		<!-- /wp:group -->
+
+	<!-- /wp:post-template -->
+
+	<!-- wp:query-no-results -->
+
+		<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
+		<p><?php esc_html_e( 'No courses found.', 'wporg-learn' ); ?></p>
+		<!-- /wp:paragraph -->
+
+	<!-- /wp:query-no-results -->
+
+	<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"}} -->
+
+		<!-- wp:query-pagination-previous {"label":"<?php esc_html_e( 'Previous', 'wporg-learn' ); ?>"} /-->
+
+		<!-- wp:query-pagination-numbers /-->
+
+		<!-- wp:query-pagination-next {"label":"<?php esc_html_e( 'Next', 'wporg-learn' ); ?>"} /-->
+		
+	<!-- /wp:query-pagination -->
+
+</div>
 <!-- /wp:query -->

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/my-courses-content.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/my-courses-content.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Title: Courses Archive Content
+ * Slug: wporg-learn-2024/my-courses-content
+ * Inserter: no
+ */
+
+?>
+
+<!-- wp:group {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|20"}}},"layout":{"type":"constrained","justifyContent":"left","contentSize":"730px"}} -->
+<div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--20)">
+
+	<!-- wp:heading {"level":1} -->
+	<h1 class="wp-block-heading"><?php esc_html_e( 'My courses', 'wporg-learn' ); ?></h1>
+	<!-- /wp:heading -->
+
+</div>
+<!-- /wp:group -->
+
+<!-- wp:group {"align":"wide","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"right"},"style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|40"}}}} -->
+<div class="wp-block-group alignwide" style="margin-top:0;margin-bottom:var(--wp--preset--spacing--40)">
+
+	<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"flex","flexWrap":"nowrap"},"className":"wporg-query-filters"} -->
+	<div class="wp-block-group wporg-query-filters">
+		<!-- wp:wporg/query-filter {"key":"student-course","multiple":false} /-->
+	</div>
+	<!-- /wp:group -->
+
+</div>
+<!-- /wp:group -->
+
+<!-- wp:query {"queryId":0,"query":{"postType":"course","perPage":12,"offset":0,"inherit":false,"sticky":"","pages":0,"order":"desc","orderBy":"date","author":"","search":"","exclude":[]},"className":"wp-block-sensei-lms-course-list wp-block-sensei-lms-course-list\u002d\u002dis-list-view wporg-learn-course-grid"} -->
+<div class="wp-block-query wp-block-sensei-lms-course-list wp-block-sensei-lms-course-list--is-list-view wporg-learn-course-grid">
+
+	<!-- wp:post-template {"style":{"spacing":{"blockGap":"var:preset|spacing|50"}},"layout":{"type":"grid","columnCount":null,"minimumColumnWidth":"330px"}} -->
+
+		<!-- wp:group {"style":{"border":{"width":"1px","color":"var:preset|color|light-grey-1","radius":"2px"},"spacing":{"blockGap":"0"},"dimensions":{"minHeight":"100%"}},"backgroundColor":"white","layout":{"type":"flex","orientation":"vertical"}} -->
+		<div class="wp-block-group has-border-color has-white-background-color has-background" style="border-color:var(--wp--preset--color--light-grey-1);border-width:1px;border-radius:2px;min-height:100%">
+
+			<!-- wp:post-featured-image {"isLink":true,"height":"","align":"center"} /-->
+
+			<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"20px","right":"20px"}}},"layout":{"type":"constrained"}} -->
+			<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--20);padding-right:20px;padding-bottom:var(--wp--preset--spacing--20);padding-left:20px">
+
+				<!-- wp:post-title {"level":3,"isLink":true,"style":{"typography":{"fontStyle":"normal","fontWeight":"600","lineHeight":1.6},"spacing":{"margin":{"bottom":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}}},"fontSize":"normal","fontFamily":"inter"} /-->
+
+				<!-- wp:post-excerpt {"showMoreOnNewLine":false,"excerptLength":16,"style":{"spacing":{"margin":{"top":"var:preset|spacing|10"}},"typography":{"lineHeight":1.6}}} /-->
+
+				<!-- wp:sensei-lms/course-progress {"barColor":"blueberry-1","barBackgroundColor":"blueberry-3","height":8,"className":"wporg-learn-sidebar-course-progress"} /-->
+
+				<!-- wp:sensei-lms/course-actions -->
+
+					<!-- wp:sensei-lms/button-take-course {"align":"right"} -->
+					<div class="wp-block-sensei-lms-button-take-course is-style-default wp-block-sensei-button wp-block-button has-text-align-right"><button class="wp-block-button__link"><?php esc_html_e( 'Start Course', 'wporg-learn' ); ?></button></div>
+					<!-- /wp:sensei-lms/button-take-course -->
+
+					<!-- wp:sensei-lms/button-continue-course {"align":"right"} -->
+					<div class="wp-block-sensei-lms-button-continue-course is-style-default wp-block-sensei-button wp-block-button has-text-align-right"><a class="wp-block-button__link"><?php esc_html_e( 'Continue', 'wporg-learn' ); ?></a></div>
+					<!-- /wp:sensei-lms/button-continue-course -->
+
+					<!-- wp:sensei-lms/button-view-results {"align":"right","className":"is-style-default"} -->
+					<div class="wp-block-sensei-lms-button-view-results is-style-default wp-block-sensei-button wp-block-button has-text-align-right"><a class="wp-block-button__link"><?php esc_html_e( 'Visit Results', 'wporg-learn' ); ?></a></div>
+					<!-- /wp:sensei-lms/button-view-results -->
+
+				<!-- /wp:sensei-lms/course-actions -->
+
+			</div>
+			<!-- /wp:group -->
+
+		</div>
+		<!-- /wp:group -->
+
+	<!-- /wp:post-template -->
+
+	<!-- wp:query-no-results -->
+
+		<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
+		<p><?php esc_html_e( 'No Courses found.', 'wporg-learn' ); ?></p>
+		<!-- /wp:paragraph -->
+
+	<!-- /wp:query-no-results -->
+
+	<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"}} -->
+
+		<!-- wp:query-pagination-previous {"label":"Previous"} /-->
+
+		<!-- wp:query-pagination-numbers /-->
+
+		<!-- wp:query-pagination-next {"label":"Next"} /-->
+
+	<!-- /wp:query-pagination -->
+
+</div>
+<!-- /wp:query -->

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/my-courses-content.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/my-courses-content.php
@@ -11,7 +11,7 @@
 <div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--20)">
 
 	<!-- wp:heading {"level":1} -->
-	<h1 class="wp-block-heading"><?php esc_html_e( 'My courses', 'wporg-learn' ); ?></h1>
+	<h1 class="wp-block-heading"><?php esc_html_e( 'My Courses', 'wporg-learn' ); ?></h1>
 	<!-- /wp:heading -->
 
 </div>

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_course-grid.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_course-grid.scss
@@ -17,6 +17,8 @@
 
 	.course {
 		position: relative;
+		margin-bottom: unset;
+		padding-bottom: unset;
 
 		&::before,
 		&::after {

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_course-grid.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_course-grid.scss
@@ -9,6 +9,10 @@
 		.sensei-lms-course-list-featured-label__text {
 			display: none;
 		}
+
+		.sensei-cta .wp-block-button__link {
+			float: unset;
+		}
 	}
 
 	.course {

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_course-grid.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_course-grid.scss
@@ -1,6 +1,14 @@
 .wporg-learn-course-grid {
 	&.wp-block-query > .is-layout-grid {
 		row-gap: var(--wp--preset--spacing--50);
+
+		.wp-block-post-featured-image {
+			margin-bottom: unset;
+		}
+
+		.sensei-lms-course-list-featured-label__text {
+			display: none;
+		}
 	}
 
 	.course {
@@ -30,10 +38,6 @@
 			width: calc(100% - 48px);
 			left: 24px;
 		}
-	}
-
-	.sensei-lms-course-list-featured-label__text {
-		display: none;
 	}
 
 	.wp-block-post-title a {

--- a/wp-content/themes/pub/wporg-learn-2024/templates/page-my-courses.html
+++ b/wp-content/themes/pub/wporg-learn-2024/templates/page-my-courses.html
@@ -1,0 +1,17 @@
+<!-- wp:template-part {"slug":"header","className":"has-display-contents","tagName":"div"} /-->
+
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"},"className":"entry-content","style":{"spacing":{"blockGap":"0px"}}} -->
+<main class="wp-block-group entry-content">
+
+	<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space","top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--edge-space)">
+
+		<!-- wp:pattern {"slug":"wporg-learn-2024/my-courses-content"} /-->
+
+	</div>
+	<!-- /wp:group -->
+
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer"} /-->


### PR DESCRIPTION
Adds a template with card grid and query filter for course completion status. For the query filter rather than using the Sensei Course Filter block, I've used the same param it uses and created one of our wporg query filters, so that it has the same appearance and behaviour as the other filters on the site.

Closes #1060

### Screenshots

![learn wordpress org_my-courses__course-list-student-course-filter-0=all(Desktop) (2)](https://github.com/WordPress/Learn/assets/1017872/1cb1a6f7-0228-4e88-905a-298e5ecd3bee)

| All | Active | Completed |
|-|-|-|
| ![learn wordpress org_my-courses__course-list-student-course-filter-0=all(Desktop) (1)](https://github.com/WordPress/Learn/assets/1017872/72bf06a6-fbd1-4208-a2e0-f07a4b4df4bf) | ![learn wordpress org_my-courses__course-list-student-course-filter-0=active(Desktop) (2)](https://github.com/WordPress/Learn/assets/1017872/9201cfcd-f752-49e3-9d98-3c4be37d21a4) | ![learn wordpress org_my-courses__course-list-student-course-filter-0=completed(Desktop)](https://github.com/WordPress/Learn/assets/1017872/e5d09ea6-2fb5-40b7-bfca-9cc4150160c5) | 

### Testing

This page doesn't function for me properly locally. There seem to be missing Sensei styles and scripts but I haven't investigated. Testing in sandbox works and you'll probably have better data there too.
