### PR TITLE
Add fallback featured image

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2024/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2024/functions.php
@@ -47,7 +47,7 @@ remove_filter( 'template_include', array( 'Sensei_Templates', 'template_loader' 
  */
 function set_default_featured_image( $html, $post_id, $post_thumbnail_id, $size, $attr ) {
 	if ( ! $html ) {
-		return '<img src="https://s.w.org/images/learn-thumbnail-fallback-2024.jpg?v=1" alt="" />';
+		return '<img src="https://s.w.org/images/learn-thumbnail-fallback.jpg?v=4" alt="" />';
 	}
 
 	return $html;
@@ -61,7 +61,7 @@ function set_default_featured_image( $html, $post_id, $post_thumbnail_id, $size,
  * @return string Image URL.
  */
 function default_open_graph_image( $default_image ) {
-	return 'https://s.w.org/images/learn-thumbnail-fallback-2024.jpg?v=1';
+	return 'https://s.w.org/images/learn-thumbnail-fallback.jpg?v=4';
 }
 
 /**

--- a/wp-content/themes/pub/wporg-learn-2024/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2024/functions.php
@@ -17,7 +17,6 @@ require_once __DIR__ . '/inc/query.php';
  * Actions and filters.
  */
 add_action( 'after_setup_theme', __NAMESPACE__ . '\setup' );
-add_action( 'jetpack_open_graph_image_default', __NAMESPACE__ . '\default_open_graph_image', 15, 1 );
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
 
 add_filter( 'post_thumbnail_html', __NAMESPACE__ . '\set_default_featured_image', 10, 5 );
@@ -34,35 +33,6 @@ add_filter( 'wporg_block_navigation_menus', __NAMESPACE__ . '\add_site_navigatio
 add_filter( 'wporg_block_site_breadcrumbs', __NAMESPACE__ . '\set_site_breadcrumbs' );
 
 remove_filter( 'template_include', array( 'Sensei_Templates', 'template_loader' ), 10, 1 );
-
-/**
- * Set the default featured image.
- *
- * @param string       $html The HTML for the featured image.
- * @param int          $post_id The post ID.
- * @param int          $post_thumbnail_id The post thumbnail ID.
- * @param string|array $size The image size.
- * @param string|array $attr The image attributes.
- * @return string The modified HTML for the featured image.
- */
-function set_default_featured_image( $html, $post_id, $post_thumbnail_id, $size, $attr ) {
-	if ( ! $html ) {
-		return '<img src="https://s.w.org/images/learn-thumbnail-fallback.jpg?v=4" alt="" />';
-	}
-
-	return $html;
-}
-
-/**
- * Add fallback image to Jetpack when no featured image exists.
- *
- * @param string $default_image The default image URL.
- *
- * @return string Image URL.
- */
-function default_open_graph_image( $default_image ) {
-	return 'https://s.w.org/images/learn-thumbnail-fallback.jpg?v=4';
-}
 
 /**
  * Modify the single template hierarchy to use customised copies of the Sensei Course Theme templates.
@@ -311,4 +281,22 @@ function set_site_breadcrumbs( $breadcrumbs ) {
 	}
 
 	return $breadcrumbs;
+}
+
+/**
+ * Set the default featured image.
+ *
+ * @param string       $html The HTML for the featured image.
+ * @param int          $post_id The post ID.
+ * @param int          $post_thumbnail_id The post thumbnail ID.
+ * @param string|array $size The image size.
+ * @param string|array $attr The image attributes.
+ * @return string The modified HTML for the featured image.
+ */
+function set_default_featured_image( $html, $post_id, $post_thumbnail_id, $size, $attr ) {
+	if ( ! $html ) {
+		return '<img src="https://s.w.org/images/learn-thumbnail-fallback.jpg?v=4" alt="" />';
+	}
+
+	return $html;
 }

--- a/wp-content/themes/pub/wporg-learn-2024/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2024/functions.php
@@ -18,18 +18,20 @@ require_once __DIR__ . '/inc/query.php';
  */
 add_action( 'after_setup_theme', __NAMESPACE__ . '\setup' );
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
-add_filter( 'wporg_block_site_breadcrumbs', __NAMESPACE__ . '\set_site_breadcrumbs' );
-add_filter( 'wporg_block_navigation_menus', __NAMESPACE__ . '\add_site_navigation_menus' );
-add_filter( 'single_template_hierarchy', __NAMESPACE__ . '\modify_single_template' );
-remove_filter( 'template_include', array( 'Sensei_Templates', 'template_loader' ), 10, 1 );
-add_filter( 'sensei_register_post_type_lesson', function( $args ) {
-	$args['has_archive'] = 'lessons';
-	return $args;
-} );
+
 add_filter( 'sensei_register_post_type_course', function( $args ) {
 	$args['has_archive'] = 'courses';
 	return $args;
 } );
+add_filter( 'sensei_register_post_type_lesson', function( $args ) {
+	$args['has_archive'] = 'lessons';
+	return $args;
+} );
+add_filter( 'single_template_hierarchy', __NAMESPACE__ . '\modify_single_template' );
+add_filter( 'wporg_block_navigation_menus', __NAMESPACE__ . '\add_site_navigation_menus' );
+add_filter( 'wporg_block_site_breadcrumbs', __NAMESPACE__ . '\set_site_breadcrumbs' );
+
+remove_filter( 'template_include', array( 'Sensei_Templates', 'template_loader' ), 10, 1 );
 
 /**
  * Modify the single template hierarchy to use customised copies of the Sensei Course Theme templates.

--- a/wp-content/themes/pub/wporg-learn-2024/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2024/functions.php
@@ -17,8 +17,10 @@ require_once __DIR__ . '/inc/query.php';
  * Actions and filters.
  */
 add_action( 'after_setup_theme', __NAMESPACE__ . '\setup' );
+add_action( 'jetpack_open_graph_image_default', __NAMESPACE__ . '\default_open_graph_image', 15, 1 );
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
 
+add_filter( 'post_thumbnail_html', __NAMESPACE__ . '\set_default_featured_image', 10, 5 );
 add_filter( 'sensei_register_post_type_course', function( $args ) {
 	$args['has_archive'] = 'courses';
 	return $args;
@@ -32,6 +34,35 @@ add_filter( 'wporg_block_navigation_menus', __NAMESPACE__ . '\add_site_navigatio
 add_filter( 'wporg_block_site_breadcrumbs', __NAMESPACE__ . '\set_site_breadcrumbs' );
 
 remove_filter( 'template_include', array( 'Sensei_Templates', 'template_loader' ), 10, 1 );
+
+/**
+ * Set the default featured image.
+ *
+ * @param string       $html The HTML for the featured image.
+ * @param int          $post_id The post ID.
+ * @param int          $post_thumbnail_id The post thumbnail ID.
+ * @param string|array $size The image size.
+ * @param string|array $attr The image attributes.
+ * @return string The modified HTML for the featured image.
+ */
+function set_default_featured_image( $html, $post_id, $post_thumbnail_id, $size, $attr ) {
+	if ( ! $html ) {
+		return '<img src="https://s.w.org/images/learn-thumbnail-fallback-2024.jpg?v=1" alt="" />';
+	}
+
+	return $html;
+}
+
+/**
+ * Add fallback image to Jetpack when no featured image exists.
+ *
+ * @param string $default_image The default image URL.
+ *
+ * @return string Image URL.
+ */
+function default_open_graph_image( $default_image ) {
+	return 'https://s.w.org/images/learn-thumbnail-fallback-2024.jpg?v=1';
+}
 
 /**
  * Modify the single template hierarchy to use customised copies of the Sensei Course Theme templates.


### PR DESCRIPTION
Adds a fallback image source for featured images.

It should be used anywhere a featured image would be; cards, post content, etc.

Closes #2474

### Screenshots

| Courses | Lessons | Tutorials |
|-|-|-|
| ![learn wordpress org_courses_(Desktop)](https://github.com/WordPress/Learn/assets/1017872/50302308-818d-4710-b081-401e21e4b8cb) | ![learn wordpress org_lessons_page_2_(Desktop)](https://github.com/WordPress/Learn/assets/1017872/664c811c-37cd-4edd-aa0b-947df3c8e0be) | ![learn wordpress org_tutorials_(Desktop)](https://github.com/WordPress/Learn/assets/1017872/f76e0e32-4b80-4739-84e3-3fd44523140f) |