### PR TITLE
Fix sticky header position incorrect when on a smaller screen for lesson page

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
@@ -9,7 +9,7 @@ body.sensei {
 	--sensei-button-text-color: var(--wp--preset--color--white);
 
 	--sensei-course-progress-bar-color: var(--wp--custom--color--border);
-	--sensei-course-progress-bar-inner-color: var(--wp--preset--color--blueberry-1);
+	--sensei-course-progress-bar-inner-color: var(--wp--custom--color--green-50);
 	--sensei-lesson-meta-color: var(--wp--preset--color--charcoal-4);
 	--sensei-module-lesson-color: var(--wp--preset--color--charcoal-1);
 

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
@@ -3,7 +3,6 @@ body.sensei {
 	--content-padding: var(--wp--preset--spacing--edge-space);
 	--sensei-lm-header-height: 60px;
 	--sensei-lm-sidebar-width: calc(280px + var(--wp--preset--spacing--edge-space));
-	--sensei-wpadminbar-offset: var(--wp-admin--admin-bar--height);
 
 	--border-color: var(--wp--custom--color--border);
 	--sensei-secondary-color: var(--wp--preset--color--blueberry-1);

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
@@ -9,7 +9,7 @@ body.sensei {
 	--sensei-button-text-color: var(--wp--preset--color--white);
 
 	--sensei-course-progress-bar-color: var(--wp--custom--color--border);
-	--sensei-course-progress-bar-inner-color: var(--wp--custom--color--green-50);
+	--sensei-course-progress-bar-inner-color: var(--wp--preset--color--blueberry-1);
 	--sensei-lesson-meta-color: var(--wp--preset--color--charcoal-4);
 	--sensei-module-lesson-color: var(--wp--preset--color--charcoal-1);
 


### PR DESCRIPTION
Fixes #2663

This issue can also be reproduced on Chrome and Safari.

The root cause is that we fixed the `--sensei-wpadminbar-offset` to `var(--wp-admin--admin-bar--height)`. However, during scrolling, `--sensei-wpadminbar-offset` should actually be 0.

I first tried removing the fixed value here, and it appears that `--sensei-wpadminbar-offset` already can adjust the admin bar height according to different screen sizes. Was there any specific consideration for adding this fixed value initially? It seems safe to remove it now.

I also noticed that the progress bar on the inner lesson page is still blue. I believe we should align the progress bar here with the others? (See screenshots) @fcoveram 

## Screenshots

**Progress Bar**
![image](https://github.com/user-attachments/assets/14c11f4c-d295-4bdf-bc43-8da07ca6ddac)
![image](https://github.com/user-attachments/assets/6c0f4a91-f2c5-4da8-be45-46173766ee55)

**Sticky Header - Safari**
![safari](https://github.com/user-attachments/assets/c842303d-fd09-4524-b4fb-24eef9bc9755)

**Sticky Header - Chrome**
![chrome](https://github.com/user-attachments/assets/233203c0-2d9a-4f39-ad2e-f13264ebd1d0)

**Sticky Header - Firefox**
![ff](https://github.com/user-attachments/assets/493fd6ce-5318-4441-8d61-e9c0a967dcf0)

**Sticky Header - iPhone**
![ios](https://github.com/user-attachments/assets/31b0d9c6-23aa-4ebb-b118-18b4f9423343)
