### PR TITLE
Move Course Grid query loop block variation to theme

### DIFF
--- a/wp-content/plugins/wporg-learn/inc/blocks.php
+++ b/wp-content/plugins/wporg-learn/inc/blocks.php
@@ -25,7 +25,6 @@ require_once get_views_path() . 'block-lesson-count.php';
  */
 add_action( 'init', __NAMESPACE__ . '\register_types' );
 add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_block_style_assets' );
-add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_course_grid_assets' );
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_block_style_assets' );
 
 /**
@@ -446,29 +445,6 @@ function enqueue_block_style_assets() {
 		get_build_url() . 'style-block-styles.css',
 		array(),
 		filemtime( get_build_path() . 'style-block-styles.css' )
-	);
-}
-
-/**
- * Enqueue course grid assets.
- *
- * @throws Error If the build files are not found.
- */
-function enqueue_course_grid_assets() {
-	$script_asset_path = get_build_path() . 'course-grid.asset.php';
-	if ( ! is_readable( $script_asset_path ) ) {
-		throw new Error(
-			'You need to run `npm start` or `npm run build` for the "wporg-learn/course-grid" block first.'
-		);
-	}
-
-	$script_asset = require $script_asset_path;
-	wp_enqueue_script(
-		'wporg-learn-course-grid',
-		get_build_url() . 'course-grid.js',
-		$script_asset['dependencies'],
-		$script_asset['version'],
-		true
 	);
 }
 

--- a/wp-content/plugins/wporg-learn/inc/sensei.php
+++ b/wp-content/plugins/wporg-learn/inc/sensei.php
@@ -17,8 +17,6 @@ add_filter( 'sensei_load_default_supported_theme_wrappers', '__return_false' );
 add_action( 'sensei_before_main_content', __NAMESPACE__ . '\theme_wrapper_start' );
 add_action( 'sensei_after_main_content', __NAMESPACE__ . '\theme_wrapper_end' );
 add_action( 'init', __NAMESPACE__ . '\wporg_correct_sensei_slugs', 9 );
-add_filter( 'pre_render_block', __NAMESPACE__ . '\modify_course_query', 10, 2 );
-add_filter( 'rest_course_query', __NAMESPACE__ . '\modify_course_rest_query', 10, 2 );
 
 /**
  * Slugs in Sensei are translatable, which won't work for our site and the language switcher.
@@ -259,59 +257,4 @@ function get_my_courses_page_url() {
 	}
 
 	return get_permalink( $page_id );
-}
-
-/**
- * Modify the course query to add the featured course meta query if set.
- *
- * @param mixed $pre_render The pre-render value.
- * @param mixed $parsed_block The parsed block value.
- * @return mixed The modified course query.
- */
-function modify_course_query( $pre_render, $parsed_block ) {
-	if ( isset( $parsed_block['attrs']['namespace'] ) && 'wporg-learn/course-grid' === $parsed_block['attrs']['namespace']
-	) {
-		add_filter(
-			'query_loop_block_query_vars',
-			function( $query, $block ) use ( $parsed_block ) {
-				if ( 'course' !== $query['post_type'] || ! isset( $parsed_block['attrs']['query']['courseFeatured'] ) ) {
-					return $query;
-				}
-
-				$course_featured = $parsed_block['attrs']['query']['courseFeatured'];
-
-				if ( true === $course_featured ) {
-					$query['meta_key']   = '_course_featured';
-					$query['meta_value'] = 'featured';
-				}
-
-				return $query;
-			},
-			10,
-			2
-		);
-	}
-
-	return $pre_render;
-}
-
-/**
- * Modify the course REST query to add the featured course meta query if set.
- *
- * @param array           $args The query arguments.
- * @param WP_REST_Request $request The REST request object.
- * @return array The modified query arguments.
- */
-function modify_course_rest_query( $args, $request ) {
-	$course_featured = $request->get_param( 'courseFeatured' );
-
-	if ( 'true' === $course_featured ) {
-		$args['meta_query'][] = array(
-			'key'     => '_course_featured',
-			'value'   => 'featured',
-			'compare' => '=',
-		);
-	}
-
-	return $args;
 }

--- a/wp-content/plugins/wporg-learn/webpack.config.js
+++ b/wp-content/plugins/wporg-learn/webpack.config.js
@@ -5,7 +5,6 @@ const config = require( '@wordpress/scripts/config/webpack.config' );
  */
 config.entry = {
 	'block-styles': './js/block-styles/index.js',
-	'course-grid': './js/course-grid/index.js',
 	'course-status': './js/course-status/src/index.js',
 	'duration-meta': './js/duration-meta/index.js',
 	'expiration-date': './js/expiration-date/index.js',

--- a/wp-content/themes/pub/wporg-learn-2024/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2024/functions.php
@@ -5,6 +5,7 @@ namespace WordPressdotorg\Theme\Learn_2024;
 use function WPOrg_Learn\Sensei\{get_my_courses_page_url};
 
 // Block files
+require_once __DIR__ . '/src/course-grid/index.php';
 require_once __DIR__ . '/src/learning-pathway-cards/index.php';
 require_once __DIR__ . '/src/learning-pathway-header/index.php';
 require_once __DIR__ . '/src/search-results-context/index.php';

--- a/wp-content/themes/pub/wporg-learn-2024/src/course-grid/block.json
+++ b/wp-content/themes/pub/wporg-learn-2024/src/course-grid/block.json
@@ -1,0 +1,7 @@
+{
+	"name": "wporg-learn/course-grid",
+	"title": "Learn Course Grid",
+	"description": "A query loop block variation which displays a cards grid of courses, filterable by the 'featured' course post meta.",
+	"textdomain": "wporg-learn",
+	"editorScript": "file:./index.js"
+}

--- a/wp-content/themes/pub/wporg-learn-2024/src/course-grid/index.js
+++ b/wp-content/themes/pub/wporg-learn-2024/src/course-grid/index.js
@@ -23,7 +23,7 @@ registerBlockVariation( 'core/query', {
 	},
 	description: __( 'Displays a cards grid of courses.', 'wporg-learn' ),
 	attributes: {
-		className: 'wporg-learn-course-grid',
+		className: 'wporg-learn-course-grid wporg-learn-card-grid',
 		namespace: VARIATION_NAME,
 		query: {
 			perPage: 6,

--- a/wp-content/themes/pub/wporg-learn-2024/src/course-grid/index.php
+++ b/wp-content/themes/pub/wporg-learn-2024/src/course-grid/index.php
@@ -1,0 +1,85 @@
+<?php
+namespace WordPressdotorg\Theme\Learn_2024\Course_Grid;
+
+add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_course_grid_assets' );
+
+add_filter( 'pre_render_block', __NAMESPACE__ . '\modify_course_query', 10, 2 );
+add_filter( 'rest_course_query', __NAMESPACE__ . '\modify_course_rest_query', 10, 2 );
+
+/**
+ * Enqueue course grid assets.
+ *
+ * @throws Error If the build files are not found.
+ */
+function enqueue_course_grid_assets() {
+	$script_asset_path = get_stylesheet_directory() . '/build/course-grid/index.asset.php';
+	if ( ! is_readable( $script_asset_path ) ) {
+		throw new Error(
+			'You need to run `npm start` or `npm run build` for the "wporg-learn/course-grid" block first.'
+		);
+	}
+
+	$script_asset = require $script_asset_path;
+	wp_enqueue_script(
+		'wporg-learn-course-grid',
+		get_stylesheet_directory_uri() . '/build/course-grid/index.js',
+		$script_asset['dependencies'],
+		$script_asset['version'],
+		true
+	);
+}
+
+/**
+ * Modify the course query to add the featured course meta query if set.
+ *
+ * @param mixed $pre_render The pre-render value.
+ * @param mixed $parsed_block The parsed block value.
+ * @return mixed The modified course query.
+ */
+function modify_course_query( $pre_render, $parsed_block ) {
+	if ( isset( $parsed_block['attrs']['namespace'] ) && 'wporg-learn/course-grid' === $parsed_block['attrs']['namespace']
+	) {
+		add_filter(
+			'query_loop_block_query_vars',
+			function( $query, $block ) use ( $parsed_block ) {
+				if ( 'course' !== $query['post_type'] || ! isset( $parsed_block['attrs']['query']['courseFeatured'] ) ) {
+					return $query;
+				}
+
+				$course_featured = $parsed_block['attrs']['query']['courseFeatured'];
+
+				if ( true === $course_featured ) {
+					$query['meta_key']   = '_course_featured';
+					$query['meta_value'] = 'featured';
+				}
+
+				return $query;
+			},
+			10,
+			2
+		);
+	}
+
+	return $pre_render;
+}
+
+/**
+ * Modify the course REST query to add the featured course meta query if set.
+ *
+ * @param array           $args The query arguments.
+ * @param WP_REST_Request $request The REST request object.
+ * @return array The modified query arguments.
+ */
+function modify_course_rest_query( $args, $request ) {
+	$course_featured = $request->get_param( 'courseFeatured' );
+
+	if ( 'true' === $course_featured ) {
+		$args['meta_query'][] = array(
+			'key'     => '_course_featured',
+			'value'   => 'featured',
+			'compare' => '=',
+		);
+	}
+
+	return $args;
+}


### PR DESCRIPTION
Follow up to https://github.com/WordPress/Learn/commit/8858ef40aa56cb005b3a24bee36a0d8663256b70, where this variation switched to using the Course Card template part from the theme.

This query loop variation is a presentation component which is tightly coupled to the theme, so it doesn't make sense for it to be in the plugin.

See https://github.com/WordPress/Learn/issues/2573

### Testing

There should be no change to the functionality.
If it's still working, the Featured Courses on the homepage should be showing only featured courses.
If you add the 'Learn Course Grid' block in the editor, it should have a 'Featured only' switch in the block settings in the sidebar.