### PR TITLE
Add a post meta filter to exclude certain lessons from archive views

### DIFF
--- a/wp-content/plugins/wporg-learn/inc/post-meta.php
+++ b/wp-content/plugins/wporg-learn/inc/post-meta.php
@@ -51,6 +51,21 @@ function register_lesson_meta() {
 			},
 		),
 	);
+
+	register_post_meta(
+		'lesson',
+		'_lesson_archive_excluded',
+		array(
+			'description'       => __( 'Whether the lesson should be excluded from archive views.', 'wporg-learn' ),
+			'type'              => 'string',
+			'single'            => true,
+			'sanitize_callback' => 'sanitize_text_field',
+			'show_in_rest'      => true,
+			'auth_callback'     => function( $allowed, $meta_key, $post_id ) {
+				return current_user_can( 'edit_post', $post_id );
+			},
+		),
+	);
 }
 
 /**
@@ -634,6 +649,7 @@ function render_locales_list() {
 function enqueue_editor_assets() {
 	enqueue_expiration_date_assets();
 	enqueue_language_meta_assets();
+	enqueue_lesson_archive_excluded_meta_assets();
 	enqueue_lesson_featured_meta_assets();
 	enqueue_duration_meta_assets();
 }
@@ -688,6 +704,31 @@ function enqueue_language_meta_assets() {
 		);
 
 		wp_set_script_translations( 'wporg-learn-language-meta', 'wporg-learn' );
+	}
+}
+
+/**
+ * Enqueue scripts for the archive excluded lesson meta block.
+ */
+function enqueue_lesson_archive_excluded_meta_assets() {
+	global $typenow;
+
+	if ( 'lesson' === $typenow ) {
+		$script_asset_path = get_build_path() . 'lesson-archive-excluded-meta.asset.php';
+		if ( ! file_exists( $script_asset_path ) ) {
+			wp_die( 'You need to run `yarn start` or `yarn build` to build the required assets.' );
+		}
+
+		$script_asset = require( $script_asset_path );
+		wp_enqueue_script(
+			'wporg-learn-lesson-archive-excluded-meta',
+			get_build_url() . 'lesson-archive-excluded-meta.js',
+			$script_asset['dependencies'],
+			$script_asset['version'],
+			true
+		);
+
+		wp_set_script_translations( 'wporg-learn-lesson-archive-excluded-meta', 'wporg-learn' );
 	}
 }
 

--- a/wp-content/plugins/wporg-learn/js/lesson-archive-excluded-meta/index.js
+++ b/wp-content/plugins/wporg-learn/js/lesson-archive-excluded-meta/index.js
@@ -1,0 +1,42 @@
+/**
+ * WordPress dependencies
+ */
+import { CheckboxControl, PanelRow } from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { registerPlugin } from '@wordpress/plugins';
+
+const EXCLUDED = 'excluded';
+
+const LessonArchiveExcludedMeta = () => {
+	const postMetaData = useSelect( ( select ) => select( 'core/editor' ).getEditedPostAttribute( 'meta' ) || {} );
+	const { editPost } = useDispatch( 'core/editor' );
+	const [ lessonExcluded, setLessonFeatured ] = useState( postMetaData?._lesson_archive_excluded === EXCLUDED );
+
+	return (
+		<PluginDocumentSettingPanel title={ __( 'Hidden Lesson', 'wporg-learn' ) }>
+			<PanelRow>
+				<CheckboxControl
+					label={ __( 'Exclude this lesson from the archive', 'wporg-learn' ) }
+					checked={ lessonExcluded }
+					onChange={ ( newLessonExcluded ) => {
+						setLessonFeatured( newLessonExcluded );
+
+						editPost( {
+							meta: {
+								...postMetaData,
+								_lesson_archive_excluded: newLessonExcluded ? EXCLUDED : '',
+							},
+						} );
+					} }
+				/>
+			</PanelRow>
+		</PluginDocumentSettingPanel>
+	);
+};
+
+registerPlugin( 'wporg-learn-lesson-archive-excluded-meta', {
+	render: LessonArchiveExcludedMeta,
+} );

--- a/wp-content/plugins/wporg-learn/webpack.config.js
+++ b/wp-content/plugins/wporg-learn/webpack.config.js
@@ -8,6 +8,7 @@ config.entry = {
 	'course-status': './js/course-status/src/index.js',
 	'duration-meta': './js/duration-meta/index.js',
 	'expiration-date': './js/expiration-date/index.js',
+	'lesson-archive-excluded-meta': './js/lesson-archive-excluded-meta/index.js',
 	'lesson-count': './js/lesson-count/src/index.js',
 	'lesson-featured-meta': './js/lesson-featured-meta/index.js',
 	'workshop-application-form': './js/workshop-application-form/src/index.js',

--- a/wp-content/themes/pub/wporg-learn-2024/inc/query.php
+++ b/wp-content/themes/pub/wporg-learn-2024/inc/query.php
@@ -5,15 +5,16 @@
 
 namespace WordPressdotorg\Theme\Learn_2024\Query;
 
-add_action( 'pre_get_posts', __NAMESPACE__ . '\modify_archive_queries' );
-add_action( 'pre_get_posts', __NAMESPACE__ . '\modify_level_query' );
+add_action( 'pre_get_posts', __NAMESPACE__ . '\add_language_to_archive_queries' );
+add_action( 'pre_get_posts', __NAMESPACE__ . '\handle_all_level_query' );
+add_action( 'pre_get_posts', __NAMESPACE__ . '\add_excluded_to_lesson_archive_query' );
 
 /**
  * Modify the query by adding meta query for language if set.
  *
  * @param WP_Query $query The query object.
  */
-function modify_archive_queries( $query ) {
+function add_language_to_archive_queries( $query ) {
 	// Ensure this code runs only for the main query on archive pages and search results.
 	if ( ! is_admin() && $query->is_main_query() && ( $query->is_archive() || $query->is_search() ) ) {
 		if ( isset( $_GET['language'] ) && is_array( $_GET['language'] ) ) {
@@ -39,6 +40,8 @@ function modify_archive_queries( $query ) {
 			$query->set( 'meta_query', $meta_query );
 		}
 	}
+
+	return $query;
 }
 
 /**
@@ -48,7 +51,7 @@ function modify_archive_queries( $query ) {
  * @param WP_Query $query The main query.
  * @return WP_Query
  */
-function modify_level_query( $query ) {
+function handle_all_level_query( $query ) {
 	if ( is_admin() || ! $query->is_main_query() ) {
 		return;
 	}
@@ -57,6 +60,34 @@ function modify_level_query( $query ) {
 
 	if ( 'all' === $level ) {
 		$query->set( 'wporg_lesson_level', '' );
+	}
+
+	return $query;
+}
+
+/**
+ * Modify the query by adding meta query for excluding the lesson from the archive if set.
+ *
+ * @param WP_Query $query The query object.
+ */
+function add_excluded_to_lesson_archive_query( $query ) {
+	// Ensure this code runs only for the main query on lesson archive pages and search results.
+	if ( ! is_admin() && $query->is_main_query() && ( $query->is_archive( 'lesson' ) || $query->is_search() ) ) {
+		$query->set(
+			'meta_query',
+			array(
+				'relation' => 'OR',
+				array(
+					'key'     => '_lesson_archive_excluded',
+					'compare' => 'NOT EXISTS',
+				),
+				array(
+					'key'     => '_lesson_archive_excluded',
+					'value'   => 'excluded',
+					'compare' => '!=',
+				),
+			)
+		);
 	}
 
 	return $query;


### PR DESCRIPTION
Adds a post meta field  to Lessons, which enables hiding certain Lessons from archive views, eg. Quiz, Course Completed.

<img src="https://github.com/WordPress/Learn/assets/1017872/23e10a84-12f0-474e-a3cc-5de5f7f7217a" width="300">

Adds a meta_query on archive queries to filter these posts out.

Closes #2591 

### Testing

1. Use the editor post meta to hide a lesson
2. Navigate the frontend and ensure the lesson doesn't appear in any of the lesson grids
3. Ensure it still appears in the Course it belongs to