### PR TITLE
Course outline block header enhance

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2024/src/course-outline/index.js
+++ b/wp-content/themes/pub/wporg-learn-2024/src/course-outline/index.js
@@ -8,7 +8,7 @@ document.addEventListener( 'DOMContentLoaded', () => {
 	 * Allow the entire header to toggle, giving users a larger area to interact with.
 	 */
 	document
-		.querySelectorAll( 'section.wp-block-sensei-lms-course-outline-module-bordered >  header' )
+		.querySelectorAll( 'section.wp-block-sensei-lms-course-outline-module-bordered > header' )
 		.forEach( ( header ) => {
 			const button = header.querySelector( 'button' );
 			header.addEventListener( 'click', () => {

--- a/wp-content/themes/pub/wporg-learn-2024/src/course-outline/index.js
+++ b/wp-content/themes/pub/wporg-learn-2024/src/course-outline/index.js
@@ -4,10 +4,20 @@ import { Icon, drafts, lockOutline } from '@wordpress/icons';
 import { renderToString } from '@wordpress/element';
 
 document.addEventListener( 'DOMContentLoaded', () => {
+	/**
+	 * Allow the entire header to toggle, giving users a larger area to interact with.
+	 */
 	document
 		.querySelectorAll( 'section.wp-block-sensei-lms-course-outline-module-bordered >  header' )
 		.forEach( ( header ) => {
-			header.classList.add( 'sensei-collapsible__toggle' );
+			const button = header.querySelector( 'button' );
+			header.addEventListener( 'click', () => {
+				button.click();
+			} );
+
+			button.addEventListener( 'click', ( event ) => {
+				event.stopPropagation();
+			} );
 		} );
 
 	/**

--- a/wp-content/themes/pub/wporg-learn-2024/src/course-outline/index.js
+++ b/wp-content/themes/pub/wporg-learn-2024/src/course-outline/index.js
@@ -27,6 +27,15 @@ document.addEventListener( 'DOMContentLoaded', () => {
 				const heading = link.parentElement;
 				heading.innerHTML = link.innerHTML;
 			}
+			// Also remove the link within the span with class "screen-reader-text" if it exists.
+			const span = header.querySelector( 'span.screen-reader-text' );
+			if ( span ) {
+				const spanLink = span.querySelector( 'a' );
+				if ( spanLink ) {
+					const spanContent = spanLink.innerHTML;
+					span.innerHTML = spanContent;
+				}
+			}
 		} );
 
 	/**

--- a/wp-content/themes/pub/wporg-learn-2024/src/course-outline/index.js
+++ b/wp-content/themes/pub/wporg-learn-2024/src/course-outline/index.js
@@ -4,6 +4,12 @@ import { Icon, drafts, lockOutline } from '@wordpress/icons';
 import { renderToString } from '@wordpress/element';
 
 document.addEventListener( 'DOMContentLoaded', () => {
+	document
+		.querySelectorAll( 'section.wp-block-sensei-lms-course-outline-module-bordered >  header' )
+		.forEach( ( header ) => {
+			header.classList.add( 'sensei-collapsible__toggle' );
+		} );
+
 	/**
 	 * Find all in progress lessons, and replace the status icon with the Gutenberg-style `drafts` icon.
 	 */

--- a/wp-content/themes/pub/wporg-learn-2024/src/course-outline/index.js
+++ b/wp-content/themes/pub/wporg-learn-2024/src/course-outline/index.js
@@ -18,6 +18,15 @@ document.addEventListener( 'DOMContentLoaded', () => {
 			button.addEventListener( 'click', ( event ) => {
 				event.stopPropagation();
 			} );
+
+			// To enable the entire header to be clickable for toggling without conflicts, remove the link.
+			// In fact, this link duplicates the first lesson link in the course outline.
+			// See https://github.com/WordPress/Learn/pull/2776#issuecomment-2258308422
+			const link = header.querySelector( 'h2 > a' );
+			if ( link ) {
+				const heading = link.parentElement;
+				heading.innerHTML = link.innerHTML;
+			}
 		} );
 
 	/**

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
@@ -164,16 +164,18 @@ body.sensei {
 			}
 
 			.wp-block-sensei-lms-collapsible {
+				overflow: unset;
+
 				h3.wp-block-sensei-lms-course-outline-module__lessons-title {
 					display: none;
 				}
 
 				// lesson item that belongs to a module
-				> .wp-block-sensei-lms-course-outline-lesson:first-of-type {
+				> a.wp-block-sensei-lms-course-outline-lesson:first-of-type {
 					padding-top: 5px;
 				}
 
-				> .wp-block-sensei-lms-course-outline-lesson:last-of-type {
+				> a.wp-block-sensei-lms-course-outline-lesson:last-of-type {
 					padding-bottom: 5px;
 				}
 			}

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
@@ -163,11 +163,11 @@ body.sensei {
 				}
 			}
 
-			.wp-block-sensei-lms-course-outline-module__lessons-title {
-				display: none;
-			}
-
 			.wp-block-sensei-lms-collapsible {
+				h3.wp-block-sensei-lms-course-outline-module__lessons-title {
+					display: none;
+				}
+
 				// lesson item that belongs to a module
 				> .wp-block-sensei-lms-course-outline-lesson:first-of-type {
 					padding-top: 5px;

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
@@ -138,7 +138,8 @@ body.sensei {
 			header {
 				background-color: var(--wp--preset--color--light-grey-2) !important;
 				color: var(--wp--preset--color--charcoal-1) !important;
-				padding: var(--wp--preset--spacing--20);
+				padding-left: var(--wp--preset--spacing--20);
+				padding-right: var(--wp--preset--spacing--20);
 				cursor: pointer;
 
 				h2 {
@@ -160,6 +161,11 @@ body.sensei {
 						line-height: var(--wp--custom--body--huge--typography--line-height);
 						margin: 4px 8px;
 					}
+				}
+
+				button.wp-block-sensei-lms-course-outline__arrow {
+					height: 32px;
+					align-items: center;
 				}
 			}
 

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
@@ -139,6 +139,7 @@ body.sensei {
 				background-color: var(--wp--preset--color--light-grey-2) !important;
 				color: var(--wp--preset--color--charcoal-1) !important;
 				padding: var(--wp--preset--spacing--20);
+				cursor: pointer;
 
 				h2 {
 					font-size: var(--wp--preset--font-size--heading-6);


### PR DESCRIPTION
Resolves #2614 and #2778

**2614**
Originally, the header was directly given a class to allow toggling, but this causes an accessibility issue since the header does not support the `aria-expanded="true"` attribute and also leads to the problem of "interactive controls being nested". So here triggers the button inside the header without allowing it to bubble up.

**2778**

~Doesn't seem to be a problem anymore, couldn't replicate it either on production or locally. I've left a comment on the issue to ask for help to check if the problem still exists.~

The issue can be replicated on Firefox.

## Screenshot

**2614**
![scroll](https://github.com/user-attachments/assets/97bfec27-ae93-4469-b738-9abf2b285aab)

**2778**

![image](https://github.com/user-attachments/assets/aa574073-9625-4ee3-baf6-7bef2bdbc405)
