### PR TITLE
Support excluding posts based on taxonomy in search queries

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2024/inc/query.php
+++ b/wp-content/themes/pub/wporg-learn-2024/inc/query.php
@@ -9,6 +9,8 @@ add_action( 'pre_get_posts', __NAMESPACE__ . '\add_language_to_archive_queries' 
 add_action( 'pre_get_posts', __NAMESPACE__ . '\add_excluded_to_lesson_archive_query' );
 add_action( 'pre_get_posts', __NAMESPACE__ . '\filter_search_queries_by_post_type' );
 add_filter( 'request', __NAMESPACE__ . '\handle_all_level_query' );
+add_filter( 'jetpack_search_es_wp_query_args', __NAMESPACE__ . '\filter_jetpack_wp_search_query', 10, 2 );
+add_filter( 'jetpack_search_es_query_args', __NAMESPACE__ . '\filter_jetpack_es_search_query', 10, 2 );
 
 /**
  * Modify the query by adding meta query for language if set.
@@ -136,4 +138,49 @@ function handle_all_level_query( $query_vars ) {
 	}
 
 	return $query_vars;
+}
+
+/**
+ * Remove incorrectly applied "show" taxonomy search filter from Jetpack Search queries, if set.
+ *
+ * @see https://developer.jetpack.com/hooks/jetpack_search_es_wp_query_args/
+ *
+ * @param array     $query_args The current query args, in WP_Query format.
+ * @param \WP_Query $query     The original query object.
+ */
+function filter_jetpack_wp_search_query( $query_args, $query ) {
+	if ( isset( $query_args['terms']['show'] ) ) {
+		unset( $query_args['terms']['show'] );
+	}
+
+	return $query_args;
+}
+
+/**
+ * Modify the underlying ES query that is passed to the Jetpack Search endpoint to support NOT IN slug tax queries.
+ *
+ * @see https://developer.jetpack.com/hooks/jetpack_search_es_query_args/
+ *
+ * @param array     $es_query_args The current query args, in WP_Query format.
+ * @param \WP_Query $query         The original query object.
+ */
+function filter_jetpack_es_search_query( $es_query_args, $query ) {
+	$tax_query = $query->get( 'tax_query', array() );
+	$must_not  = array();
+	foreach ( $tax_query as $tax_query_item ) {
+		if ( isset( $tax_query_item['operator'] ) && 'NOT IN' === $tax_query_item['operator'] && isset( $tax_query_item['field'] ) && 'slug' === $tax_query_item['field'] ) {
+			$must_not[] = array( 'terms' => array( "taxonomy.{$tax_query_item['taxonomy']}.slug" => (array) $tax_query_item['terms'] ) );
+		}
+	}
+	if ( empty( $must_not ) ) {
+		return $es_query_args;
+	}
+	$es_query_args['query'] = array(
+		'bool' => array(
+			'must' => array( $es_query_args['query'] ),
+			'must_not' => $must_not,
+		),
+	);
+
+	return $es_query_args;
 }


### PR DESCRIPTION
Attempt to fix https://github.com/WordPress/Learn/issues/2735

In https://github.com/WordPress/Learn/pull/2830 a taxonomy `show` was added. It also added a `NOT IN` condition to the search query, and posts with value `hidden` should not appear in search results.

It appears that Jetpack Search, which is used as a backend for searching lessons, does not support `NOT IN` queries for taxonomies out of the box. The code for converting tax_query is [here](https://github.com/Automattic/jetpack/blob/b1fe483220715ce11c87c6c0e62e005abd34e661/projects/packages/search/src/classic-search/class-classic-search.php#L661-L692). It returns early because `queried_terms` isn't set. If it would be set, it would actually be worse, as it would only include hidden results instead of excluding them.

In this PR, I propose to add two Jetpack Search filters to manually fix the query. One excludes `show` from `terms` in case `queried_terms` would be present, and the other converts `NOT IN` queries to `must_not` query in Jetpack Search.

I don't have access to .org sandbox, so I tested it by adding a hacky `print_r`:

```
if ( isset($this->query['s']) ) {
	$search = \Automattic\Jetpack\Search\Classic_Search::instance(47261184);
	$search->do_search( $this);
	echo '<pre>';
	print_r($search->get_search_result());
	die();
}
```

in `wp-includes/class.wp-query.php` on line 3161 (before applying filter `posts_pre_query`, which is what normally triggers Jetpack Search) in WP Learn Docker container. I've verified that the problematic post_id disappeared when visiting http://localhost:8888/lessons/?s=quiz&post_type=lesson.