### PR TITLE
Update icon, font size, color for Learning Duration

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2024/assets/icon-clock.svg
+++ b/wp-content/themes/pub/wporg-learn-2024/assets/icon-clock.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="25" fill="none">
+  <path fill="#656A71" fill-rule="evenodd" d="M12 19.75a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15Zm0 1.5a9 9 0 1 0 0-18 9 9 0 0 0 0 18Z" clip-rule="evenodd"/>
+  <path fill="#656A71" d="m11 12.25 1-5 1 5h-2ZM12 13.25a1 1 0 0 0 1-1h-2a1 1 0 0 0 1 1Z"/>
+  <path fill="#656A71" d="m12.814 11.634 2.829 4.243L11.4 13.05l1.414-1.415Z"/>
+</svg>

--- a/wp-content/themes/pub/wporg-learn-2024/parts/card-course-h3.html
+++ b/wp-content/themes/pub/wporg-learn-2024/parts/card-course-h3.html
@@ -13,7 +13,7 @@
 		<!-- wp:group {"style":{"layout":{"selfStretch":"fit","flexSize":null},"spacing":{"margin":{"top":"var:preset|spacing|20"}}},"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between","verticalAlignment":"center"}} -->
 		<div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--20)">
 
-			<!-- wp:wporg-learn/learning-duration {"style":{"elements":{"link":{"color":{"text":"var:preset|color|charcoal-4"}}}},"textColor":"charcoal-4","fontSize":"small"} /-->
+			<!-- wp:wporg-learn/learning-duration {"fontSize":"extra-small"} /-->
 
 			<!-- wp:wporg-learn/lesson-count {"style":{"layout":{"selfStretch":"fill","flexSize":null}},"fontSize":"extra-small"} /-->
 

--- a/wp-content/themes/pub/wporg-learn-2024/parts/card-course.html
+++ b/wp-content/themes/pub/wporg-learn-2024/parts/card-course.html
@@ -13,7 +13,7 @@
 		<!-- wp:group {"style":{"layout":{"selfStretch":"fit","flexSize":null},"spacing":{"margin":{"top":"var:preset|spacing|20"}}},"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between","verticalAlignment":"center"}} -->
 		<div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--20)">
 
-			<!-- wp:wporg-learn/learning-duration {"style":{"elements":{"link":{"color":{"text":"var:preset|color|charcoal-4"}}}},"textColor":"charcoal-4","fontSize":"small"} /-->
+			<!-- wp:wporg-learn/learning-duration {"fontSize":"extra-small"} /-->
 
 			<!-- wp:wporg-learn/lesson-count {"style":{"layout":{"selfStretch":"fill","flexSize":null}},"fontSize":"extra-small"} /-->
 

--- a/wp-content/themes/pub/wporg-learn-2024/parts/card-lesson-h3.html
+++ b/wp-content/themes/pub/wporg-learn-2024/parts/card-lesson-h3.html
@@ -13,7 +13,7 @@
 		<!-- wp:group {"style":{"layout":{"selfStretch":"fit","flexSize":null},"spacing":{"margin":{"top":"var:preset|spacing|20"}}},"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between","verticalAlignment":"center"}} -->
 		<div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--20)">
 
-			<!-- wp:wporg-learn/learning-duration {"style":{"elements":{"link":{"color":{"text":"var:preset|color|charcoal-4"}}}},"textColor":"charcoal-4","fontSize":"small"} /-->
+			<!-- wp:wporg-learn/learning-duration {"fontSize":"extra-small"} /-->
 
 			<!-- wp:post-terms {"term":"level","separator":" ","className":"is-style-tag","fontSize":"extra-small"} /-->
 

--- a/wp-content/themes/pub/wporg-learn-2024/parts/card-lesson.html
+++ b/wp-content/themes/pub/wporg-learn-2024/parts/card-lesson.html
@@ -13,7 +13,7 @@
 		<!-- wp:group {"style":{"layout":{"selfStretch":"fit","flexSize":null},"spacing":{"margin":{"top":"var:preset|spacing|20"}}},"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between","verticalAlignment":"center"}} -->
 		<div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--20)">
 
-			<!-- wp:wporg-learn/learning-duration {"style":{"elements":{"link":{"color":{"text":"var:preset|color|charcoal-4"}}}},"textColor":"charcoal-4","fontSize":"small"} /-->
+			<!-- wp:wporg-learn/learning-duration {"fontSize":"extra-small"} /-->
 
 			<!-- wp:post-terms {"term":"level","separator":" ","className":"is-style-tag","fontSize":"extra-small"} /-->
 

--- a/wp-content/themes/pub/wporg-learn-2024/parts/card.html
+++ b/wp-content/themes/pub/wporg-learn-2024/parts/card.html
@@ -13,7 +13,7 @@
 		<!-- wp:group {"style":{"layout":{"selfStretch":"fit","flexSize":null},"spacing":{"margin":{"top":"var:preset|spacing|20"}}},"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between","verticalAlignment":"center"}} -->
 		<div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--20)">
 
-			<!-- wp:wporg-learn/learning-duration {"style":{"elements":{"link":{"color":{"text":"var:preset|color|charcoal-4"}}}},"textColor":"charcoal-4","fontSize":"small"} /-->
+			<!-- wp:wporg-learn/learning-duration {"fontSize":"extra-small"} /-->
 
 			<!-- wp:wporg-learn/lesson-count {"style":{"layout":{"selfStretch":"fill","flexSize":null}},"fontSize":"extra-small"} /-->
 

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_card-grid.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_card-grid.scss
@@ -18,16 +18,14 @@
 			align-items: center;
 
 			&::before {
-				// 'clock' icon
-				content: "\f469";
-				/* stylelint-disable-next-line font-family-no-missing-generic-family-keyword */
-				font-family: dashicons;
+				content: "";
 				display: block;
 				width: 24px;
 				height: 24px;
 				font-size: 24px;
 				line-height: 1;
 				margin-right: 6px;
+				background: url(../../assets/icon-clock.svg) no-repeat;
 			}
 		}
 


### PR DESCRIPTION
Fixes #2627 — This updates the icon for the Learning Duration block to use the SVG from figma, instead of a dashicon. It also updates the style attributes on each instance of the block so that it matches the "Lesson Count" block, which inherits text color and uses `extra-small` font. This matches the figma, which is 12px default text color (charcoal-1).

| Before | After |
|---|---|
| <img width="809" alt="Screenshot 2024-07-09 at 2 14 13 PM" src="https://github.com/WordPress/Learn/assets/541093/455c01e8-f9a8-4ad8-9a0e-b62cab4940f8"> | <img width="810" alt="Screenshot 2024-07-09 at 2 04 31 PM" src="https://github.com/WordPress/Learn/assets/541093/a27a82e1-5d2b-4fdf-98ab-17de83fe3090"> |

**To test**

- Add durations to some courses. This block is also used on lessons, though none on production seem to have duration; but the style update has been done for lessons as well.
- Everywhere the duration appears, it should be 12px font size, charcoal-1 color, and the icon should be an SVG (the SVG has a thinner circle border around it)
