### PR TITLE
Filters: Add prefix label to the single query filters

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2024/inc/block-config.php
+++ b/wp-content/themes/pub/wporg-learn-2024/inc/block-config.php
@@ -59,7 +59,7 @@ function get_content_type_options( $options ) {
 
 	return array(
 		'label' => sprintf( __( 'Type: %s', 'wporg-learn' ), $label ),
-		'title' => __( 'Content Type', 'wporg-learn' ),
+		'title' => __( 'Content type', 'wporg-learn' ),
 		'key' => 'post_type',
 		'action' => get_filtered_url(),
 		'options' => $options,
@@ -100,24 +100,18 @@ function create_level_options( $levels ) {
 		$levels,
 	);
 
-	$label = __( 'Level', 'wporg-learn' );
+	$label = __( 'All', 'wporg-learn' );
 
 	$selected_slug = $wp_query->get( 'wporg_lesson_level' );
 	if ( $selected_slug ) {
 		// Find the selected level from $levels by slug and then get the name.
-		$selected_level = array_filter(
-			$levels,
-			function ( $level ) use ( $selected_slug ) {
-				return $level->slug === $selected_slug;
-			}
-		);
+		$selected_level = wp_list_filter( $levels, array( 'slug' => $selected_slug ) );
 		if ( ! empty( $selected_level ) ) {
 			$selected_level = array_shift( $selected_level );
 			$label = $selected_level->name;
 		}
 	} else {
 		$selected_slug = 'all';
-		$label = __( 'All', 'wporg-learn' );
 	}
 
 	return array(

--- a/wp-content/themes/pub/wporg-learn-2024/inc/block-config.php
+++ b/wp-content/themes/pub/wporg-learn-2024/inc/block-config.php
@@ -58,7 +58,7 @@ function get_content_type_options( $options ) {
 	$label = $options[ $selected_slug ] ?? $options['any'];
 
 	return array(
-		'label' => $label,
+		'label' => sprintf( __( 'Type: %s', 'wporg-learn' ), $label ),
 		'title' => __( 'Content Type', 'wporg-learn' ),
 		'key' => 'post_type',
 		'action' => get_filtered_url(),
@@ -121,7 +121,7 @@ function create_level_options( $levels ) {
 	}
 
 	return array(
-		'label' => $label,
+		'label' => sprintf( __( 'Level: %s', 'wporg-learn' ), $label ),
 		'title' => __( 'Level', 'wporg-learn' ),
 		'key' => 'wporg_lesson_level',
 		'action' => get_filtered_url(),
@@ -534,7 +534,7 @@ function get_student_course_options( $options ) {
 	$label = $options[ $selected_slug ] ?? $options['all'];
 
 	return array(
-		'label' => $label,
+		'label' => sprintf( __( 'Status: %s', 'wporg-learn' ), $label ),
 		'title' => __( 'Completion status', 'wporg-learn' ),
 		'key' => $key,
 		'action' => get_filtered_url(),


### PR DESCRIPTION
Fixes #2784 - this prefixes the single select filters with the filter name, to give it a more accessible name.

- Level filter is prefixed with "Level: ", ex "Level: Advanced"
- Content type filter is prefixed with "Type: ", ex "Type: Course"
- Completion status is prefixed with "Status: ", ex "Status: Completed"

cc @ndiego @kathrynwp Do those prefixes make sense? Using the full title for the last two would be too long, IMO, so I went with a short version.

**Screenshots:**

[Learning pathway](https://learn.wordpress.org/learning-pathway/developer/)

| Before | After |
|---|---|
| ![Screen Shot 2024-07-31 at 13 48 08](https://github.com/user-attachments/assets/42479df4-b7c6-46d1-98b0-19cf150ec086) | ![Screen Shot 2024-07-31 at 13 42 41](https://github.com/user-attachments/assets/37cfeaae-e565-4106-b0ce-7836c3288b1f) |

[Lesson archive (with "Advanced" filter)](https://learn.wordpress.org/lessons/?post_type=lesson&wporg_lesson_level=advanced)

| Before | After |
|---|---|
| ![Screen Shot 2024-07-31 at 13 48 26](https://github.com/user-attachments/assets/e67d066c-04ea-420d-9b5c-6fed6f44d09d) | ![Screen Shot 2024-07-31 at 13 43 48](https://github.com/user-attachments/assets/9cc33e61-4b16-4a6e-a5bb-e073d8f2a12d) |

[Search results](https://learn.wordpress.org/?s=wordpress)

| Before | After |
|---|---|
| ![Screen Shot 2024-07-31 at 13 48 45](https://github.com/user-attachments/assets/473cd78c-3ce6-4c1e-9740-3b47c9b1bbe4) | ![Screen Shot 2024-07-31 at 13 45 02](https://github.com/user-attachments/assets/bd2ad43a-f34f-46d9-828b-c60eb3a908df) |

[My courses](https://learn.wordpress.org/my-courses/)

| Before | After |
|---|---|
| ![Screen Shot 2024-07-31 at 13 52 41](https://github.com/user-attachments/assets/3694db5c-c3d0-4823-9027-04cf7c07bf90) | ![Screen Shot 2024-07-31 at 13 52 54](https://github.com/user-attachments/assets/bdd51b85-cacc-4bae-8e31-4f7c48688208) |


