### PR TITLE
Redirect deprecated tutorials to wordpress.tv

### DIFF
--- a/wp-content/plugins/wporg-learn/inc/redirects.php
+++ b/wp-content/plugins/wporg-learn/inc/redirects.php
@@ -44,6 +44,10 @@ function wporg_learn_redirect_old_urls() {
 		'/social-learning'                => '/online-workshops',
 		'/workshop-presenter-application' => '/tutorial-presenter-application',
 		'/report-content-errors'          => '/report-content-feedback',
+		// External redirects.
+		'/tutorial/block-editor-01-basics/'      => 'https://wordpress.tv/2021/06/18/shusei-toda-naoko-takano-block-editor-01-basics/',
+		'/tutorial/block-editor-02-text-blocks/' => 'https://wordpress.tv/2021/06/03/shusei-toda-block-editor-02-text-blocks/',
+		'/tutorial/ja-login-password-reset/'     => 'https://wordpress.tv/2021/02/16/login-password-reset/',
 	);
 
 	// Use `REQUEST_URI` rather than `$wp->request`, to get the entire source URI including url parameters.
@@ -52,14 +56,17 @@ function wporg_learn_redirect_old_urls() {
 	foreach ( $redirects as $source => $destination ) {
 		if ( str_starts_with( $request, $source ) ) {
 			$redirect = $destination;
+			$code = 301;
 
 			// Append any extra request parameters.
 			if ( strlen( $request ) > strlen( $source ) ) {
 				$redirect .= substr( $request, strlen( $source ) );
 			}
 
-			wp_safe_redirect( $redirect );
-			die();
+			str_starts_with( $destination, 'https://' )
+				? wp_redirect( $redirect, $code, 'Learn WordPress' )
+				: wp_safe_redirect( $redirect, $code );
+			exit;
 		}
 	}
 }

--- a/wp-content/plugins/wporg-learn/inc/redirects.php
+++ b/wp-content/plugins/wporg-learn/inc/redirects.php
@@ -5,6 +5,18 @@ namespace WPOrg_Learn\Redirects;
 add_action( 'template_redirect', __NAMESPACE__ . '\wporg_learn_redirect_meetings' );
 add_action( 'template_redirect', __NAMESPACE__ . '\wporg_learn_redirect_old_urls' );
 
+add_filter( 'allowed_redirect_hosts', __NAMESPACE__ . '\wporg_learn_allowed_redirect_hosts' );
+
+/**
+ * Add allowed redirect hosts.
+ *
+ * @param array $hosts The array of allowed redirect hosts.
+ * @return array The updated array of allowed redirect hosts.
+ */
+function wporg_learn_allowed_redirect_hosts( $hosts ) {
+	return array_merge( $hosts, array( 'wordpress.tv' ) );
+};
+
 /**
  * Redirect meeting posts to associated link
  *
@@ -39,12 +51,11 @@ function wporg_learn_redirect_old_urls() {
 
 	$redirects = array(
 		// Source => Destination, any characters after the source will be appended to the destination.
-		'/workshop/'                      => '/tutorial/',
-		'/workshops'                      => '/tutorials',
-		'/social-learning'                => '/online-workshops',
-		'/workshop-presenter-application' => '/tutorial-presenter-application',
-		'/report-content-errors'          => '/report-content-feedback',
-		// External redirects.
+		'/workshop/'                             => '/tutorial/',
+		'/workshops'                             => '/tutorials',
+		'/social-learning'                       => '/online-workshops',
+		'/workshop-presenter-application'        => '/tutorial-presenter-application',
+		'/report-content-errors'                 => '/report-content-feedback',
 		'/tutorial/block-editor-01-basics/'      => 'https://wordpress.tv/2021/06/18/shusei-toda-naoko-takano-block-editor-01-basics/',
 		'/tutorial/block-editor-02-text-blocks/' => 'https://wordpress.tv/2021/06/03/shusei-toda-block-editor-02-text-blocks/',
 		'/tutorial/ja-login-password-reset/'     => 'https://wordpress.tv/2021/02/16/login-password-reset/',
@@ -63,9 +74,7 @@ function wporg_learn_redirect_old_urls() {
 				$redirect .= substr( $request, strlen( $source ) );
 			}
 
-			str_starts_with( $destination, 'https://' )
-				? wp_redirect( $redirect, $code, 'Learn WordPress' )
-				: wp_safe_redirect( $redirect, $code );
+			wp_safe_redirect( $redirect, $code, 'Learn WordPress' );
 			exit;
 		}
 	}


### PR DESCRIPTION
Adds redirects for several deprecated tutorials to external locations on WordPress.tv

Also updates the existing internal redirects to use 301, as these are permanent, and the default for `wp_safe_redirect` is 302.

See https://github.com/WordPress/Learn/issues/2496, specifically https://github.com/WordPress/Learn/issues/2496#issuecomment-2305200045