### PR TITLE
Filter searches by allowed post types if post_type is not set

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2024/inc/block-config.php
+++ b/wp-content/themes/pub/wporg-learn-2024/inc/block-config.php
@@ -54,7 +54,8 @@ function get_content_type_options( $options ) {
 		'lesson' => __( 'Lesson', 'wporg-learn' ),
 	);
 
-	$selected_slug = $wp_query->get( 'post_type' ) ? $wp_query->get( 'post_type' ) : 'any';
+	$post_type = $wp_query->get( 'post_type' );
+	$selected_slug = is_string( $post_type ) ? $post_type : 'any';
 	$label = $options[ $selected_slug ] ?? $options['any'];
 
 	return array(

--- a/wp-content/themes/pub/wporg-learn-2024/inc/query.php
+++ b/wp-content/themes/pub/wporg-learn-2024/inc/query.php
@@ -7,6 +7,7 @@ namespace WordPressdotorg\Theme\Learn_2024\Query;
 
 add_action( 'pre_get_posts', __NAMESPACE__ . '\add_language_to_archive_queries' );
 add_action( 'pre_get_posts', __NAMESPACE__ . '\add_excluded_to_lesson_archive_query' );
+add_action( 'pre_get_posts', __NAMESPACE__ . '\filter_search_queries_by_post_type' );
 add_filter( 'request', __NAMESPACE__ . '\handle_all_level_query' );
 
 /**
@@ -78,6 +79,23 @@ function add_excluded_to_lesson_archive_query( $query ) {
 
 		$query->set( 'meta_query', $meta_query );
 	}
+}
+
+/**
+ * Filter search queries by post type.
+ * Only include courses and lessons in search results unless post_type is set, eg. for an archive search.
+ *
+ * @param WP_Query $query The query object.
+ * @return WP_Query The modified query object.
+ */
+function filter_search_queries_by_post_type( $query ) {
+	if ( ! is_admin() && $query->is_search() && $query->is_main_query() ) {
+		if ( ! $query->get( 'post_type' ) ) {
+			$query->set( 'post_type', array( 'course', 'lesson' ) );
+		}
+	}
+
+	return $query;
 }
 
 /**


### PR DESCRIPTION
Fixes https://github.com/WordPress/Learn/issues/2815 by allowing only lessons and courses in global searches where `post_type` is not set. On archives this is set, so they should be unaffected.

### Testing

1. Using the global search from the home page search for an existing tutorial or lesson plan. It should not show in the results.
2. On the tutorial or lesson plan archive perform a search. The results should be unaffected.
3. On the lesson or course archive perform a search. The results should be unaffected.