### PR TITLE
Update lesson page progress bar inner color

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
@@ -9,7 +9,7 @@ body.sensei {
 	--sensei-button-text-color: var(--wp--preset--color--white);
 
 	--sensei-course-progress-bar-color: var(--wp--custom--color--border);
-	--sensei-course-progress-bar-inner-color: var(--wp--preset--color--blueberry-1);
+	--sensei-course-progress-bar-inner-color: var(--wp--custom--color--green-50);
 	--sensei-lesson-meta-color: var(--wp--preset--color--charcoal-4);
 	--sensei-module-lesson-color: var(--wp--preset--color--charcoal-1);
 


### PR DESCRIPTION
This was previously discussed in this [ticket](https://github.com/WordPress/Learn/pull/2768#issue-2428486545), and design feedback was sought but has not yet been received. However, this change appears to be very [reasonable](https://github.com/WordPress/Learn/pull/2768#issuecomment-2249030996), so the adjustment has been made for now. If any feedback later indicates that it is not suitable, we can revert it. It's a simple change.

## Screenshots

**Progress Bar**
![image](https://github.com/user-attachments/assets/14c11f4c-d295-4bdf-bc43-8da07ca6ddac)
![image](https://github.com/user-attachments/assets/6c0f4a91-f2c5-4da8-be45-46173766ee55)