### PR TITLE
Query modifications: Handle the `all` level query var early

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2024/inc/query.php
+++ b/wp-content/themes/pub/wporg-learn-2024/inc/query.php
@@ -6,8 +6,8 @@
 namespace WordPressdotorg\Theme\Learn_2024\Query;
 
 add_action( 'pre_get_posts', __NAMESPACE__ . '\add_language_to_archive_queries' );
-add_action( 'pre_get_posts', __NAMESPACE__ . '\handle_all_level_query' );
 add_action( 'pre_get_posts', __NAMESPACE__ . '\add_excluded_to_lesson_archive_query' );
+add_filter( 'request', __NAMESPACE__ . '\handle_all_level_query' );
 
 /**
  * Modify the query by adding meta query for language if set.
@@ -40,29 +40,6 @@ function add_language_to_archive_queries( $query ) {
 			$query->set( 'meta_query', $meta_query );
 		}
 	}
-
-	return $query;
-}
-
-/**
- * Modify the main query.
- * If the 'all' level filter is set in the query, remove it to return all posts.
- *
- * @param WP_Query $query The main query.
- * @return WP_Query
- */
-function handle_all_level_query( $query ) {
-	if ( is_admin() || ! $query->is_main_query() ) {
-		return;
-	}
-
-	$level = $query->get( 'wporg_lesson_level' );
-
-	if ( 'all' === $level ) {
-		$query->set( 'wporg_lesson_level', '' );
-	}
-
-	return $query;
 }
 
 /**
@@ -101,4 +78,27 @@ function add_excluded_to_lesson_archive_query( $query ) {
 
 		$query->set( 'meta_query', $meta_query );
 	}
+}
+
+/**
+ * Modify the request.
+ *
+ * Update the query_vars to reset 'all' to an empty string.
+ *
+ * @param array $query_vars The array of requested query variables.
+ *
+ * @return array
+ */
+function handle_all_level_query( $query_vars ) {
+	if ( is_admin() ) {
+		return;
+	}
+
+	$level = $query_vars['wporg_lesson_level'] ?? '';
+
+	if ( 'all' === $level ) {
+		$query_vars['wporg_lesson_level'] = '';
+	}
+
+	return $query_vars;
 }


### PR DESCRIPTION
This fixes a PHP notice on the "all level" lesson page. I noticed this in testing and was able to reproduce on my sandbox. The `wporg_lesson_level` reset code was happening too late, and the `$wp_query` had a tax_query set on it, which confused the `get_queried_object()` [in the navigation blocks](https://github.com/WordPress/gutenberg/blob/6581dfb8f1c605119db776f023a83d655209bfa8/packages/block-library/src/navigation-link/index.php#L202).

Going to `/?wporg_lesson_level=all&post_type=lesson` gave me a few of these notices:

```
Notice: Trying to get property 'name' of non-object in /var/www/html/wp-content/plugins/gutenberg/build/block-library/blocks/navigation-link.php on line 202
Notice: Trying to get property 'name' of non-object in /var/www/html/wp-content/plugins/gutenberg/build/block-library/blocks/navigation-submenu.php on line 91
```

So this PR moves the `handle_all_level_query` callback to the `request` filter, which happens before any query parsing is triggered.

**To test**

Use a debug tool to see PHP notices (the local env should show these, or Query Monitor).

1. Go to the lessons page
2. Open the  "Level" filter, select a level, apply
3. Open the  "Level" filter again, select "all", apply
4. Before this PR, the page loads with PHP notices
5. After, there should be no notices

Alternately, go to `/?wporg_lesson_level=all&post_type=lesson` directly, but the above is how a user might get there.