### PR TITLE
Add labels to the lesson status icons

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2024/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2024/functions.php
@@ -2,6 +2,7 @@
 
 namespace WordPressdotorg\Theme\Learn_2024;
 
+use WP_HTML_Tag_Processor;
 use function WPOrg_Learn\Sensei\{get_my_courses_page_url, get_lesson_has_published_course};
 
 // Block files
@@ -41,6 +42,8 @@ add_filter( 'single_template_hierarchy', __NAMESPACE__ . '\modify_single_templat
 add_filter( 'wporg_block_navigation_menus', __NAMESPACE__ . '\add_site_navigation_menus' );
 add_filter( 'wporg_block_site_breadcrumbs', __NAMESPACE__ . '\set_site_breadcrumbs' );
 add_filter( 'taxonomy_template_hierarchy', __NAMESPACE__ . '\modify_taxonomy_template_hierarchy' );
+
+add_filter( 'sensei_learning_mode_lesson_status_icon', __NAMESPACE__ . '\modify_lesson_status_icon_add_aria', 10, 2 );
 
 remove_filter( 'template_include', array( 'Sensei_Templates', 'template_loader' ), 10, 1 );
 
@@ -404,4 +407,35 @@ function modify_taxonomy_template_hierarchy( $templates ) {
 	}
 
 	return $templates;
+}
+
+/**
+ * Filter the lesson status icon.
+ *
+ * @param string $icon   The icon HTML.
+ * @param string $status The lesson status.
+ *
+ * @return string The updated icon HTML with aria data.
+ */
+function modify_lesson_status_icon_add_aria( $icon, $status ) {
+	// These statuses have been copied from Sensei\Blocks\Course_Theme\Course_Navigation\ICONS.
+	$labels = array(
+		'not-started' => __( 'Not started', 'wporg-learn' ),
+		'in-progress' => __( 'In progress', 'wporg-learn' ),
+		'ungraded'    => __( 'Ungraded', 'wporg-learn' ),
+		'completed'   => __( 'Completed', 'wporg-learn' ),
+		'failed'      => __( 'Failed', 'wporg-learn' ),
+		'locked'      => __( 'Locked', 'wporg-learn' ),
+		'preview'     => __( 'Preview', 'wporg-learn' ),
+	);
+
+	if ( ! isset( $labels[ $status ] ) ) {
+		return $icon;
+	}
+
+	$html = new WP_HTML_Tag_Processor( $icon );
+	$html->next_tag( 'svg' );
+	$html->set_attribute( 'aria-label', $labels[ $status ] );
+	$html->set_attribute( 'role', 'img' );
+	return $html->get_updated_html();
 }

--- a/wp-content/themes/pub/wporg-learn-2024/inc/block-hooks.php
+++ b/wp-content/themes/pub/wporg-learn-2024/inc/block-hooks.php
@@ -5,9 +5,13 @@
  * @package wporg-learn-2024
  */
 
-use function DevHub\is_parsed_post_type;
+namespace WordPressdotorg\Theme\Learn_2024\Block_Hooks;
+
+use WP_HTML_Tag_Processor, Sensei_Utils;
 
 add_filter( 'render_block_data', __NAMESPACE__ . '\modify_header_template_part' );
+add_filter( 'render_block_data', __NAMESPACE__ . '\modify_course_outline_lesson_block_attrs' );
+add_filter( 'render_block_sensei-lms/course-outline', __NAMESPACE__ . '\update_course_outline_block_add_aria', 10, 2 );
 
 /**
  * Update header template based on current query.
@@ -26,4 +30,63 @@ function modify_header_template_part( $parsed_block ) {
 		$parsed_block['attrs']['slug'] = 'header-second-archive-title';
 	}
 	return $parsed_block;
+}
+
+/**
+ * Add the status to the outline lesson block as a class, so that it can be
+ * read by the `update_course_outline_block_add_aria` function.
+ *
+ * @param array $parsed_block The block being rendered.
+ *
+ * @return array The updated block.
+ */
+function modify_course_outline_lesson_block_attrs( $parsed_block ) {
+	if ( 'sensei-lms/course-outline-lesson' !== $parsed_block['blockName'] ) {
+		return $parsed_block;
+	}
+
+	$status = 'not-started';
+	if ( isset( $parsed_block['attrs']['id'] ) ) {
+		$lesson_status = Sensei_Utils::user_lesson_status( $parsed_block['attrs']['id'] );
+		if ( $lesson_status ) {
+			$status = $lesson_status->comment_approved;
+		}
+	}
+
+	$parsed_block['attrs']['className'] = 'is-' . $status;
+
+	return $parsed_block;
+}
+
+/**
+ * Filter the course outline block to add accessible attributes.
+ *
+ * Note, this filters the entire `sensei-lms/course-outline` block instead of
+ * `sensei-lms/course-outline-lesson` due to Sensei's rendering of these
+ * blocks. The outline module & outline lesson blocks are not rendered
+ * individually, so they cannot be independently filtered.
+ *
+ * @param string $block_content The block content.
+ * @param array  $block         The full block, including name and attributes.
+ *
+ * @return string The updated icon HTML with aria data.
+ */
+function update_course_outline_block_add_aria( $block_content, $block ) {
+	$html = new WP_HTML_Tag_Processor( $block_content );
+
+	$label = '';
+	while ( $html->next_tag( array( 'class_name' => 'wp-block-sensei-lms-course-outline-lesson' ) ) ) {
+		if ( $html->has_class( 'is-complete' ) ) {
+			$label = __( 'Completed', 'wporg-learn' );
+		} else if ( $html->has_class( 'is-in-progress' ) ) {
+			$label = __( 'In progress', 'wporg-learn' );
+		} else {
+			$label = __( 'Not started', 'wporg-learn' );
+		}
+
+		$html->next_tag( 'svg' );
+		$html->set_attribute( 'aria-label', $label );
+		$html->set_attribute( 'role', 'img' );
+	}
+	return $html->get_updated_html();
 }

--- a/wp-content/themes/pub/wporg-learn-2024/src/course-outline/index.js
+++ b/wp-content/themes/pub/wporg-learn-2024/src/course-outline/index.js
@@ -1,4 +1,4 @@
-/* global wporgCourseOutlineData */
+/* global wporgCourseOutlineData, wporgCourseOutlineL10n */
 
 import { Icon, drafts, lockOutline } from '@wordpress/icons';
 import { renderToString } from '@wordpress/element';
@@ -15,7 +15,12 @@ document.addEventListener( 'DOMContentLoaded', () => {
 			if ( span && span.textContent.trim() === title ) {
 				const statusIcon = link.querySelector( '.wp-block-sensei-lms-course-outline-lesson__status' );
 				if ( statusIcon ) {
-					statusIcon.outerHTML = renderToString( <Icon icon={ drafts } transform={ 'scale(1.5)' } /> );
+					statusIcon.outerHTML = renderToString(
+						<>
+							<Icon icon={ drafts } style={ { transform: 'scale(1.5)' } } />
+							<span className="screen-reader-text">{ wporgCourseOutlineL10n.inProgress }</span>
+						</>
+					);
 				}
 			}
 		} );

--- a/wp-content/themes/pub/wporg-learn-2024/src/course-outline/index.js
+++ b/wp-content/themes/pub/wporg-learn-2024/src/course-outline/index.js
@@ -7,12 +7,17 @@ document.addEventListener( 'DOMContentLoaded', () => {
 	document.querySelectorAll( '.wp-block-sensei-lms-course-outline-lesson.is-in-progress' ).forEach( ( link ) => {
 		const statusIcon = link.querySelector( '.wp-block-sensei-lms-course-outline-lesson__status' );
 		if ( statusIcon ) {
-			statusIcon.outerHTML = renderToString(
-				<>
-					<Icon icon={ drafts } style={ { transform: 'scale(1.5)' } } />
-					<span className="screen-reader-text">{ wporgCourseOutlineL10n.inProgress }</span>
-				</>
+			const iconString = renderToString(
+				<Icon
+					icon={ drafts }
+					style={ { transform: 'scale(1.5)' } }
+					aria-label={ wporgCourseOutlineL10n.inProgress }
+					role="img"
+				/>
 			);
+
+			// Remove the `aria-hidden` attribute from the icon, as it has a readable label.
+			statusIcon.outerHTML = iconString.replace( ' aria-hidden="true"', '' );
 		}
 	} );
 

--- a/wp-content/themes/pub/wporg-learn-2024/src/course-outline/index.js
+++ b/wp-content/themes/pub/wporg-learn-2024/src/course-outline/index.js
@@ -4,6 +4,9 @@ import { Icon, drafts, lockOutline } from '@wordpress/icons';
 import { renderToString } from '@wordpress/element';
 
 document.addEventListener( 'DOMContentLoaded', () => {
+	/**
+	 * Find all in progress lessons, and replace the status icon with the Gutenberg-style `drafts` icon.
+	 */
 	document.querySelectorAll( '.wp-block-sensei-lms-course-outline-lesson.is-in-progress' ).forEach( ( link ) => {
 		const statusIcon = link.querySelector( '.wp-block-sensei-lms-course-outline-lesson__status' );
 		if ( statusIcon ) {
@@ -21,6 +24,9 @@ document.addEventListener( 'DOMContentLoaded', () => {
 		}
 	} );
 
+	/**
+	 * Find all locked lessons, and inject a `lock` icon after the title.
+	 */
 	document.querySelectorAll( '.wp-block-sensei-lms-course-outline-lesson.is-locked' ).forEach( ( link ) => {
 		const span = link.querySelector( 'span' );
 		if ( span ) {

--- a/wp-content/themes/pub/wporg-learn-2024/src/course-outline/index.js
+++ b/wp-content/themes/pub/wporg-learn-2024/src/course-outline/index.js
@@ -1,37 +1,33 @@
-/* global wporgCourseOutlineData, wporgCourseOutlineL10n */
+/* global wporgCourseOutlineL10n */
 
 import { Icon, drafts, lockOutline } from '@wordpress/icons';
 import { renderToString } from '@wordpress/element';
 
 document.addEventListener( 'DOMContentLoaded', () => {
-	if ( ! wporgCourseOutlineData ) {
-		return;
-	}
-
-	wporgCourseOutlineData[ 'in-progress' ]?.forEach( ( title ) => {
-		const lessonLinks = document.querySelectorAll( '.wp-block-sensei-lms-course-outline-lesson' );
-		lessonLinks.forEach( ( link ) => {
-			const span = link.querySelector( 'span' );
-			if ( span && span.textContent.trim() === title ) {
-				const statusIcon = link.querySelector( '.wp-block-sensei-lms-course-outline-lesson__status' );
-				if ( statusIcon ) {
-					statusIcon.outerHTML = renderToString(
-						<>
-							<Icon icon={ drafts } style={ { transform: 'scale(1.5)' } } />
-							<span className="screen-reader-text">{ wporgCourseOutlineL10n.inProgress }</span>
-						</>
-					);
-				}
-			}
-		} );
+	document.querySelectorAll( '.wp-block-sensei-lms-course-outline-lesson.is-in-progress' ).forEach( ( link ) => {
+		const statusIcon = link.querySelector( '.wp-block-sensei-lms-course-outline-lesson__status' );
+		if ( statusIcon ) {
+			statusIcon.outerHTML = renderToString(
+				<>
+					<Icon icon={ drafts } style={ { transform: 'scale(1.5)' } } />
+					<span className="screen-reader-text">{ wporgCourseOutlineL10n.inProgress }</span>
+				</>
+			);
+		}
 	} );
-	wporgCourseOutlineData.locked?.forEach( ( title ) => {
-		const lessonLinks = document.querySelectorAll( '.wp-block-sensei-lms-course-outline-lesson' );
-		lessonLinks.forEach( ( link ) => {
-			const span = link.querySelector( 'span' );
-			if ( span && span.textContent.trim() === title ) {
-				span.insertAdjacentHTML( 'afterend', renderToString( <Icon icon={ lockOutline } /> ) );
-			}
-		} );
+
+	document.querySelectorAll( '.wp-block-sensei-lms-course-outline-lesson.is-locked' ).forEach( ( link ) => {
+		const span = link.querySelector( 'span' );
+		if ( span ) {
+			span.insertAdjacentHTML(
+				'afterend',
+				renderToString(
+					<>
+						<Icon icon={ lockOutline } />
+						<span className="screen-reader-text">{ wporgCourseOutlineL10n.locked }</span>
+					</>
+				)
+			);
+		}
 	} );
 } );

--- a/wp-content/themes/pub/wporg-learn-2024/src/course-outline/index.php
+++ b/wp-content/themes/pub/wporg-learn-2024/src/course-outline/index.php
@@ -22,58 +22,13 @@ function enqueue_assets() {
 		true
 	);
 
-	$lesson_data = get_lesson_data();
-	wp_localize_script(
-		'wporg-learn-2024-course-outline',
-		'wporgCourseOutlineData',
-		$lesson_data
-	);
-
 	wp_localize_script(
 		'wporg-learn-2024-course-outline',
 		'wporgCourseOutlineL10n',
 		array(
 			'inProgress' => __( 'In progress', 'wporg-learn' ),
+			'locked' => __( 'Locked', 'wporg-learn' ),
 		)
 	);
 }
 add_action( 'wp_enqueue_scripts', 'enqueue_assets' );
-
-/**
- * Get the titles of specific status lessons.
- *
- * The returned array $lesson_data has the following structure:
- * [
- *     'in-progress' => [ (string) The title of the lesson, ... ],
- *     'locked' => [ (string) The title of the lesson, ... ],
- * ]
- *
- * @return array $lesson_data Array of lesson data.
- */
-function get_lesson_data() {
-	$lesson_data = array();
-	$lesson_ids = Sensei()->course->course_lessons( get_the_ID(), 'publish', 'ids' );
-
-	foreach ( $lesson_ids as $lesson_id ) {
-		$user_lesson_status = Sensei_Utils::user_lesson_status( $lesson_id, get_current_user_id() );
-		$lesson_title = get_the_title( $lesson_id );
-		$is_preview_lesson = Sensei_Utils::is_preview_lesson( $lesson_id );
-
-		// Add in-progress lesson title to lesson data
-		if ( $user_lesson_status ) {
-			$lesson_status = $user_lesson_status->comment_approved;
-			if ( 'in-progress' === $lesson_status ) {
-				$lesson_data['in-progress'][] = $lesson_title;
-			}
-		}
-
-		// Add previewable and prerequisite-required lesson title to lesson data
-		if ( ( ! $is_preview_lesson && ! Sensei_Course::is_user_enrolled( get_the_ID() ) )
-			|| ! Sensei_Lesson::is_prerequisite_complete( $lesson_id, get_current_user_id() )
-		) {
-			$lesson_data['locked'][] = $lesson_title;
-		}
-	}
-
-	return $lesson_data;
-}

--- a/wp-content/themes/pub/wporg-learn-2024/src/course-outline/index.php
+++ b/wp-content/themes/pub/wporg-learn-2024/src/course-outline/index.php
@@ -28,6 +28,14 @@ function enqueue_assets() {
 		'wporgCourseOutlineData',
 		$lesson_data
 	);
+
+	wp_localize_script(
+		'wporg-learn-2024-course-outline',
+		'wporgCourseOutlineL10n',
+		array(
+			'inProgress' => __( 'In progress', 'wporg-learn' ),
+		)
+	);
 }
 add_action( 'wp_enqueue_scripts', 'enqueue_assets' );
 


### PR DESCRIPTION
Fixes #2780 — This adds labels (`aria-label` & `role=img`) to the Sensei-provided icons, and adds a `screen-reader-text` label to the custom "in progress" icon & the lock icon. This also fixes a minor style issue in Safari.

I used the `WP_HTML_Tag_Processor` to make these changes, which works great for the navigation icon, as it has a filter. The course outline block doesn't use this, though, so it was a little awkward for the `sensei-lms/course-outline` block. I ended up adding a class to each lesson block data, which is then added to the markup and available when rendering the full outline block markup.

If you visit a course you're working through, you'll now hear:

- Completed Introduction to WordPress
- In Progress WordPress essentials: Domains and hosting
- Not started Choosing and installing a theme

You could also hear the following

- Not started Choosing and installing a theme PREVIEW
- Not started WordPress essentials: Domains and hosting Locked

But in the lesson sidebar, it reads as

- Preview Choosing and installing a theme
- Locked WordPress essentials: Domains and hosting

**Screenshots/Code**

The SVGs with the new attributes:

Navigation (sidebar) https://learn.wordpress.org/lesson/introduction-to-wordpress-2/?new-theme=1

```
<svg aria-label="In progress" role="img" class="sensei-lms-course-navigation-lesson__status"><use href="http://localhost:8888/wp-content/plugins/sensei-lms/assets/dist/icons/sensei-sprite.svg?v=4.24.1#sensei-sprite-half-filled-circle"></use></svg>
```

Outline (on course page) https://learn.wordpress.org/course/beginner-wordpress-user/?new-theme=1

```
<svg aria-label="Completed" role="img" class="wp-block-sensei-lms-course-outline-lesson__status"><use href="http://localhost:8888/wp-content/plugins/sensei-lms/assets/dist/icons/sensei-sprite.svg?v=4.24.1#sensei-sprite-checked"></use></svg>
```

For the style issue, the scale wasn't working for me. Switching to an inline style instead of the `transform` attribute fixed it.

| Before | After |
|---|---|
| <img width="402" alt="Screenshot 2024-07-26 at 5 33 57 PM" src="https://github.com/user-attachments/assets/5702426c-bc16-44cc-ab22-02f65a0e1fa1"> | <img width="523" alt="Screenshot 2024-07-26 at 5 33 38 PM" src="https://github.com/user-attachments/assets/00ef5f5e-30e2-4f08-8288-9eca28180553"> |
