### PR TITLE
Fix My Courses returns all courses when 'All' is selected

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2024/inc/block-config.php
+++ b/wp-content/themes/pub/wporg-learn-2024/inc/block-config.php
@@ -568,10 +568,7 @@ function inject_other_filters( $key ) {
  * @return array The modified course query.
  */
 function modify_course_query( $query ) {
-	if (
-		'course' === $query['post_type'] &&
-		get_the_ID() === Sensei()->settings->get_my_courses_page_id()
-	) {
+	if ( get_the_ID() === Sensei()->settings->get_my_courses_page_id() ) {
 		$key             = get_student_course_filter_query_var_name();
 		$selected_option = isset( $_GET[ $key ] ) ? sanitize_text_field( wp_unslash( $_GET[ $key ] ) ) : '';
 

--- a/wp-content/themes/pub/wporg-learn-2024/inc/block-config.php
+++ b/wp-content/themes/pub/wporg-learn-2024/inc/block-config.php
@@ -570,8 +570,7 @@ function filter_student_course_list( $parsed_block ) {
 	if (
 		'core/query' !== $parsed_block['blockName'] ||
 		'course' !== ( $parsed_block['attrs']['query']['postType'] ?? '' ) ||
-		! isset( $parsed_block['attrs']['queryId'] ) ||
-		! get_the_ID() === Sensei()->settings->get_my_courses_page_id()
+		get_the_ID() !== Sensei()->settings->get_my_courses_page_id()
 	) {
 		return $parsed_block;
 	}

--- a/wp-content/themes/pub/wporg-learn-2024/inc/block-config.php
+++ b/wp-content/themes/pub/wporg-learn-2024/inc/block-config.php
@@ -561,7 +561,7 @@ function inject_other_filters( $key ) {
 }
 
 /**
- * Filter the block data for the student course list.
+ * Modifies the courses query for the My Courses page, by adding courses to be excluded.
  *
  * @param array $parsed_block The parsed block data.
  * @return array The updated block data.
@@ -591,9 +591,9 @@ function filter_student_course_list( $parsed_block ) {
 }
 
 /**
- * Get the course IDs to be excluded from the query.
+ * Get the course IDs to be excluded from the query, using the query filter value.
  */
-function get_course_ids_to_be_excluded( $query_id ): array {
+function get_course_ids_to_be_excluded(): array {
 	$user_id = get_current_user_id();
 	if ( empty( $user_id ) ) {
 		return array();

--- a/wp-content/themes/pub/wporg-learn-2024/inc/block-config.php
+++ b/wp-content/themes/pub/wporg-learn-2024/inc/block-config.php
@@ -571,7 +571,7 @@ function filter_student_course_list( $parsed_block ) {
 		'core/query' !== $parsed_block['blockName'] ||
 		'course' !== ( $parsed_block['attrs']['query']['postType'] ?? '' ) ||
 		! isset( $parsed_block['attrs']['queryId'] ) ||
-		! is_page( 'my-courses' )
+		! get_the_ID() === Sensei()->settings->get_my_courses_page_id()
 	) {
 		return $parsed_block;
 	}


### PR DESCRIPTION
Fixes #2609

Because the `get_course_ids_to_be_excluded` function from sensei-lms directly [returns an empty array](https://github.com/Automattic/sensei/blob/trunk/includes/blocks/course-list/class-sensei-course-list-student-course-filter.php#L95-L97) when encountering "all" and unexpected options, it causes the filter to return all courses when "all" is selected, instead of the courses that a student has been enrolled in. Since there is no native hook to adjust this, it has been ported from Sensei. 
The [filter_course_list](https://github.com/Automattic/sensei/blob/trunk/includes/blocks/course-list/class-sensei-course-list-filter-block.php#L30) function from `class-sensei-course-list-filter-block.php` is ported over, and unnecessary conditions and commands are removed.

The old theme used the learner-courses to directly [render](https://github.com/Automattic/sensei/blob/trunk/includes/blocks/class-sensei-learner-courses-block.php#L61) the [Sensei_Shortcode_User_Courses](https://github.com/Automattic/sensei/blob/trunk/includes/shortcodes/class-sensei-shortcode-user-courses.php) shortcode, which retrieves the expected course list. You can see from [here](https://github.com/Automattic/sensei/blob/trunk/includes/shortcodes/class-sensei-shortcode-user-courses.php#L235) that it specifically fetches enrolled courses for "all".

**Testing:**

1. The filters on the My Courses page should now work as expected.
2. The newly added filter should only affect the My Courses page.