### PR TITLE
Remove linking tutorials with lessons

### DIFF
--- a/wp-content/plugins/wporg-learn/inc/post-meta.php
+++ b/wp-content/plugins/wporg-learn/inc/post-meta.php
@@ -483,13 +483,6 @@ function render_metabox_workshop_details( WP_Post $post ) {
 	$duration_interval = get_workshop_duration( $post, 'interval' );
 	$locales           = get_locales_with_english_names();
 	$captions          = get_post_meta( $post->ID, 'video_caption_language' ) ?: array();
-	$all_lessons       = get_posts( array(
-		'post_type'      => 'lesson',
-		'post_status'    => 'publish',
-		'posts_per_page' => 999,
-		'orderby'        => 'title',
-		'order'          => 'asc',
-	) );
 
 	require get_views_path() . 'metabox-workshop-details.php';
 }
@@ -575,9 +568,6 @@ function save_workshop_meta_fields( $post_id ) {
 			add_post_meta( $post_id, 'video_caption_language', $caption );
 		}
 	}
-
-	$lesson_id = filter_input( INPUT_POST, 'linked-lesson-id', FILTER_SANITIZE_NUMBER_INT );
-	update_post_meta( $post_id, 'linked_lesson_id', $lesson_id );
 
 	$presenter_wporg_username = filter_input( INPUT_POST, 'presenter-wporg-username' );
 	$presenter_usernames      = array_map( 'trim', explode( ',', $presenter_wporg_username ) );

--- a/wp-content/plugins/wporg-learn/views/metabox-workshop-details.php
+++ b/wp-content/plugins/wporg-learn/views/metabox-workshop-details.php
@@ -7,8 +7,6 @@
 /** @var DateInterval $duration_interval */
 /** @var array $locales */
 /** @var array $captions */
-/** @var array $all_lessons */
-/** @var array $selected_lessons */
 ?>
 
 <p>
@@ -76,20 +74,8 @@
 	</select>
 </p>
 
-<p>
-	<label for="workshop-linked-lesson-id"><?php esc_html_e( 'Linked Quiz', 'wporg_learn' ); ?></label>
-	<select id="workshop-linked-lesson-id" name="linked-lesson-id" style="width: 100%;">
-		<option value="" disabled hidden <?php selected( ! $post->linked_lesson_id ); ?>></option>
-		<?php foreach ( $all_lessons as $lesson ) : ?>
-			<option value="<?php echo esc_attr( $lesson->ID ); ?>" <?php selected( $lesson->ID, $post->linked_lesson_id ); ?>>
-				<?php echo esc_html( get_the_title( $lesson->ID ) ); ?>
-			</option>
-		<?php endforeach; ?>
-	</select>
-</p>
-
 <script>
 	( function( $ ) {
-		$( '#workshop-video-language, #workshop-video-caption-language, #workshop-linked-lesson-id' ).select2();
+		$( '#workshop-video-language, #workshop-video-caption-language' ).select2();
 	} )( jQuery );
 </script>


### PR DESCRIPTION
This functionality exists to link a tutorial with a lesson quiz, and is no longer needed with the new site architecture.

Closes #2823