### PR TITLE
Fix performance: unused and blocking resources

### DIFF
--- a/wp-content/mu-plugins/pub/locale-switcher/locale-switcher.php
+++ b/wp-content/mu-plugins/pub/locale-switcher/locale-switcher.php
@@ -108,7 +108,7 @@ function enqueue_assets() {
 		plugins_url( 'build/index.js', __FILE__ ),
 		$script_data['dependencies'],
 		$script_data['version'],
-		true
+		array( 'strategy' => 'defer' )
 	);
 
 	$locale_options = get_locale_options();

--- a/wp-content/plugins/wporg-learn/inc/locale.php
+++ b/wp-content/plugins/wporg-learn/inc/locale.php
@@ -64,10 +64,10 @@ function register_assets() {
 	// Locale notice script.
 	wp_enqueue_script(
 		'locale-notice',
-		get_build_url() . '/locale-notice.js',
+		get_build_url() . 'locale-notice.js',
 		array( 'jquery', 'utils' ),
 		filemtime( get_build_path() . '/locale-notice.js' ),
-		true
+		array( 'strategy' => 'defer' )
 	);
 
 	wp_localize_script(

--- a/wp-content/themes/pub/wporg-learn-2024/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2024/functions.php
@@ -36,6 +36,7 @@ add_action( 'sensei_quiz_question_inside_before', __NAMESPACE__ . '\sensei_quest
 add_action( 'wp', __NAMESPACE__ . '\dequeue_lesson_archive_video_scripts', 20 );
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\maybe_enqueue_sensei_assets', 100 );
+add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\defer_scripts', 11 );
 
 // Remove Jetpack CSS on frontend
 add_filter( 'jetpack_implode_frontend_css', '__return_false', 99 );
@@ -184,6 +185,27 @@ function maybe_enqueue_sensei_assets() {
 			return $classes;
 		} );
 	}
+}
+
+/**
+ * Defer frontend script loading for performance optimization.
+ */
+function defer_scripts() {
+	if ( is_admin() ) {
+		return;
+	}
+
+	wp_script_add_data( 'jquery-core', 'strategy', 'defer' );
+	wp_script_add_data( 'jquery-core', 'group', 0 );
+
+	wp_script_add_data( 'jquery-migrate', 'strategy', 'defer' );
+	wp_script_add_data( 'jquery-migrate', 'group', 0 );
+
+	wp_script_add_data( 'jetpack-block-subscriptions', 'strategy', 'defer' );
+	wp_script_add_data( 'jetpack-block-subscriptions', 'group', 0 );
+
+	wp_script_add_data( 'utils', 'strategy', 'defer' );
+	wp_script_add_data( 'utils', 'group', 0 );
 }
 
 /**

--- a/wp-content/themes/pub/wporg-learn-2024/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2024/functions.php
@@ -36,6 +36,8 @@ add_action( 'sensei_quiz_question_inside_before', __NAMESPACE__ . '\sensei_quest
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\maybe_enqueue_sensei_assets', 100 );
 
+// Remove Jetpack CSS on frontend
+add_filter( 'jetpack_implode_frontend_css', '__return_false', 99 );
 add_filter( 'post_thumbnail_html', __NAMESPACE__ . '\set_default_featured_image', 10, 5 );
 add_filter( 'search_template_hierarchy', __NAMESPACE__ . '\modify_search_template' );
 add_filter( 'sensei_learning_mode_lesson_status_icon', __NAMESPACE__ . '\modify_lesson_status_icon_add_aria', 10, 2 );

--- a/wp-content/themes/pub/wporg-learn-2024/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2024/functions.php
@@ -30,11 +30,15 @@ require_once __DIR__ . '/inc/template-helpers.php';
  * Actions and filters.
  */
 add_action( 'after_setup_theme', __NAMESPACE__ . '\setup' );
-add_filter( 'wp_get_attachment_image_attributes', __NAMESPACE__ . '\eager_load_first_card_rows_images', 10, 3 );
+add_action( 'sensei_quiz_question_inside_after', __NAMESPACE__ . '\sensei_question_add_closing_fieldset' );
+// Attached at 50 to inject after title, description, etc, so that only answers are in the fieldset.
+add_action( 'sensei_quiz_question_inside_before', __NAMESPACE__ . '\sensei_question_add_opening_fieldset', 50 );
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\maybe_enqueue_sensei_assets', 100 );
 
 add_filter( 'post_thumbnail_html', __NAMESPACE__ . '\set_default_featured_image', 10, 5 );
+add_filter( 'search_template_hierarchy', __NAMESPACE__ . '\modify_search_template' );
+add_filter( 'sensei_learning_mode_lesson_status_icon', __NAMESPACE__ . '\modify_lesson_status_icon_add_aria', 10, 2 );
 add_filter( 'sensei_register_post_type_course', function( $args ) {
 	$args['has_archive'] = 'courses';
 	return $args;
@@ -44,15 +48,10 @@ add_filter( 'sensei_register_post_type_lesson', function( $args ) {
 	return $args;
 } );
 add_filter( 'single_template_hierarchy', __NAMESPACE__ . '\modify_single_template' );
-add_filter( 'search_template_hierarchy', __NAMESPACE__ . '\modify_search_template' );
+add_filter( 'taxonomy_template_hierarchy', __NAMESPACE__ . '\modify_taxonomy_template_hierarchy' );
+add_filter( 'wp_get_attachment_image_attributes', __NAMESPACE__ . '\eager_load_first_card_rows_images', 10, 3 );
 add_filter( 'wporg_block_navigation_menus', __NAMESPACE__ . '\add_site_navigation_menus' );
 add_filter( 'wporg_block_site_breadcrumbs', __NAMESPACE__ . '\set_site_breadcrumbs' );
-add_filter( 'taxonomy_template_hierarchy', __NAMESPACE__ . '\modify_taxonomy_template_hierarchy' );
-
-// Attached at 50 to inject after title, description, etc, so that only answers are in the fieldset.
-add_action( 'sensei_quiz_question_inside_before', __NAMESPACE__ . '\sensei_question_add_opening_fieldset', 50 );
-add_action( 'sensei_quiz_question_inside_after', __NAMESPACE__ . '\sensei_question_add_closing_fieldset' );
-add_filter( 'sensei_learning_mode_lesson_status_icon', __NAMESPACE__ . '\modify_lesson_status_icon_add_aria', 10, 2 );
 
 remove_filter( 'template_include', array( 'Sensei_Templates', 'template_loader' ), 10, 1 );
 

--- a/wp-content/themes/pub/wporg-learn-2024/src/course-outline/index.php
+++ b/wp-content/themes/pub/wporg-learn-2024/src/course-outline/index.php
@@ -19,7 +19,7 @@ function enqueue_assets() {
 		get_stylesheet_directory_uri() . '/build/course-outline/index.js',
 		$script_asset['dependencies'],
 		$script_asset['version'],
-		true
+		array( 'strategy' => 'defer' )
 	);
 
 	wp_localize_script(


### PR DESCRIPTION
Fixes #2679

There are some unused resources loaded by plugins which impact FCP and LCP:

<img src="https://github.com/user-attachments/assets/c99e21ed-11c0-4685-9d2d-f49bab16f6bf" width="400">

Note that dashicons CSS also affects load performance, but can't be removed while the admin bar is always shown for login/registration.

This PR improves loading performance by:

- [x] Only loading necessary Jetpack CSS
- [x] Removing Vimeo player JS on lesson archive
- [x] Removing YouTube player JS on lesson archive
- [x] Deferring frontend scripts where possible (locale notice and dependencies, course outline) 

There is still a large performance hit from loading the WordPress components package for the locale switcher but this will be addressed separately. If TranslatePress is adopted the locale switcher may not be necessary at all, or otherwise we might want to rewrite it using native web UI components.