### PR TITLE
Single Lesson: Polish the design

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2024/assets/icon-check.svg
+++ b/wp-content/themes/pub/wporg-learn-2024/assets/icon-check.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M17.9295 7.97898L10.7313 17.6598L6.21499 14.3017L7.11001 13.098L10.4226 15.5611L16.7258 7.08395L17.9295 7.97898Z" fill="#008A20"/>
+</svg>

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/sensei-lesson-actions.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/sensei-lesson-actions.php
@@ -45,8 +45,8 @@ $is_completed = Sensei_Utils::user_completed_lesson( get_the_ID() );
 					<!-- /wp:button -->
 				<?php endif; ?>
 				<?php if ( $next_url ) : ?>
-					<!-- wp:button {"className":"is-style-fill"} -->
-					<div class="wp-block-button is-style-fill has-text-align-left">
+					<!-- wp:button {"className":"is-style-outline"} -->
+					<div class="wp-block-button is-style-outline has-text-align-left">
 						<a class="wp-block-button__link wp-element-button" href="<?php echo esc_attr( $next_url ); ?>"><?php esc_html_e( 'Next Lesson', 'wporg-learn' ); ?></a>
 					</div>
 					<!-- /wp:button -->

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/sensei-lesson-actions.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/sensei-lesson-actions.php
@@ -21,7 +21,7 @@ $is_completed = Sensei_Utils::user_completed_lesson( get_the_ID() );
 		<!-- wp:sensei-lms/button-view-quiz {"inContainer":true} -->
 		<div class="wp-block-sensei-lms-button-view-quiz is-style-default sensei-buttons-container__button-block wp-block-sensei-lms-button-view-quiz__wrapper">
 			<div class="wp-block-sensei-lms-button-view-quiz is-style-default wp-block-sensei-button wp-block-button has-text-align-left">
-				<button class="wp-block-button__link"><?php esc_html_e( 'Take quiz', 'sensei-lms' ); ?></button>
+				<button class="wp-block-button__link"><?php esc_html_e( 'Take quiz to complete lesson', 'sensei-lms' ); ?></button>
 			</div>
 		</div>
 		<!-- /wp:sensei-lms/button-view-quiz -->

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/sensei-lesson-actions.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/sensei-lesson-actions.php
@@ -18,18 +18,18 @@ $is_completed = Sensei_Utils::user_completed_lesson( get_the_ID() );
 <div class="wp-block-sensei-lms-lesson-actions">
 	<div class="sensei-buttons-container">
 
-		<!-- wp:sensei-lms/button-view-quiz {"inContainer":true} -->
+		<!-- wp:sensei-lms/button-view-quiz {"inContainer":true,"className":"is-style-default"} -->
 		<div class="wp-block-sensei-lms-button-view-quiz is-style-default sensei-buttons-container__button-block wp-block-sensei-lms-button-view-quiz__wrapper">
-			<div class="wp-block-sensei-lms-button-view-quiz is-style-default wp-block-sensei-button wp-block-button has-text-align-left">
-				<button class="wp-block-button__link"><?php esc_html_e( 'Take quiz to complete lesson', 'sensei-lms' ); ?></button>
+			<div class="wp-block-sensei-lms-button-view-quiz is-style-default wp-block-sensei-button wp-block-button has-text-align-center has-inter-font-family has-normal-font-size">
+				<button class="wp-block-button__link" style="font-weight:600;line-height:1"><?php esc_html_e( 'Take quiz to complete lesson', 'sensei-lms' ); ?></button>
 			</div>
 		</div>
 		<!-- /wp:sensei-lms/button-view-quiz -->
 
-		<!-- wp:sensei-lms/button-complete-lesson {"inContainer":true,"className":"is-style-outline"} -->
-		<div class="wp-block-sensei-lms-button-complete-lesson is-style-outline sensei-buttons-container__button-block wp-block-sensei-lms-button-complete-lesson__wrapper">
-			<div class="wp-block-sensei-lms-button-complete-lesson is-style-outline wp-block-sensei-button wp-block-button has-text-align-left">
-				<button class="wp-block-button__link sensei-stop-double-submission"><?php esc_html_e( 'Complete lesson', 'sensei-lms' ); ?></button>
+		<!-- wp:sensei-lms/button-complete-lesson {"inContainer":true,"className":"is-style-default"} -->
+		<div class="wp-block-sensei-lms-button-complete-lesson is-style-default sensei-buttons-container__button-block wp-block-sensei-lms-button-complete-lesson__wrapper">
+			<div class="wp-block-sensei-lms-button-complete-lesson is-style-default wp-block-sensei-button wp-block-button has-text-align-center has-inter-font-family has-normal-font-size">
+				<button class="wp-block-button__link sensei-stop-double-submission" style="font-weight:600;line-height:1"><?php esc_html_e( 'Complete lesson', 'sensei-lms' ); ?></button>
 			</div>
 		</div>
 		<!-- /wp:sensei-lms/button-complete-lesson -->
@@ -38,16 +38,16 @@ $is_completed = Sensei_Utils::user_completed_lesson( get_the_ID() );
 			<!-- wp:buttons {"className":"sensei-lesson-actions-nav"} -->
 			<div class="wp-block-buttons sensei-lesson-actions-nav">
 				<?php if ( $prev_url ) : ?>
-					<!-- wp:button {"className":"is-style-outline"} -->
-					<div class="wp-block-button is-style-outline has-text-align-left">
-						<a class="wp-block-button__link wp-element-button" href="<?php echo esc_attr( $prev_url ); ?>"><?php esc_html_e( 'Previous Lesson', 'wporg-learn' ); ?></a>
+					<!-- wp:button {"className":"has-text-align-center is-style-outline","fontSize":"normal","fontFamily":"inter"} -->
+					<div class="wp-block-button has-custom-font-size has-text-align-center is-style-outline has-inter-font-family has-normal-font-size">
+						<a class="wp-block-button__link wp-element-button" style="font-weight:600;line-height:1" href="<?php echo esc_attr( $prev_url ); ?>"><?php esc_html_e( 'Previous Lesson', 'wporg-learn' ); ?></a>
 					</div>
 					<!-- /wp:button -->
 				<?php endif; ?>
 				<?php if ( $next_url ) : ?>
-					<!-- wp:button {"className":"is-style-outline"} -->
-					<div class="wp-block-button is-style-outline has-text-align-left">
-						<a class="wp-block-button__link wp-element-button" href="<?php echo esc_attr( $next_url ); ?>"><?php esc_html_e( 'Next Lesson', 'wporg-learn' ); ?></a>
+					<!-- wp:button {"className":"has-text-align-center is-style-outline","fontSize":"normal","fontFamily":"inter"} -->
+					<div class="wp-block-button has-custom-font-size has-text-align-center is-style-outline has-inter-font-family has-normal-font-size">
+						<a class="wp-block-button__link wp-element-button" style="font-weight:600;line-height:1" href="<?php echo esc_attr( $next_url ); ?>"><?php esc_html_e( 'Next Lesson', 'wporg-learn' ); ?></a>
 					</div>
 					<!-- /wp:button -->
 				<?php endif; ?>

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/sensei-lesson-actions.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/sensei-lesson-actions.php
@@ -38,18 +38,18 @@ $is_completed = Sensei_Utils::user_completed_lesson( get_the_ID() );
 			<!-- /wp:buttons -->
 		<?php endif; ?>
 
-		<!-- wp:sensei-lms/button-view-quiz {"inContainer":true,"className":"is-style-default"} -->
-		<div class="wp-block-sensei-lms-button-view-quiz is-style-default sensei-buttons-container__button-block wp-block-sensei-lms-button-view-quiz__wrapper">
-			<div class="wp-block-sensei-lms-button-view-quiz is-style-default wp-block-sensei-button wp-block-button has-text-align-center has-inter-font-family has-normal-font-size">
-				<button class="wp-block-button__link" style="font-weight:600;line-height:1"><?php esc_html_e( 'Take quiz to complete lesson', 'sensei-lms' ); ?></button>
+		<!-- wp:sensei-lms/button-view-quiz {"inContainer":true} -->
+		<div class="wp-block-sensei-lms-button-view-quiz sensei-buttons-container__button-block wp-block-sensei-lms-button-view-quiz__wrapper">
+			<div class="wp-block-sensei-lms-button-view-quiz wp-block-sensei-button wp-block-button has-text-align-center has-inter-font-family has-normal-font-size">
+				<button class="wp-block-button__link"><?php esc_html_e( 'Take quiz to complete lesson', 'wporg-learn' ); ?></button>
 			</div>
 		</div>
 		<!-- /wp:sensei-lms/button-view-quiz -->
 
-		<!-- wp:sensei-lms/button-complete-lesson {"inContainer":true,"className":"is-style-default"} -->
-		<div class="wp-block-sensei-lms-button-complete-lesson is-style-default sensei-buttons-container__button-block wp-block-sensei-lms-button-complete-lesson__wrapper">
-			<div class="wp-block-sensei-lms-button-complete-lesson is-style-default wp-block-sensei-button wp-block-button has-text-align-center has-inter-font-family has-normal-font-size">
-				<button class="wp-block-button__link sensei-stop-double-submission" style="font-weight:600;line-height:1"><?php esc_html_e( 'Complete lesson', 'sensei-lms' ); ?></button>
+		<!-- wp:sensei-lms/button-complete-lesson {"inContainer":true} -->
+		<div class="wp-block-sensei-lms-button-complete-lesson sensei-buttons-container__button-block wp-block-sensei-lms-button-complete-lesson__wrapper">
+			<div class="wp-block-sensei-lms-button-complete-lesson wp-block-sensei-button wp-block-button has-text-align-center has-inter-font-family has-normal-font-size">
+				<button class="wp-block-button__link sensei-stop-double-submission"><?php esc_html_e( 'Complete lesson', 'sensei-lms' ); ?></button>
 			</div>
 		</div>
 		<!-- /wp:sensei-lms/button-complete-lesson -->

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/sensei-lesson-actions.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/sensei-lesson-actions.php
@@ -17,24 +17,7 @@ $is_completed = Sensei_Utils::user_completed_lesson( get_the_ID() );
 <!-- wp:sensei-lms/lesson-actions {"toggledBlocks":{"sensei-lms/button-reset-lesson":false}} -->
 <div class="wp-block-sensei-lms-lesson-actions">
 	<div class="sensei-buttons-container">
-
-		<!-- wp:sensei-lms/button-view-quiz {"inContainer":true,"className":"is-style-default"} -->
-		<div class="wp-block-sensei-lms-button-view-quiz is-style-default sensei-buttons-container__button-block wp-block-sensei-lms-button-view-quiz__wrapper">
-			<div class="wp-block-sensei-lms-button-view-quiz is-style-default wp-block-sensei-button wp-block-button has-text-align-center has-inter-font-family has-normal-font-size">
-				<button class="wp-block-button__link" style="font-weight:600;line-height:1"><?php esc_html_e( 'Take quiz to complete lesson', 'sensei-lms' ); ?></button>
-			</div>
-		</div>
-		<!-- /wp:sensei-lms/button-view-quiz -->
-
-		<!-- wp:sensei-lms/button-complete-lesson {"inContainer":true,"className":"is-style-default"} -->
-		<div class="wp-block-sensei-lms-button-complete-lesson is-style-default sensei-buttons-container__button-block wp-block-sensei-lms-button-complete-lesson__wrapper">
-			<div class="wp-block-sensei-lms-button-complete-lesson is-style-default wp-block-sensei-button wp-block-button has-text-align-center has-inter-font-family has-normal-font-size">
-				<button class="wp-block-button__link sensei-stop-double-submission" style="font-weight:600;line-height:1"><?php esc_html_e( 'Complete lesson', 'sensei-lms' ); ?></button>
-			</div>
-		</div>
-		<!-- /wp:sensei-lms/button-complete-lesson -->
-
-		<?php if ( $is_completed && ( $prev_url || $next_url ) ) : ?>
+		<?php if ( $prev_url || $next_url ) : ?>
 			<!-- wp:buttons {"className":"sensei-lesson-actions-nav"} -->
 			<div class="wp-block-buttons sensei-lesson-actions-nav">
 				<?php if ( $prev_url ) : ?>
@@ -54,6 +37,22 @@ $is_completed = Sensei_Utils::user_completed_lesson( get_the_ID() );
 			</div>
 			<!-- /wp:buttons -->
 		<?php endif; ?>
+
+		<!-- wp:sensei-lms/button-view-quiz {"inContainer":true,"className":"is-style-default"} -->
+		<div class="wp-block-sensei-lms-button-view-quiz is-style-default sensei-buttons-container__button-block wp-block-sensei-lms-button-view-quiz__wrapper">
+			<div class="wp-block-sensei-lms-button-view-quiz is-style-default wp-block-sensei-button wp-block-button has-text-align-center has-inter-font-family has-normal-font-size">
+				<button class="wp-block-button__link" style="font-weight:600;line-height:1"><?php esc_html_e( 'Take quiz to complete lesson', 'sensei-lms' ); ?></button>
+			</div>
+		</div>
+		<!-- /wp:sensei-lms/button-view-quiz -->
+
+		<!-- wp:sensei-lms/button-complete-lesson {"inContainer":true,"className":"is-style-default"} -->
+		<div class="wp-block-sensei-lms-button-complete-lesson is-style-default sensei-buttons-container__button-block wp-block-sensei-lms-button-complete-lesson__wrapper">
+			<div class="wp-block-sensei-lms-button-complete-lesson is-style-default wp-block-sensei-button wp-block-button has-text-align-center has-inter-font-family has-normal-font-size">
+				<button class="wp-block-button__link sensei-stop-double-submission" style="font-weight:600;line-height:1"><?php esc_html_e( 'Complete lesson', 'sensei-lms' ); ?></button>
+			</div>
+		</div>
+		<!-- /wp:sensei-lms/button-complete-lesson -->
 	</div>
 </div>
 <!-- /wp:sensei-lms/lesson-actions -->

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/sensei-lesson-columns.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/sensei-lesson-columns.php
@@ -39,9 +39,9 @@ $is_completed = Sensei_Utils::user_completed_lesson( $lesson_id );
 		<?php endif; ?>
 
 		<?php if ( $module ) : ?>
-			<!-- wp:post-title {"level":1,"fontSize":"heading-3"} /-->
+			<!-- wp:post-title {"level":1,"style":{"spacing":{"margin":{"top":"var:preset|spacing|50"}},"typography":{"fontStyle":"normal","fontWeight":"600"}},"fontSize":"heading-3","fontFamily":"inter"} /-->
 		<?php else : ?>
-			<!-- wp:post-title {"level":1,"fontSize":"heading-1","style":{"spacing":{"margin":{"top":"0"}},"typography":{"lineHeight":"1"}}} /-->	 
+			<!-- wp:post-title {"level":1,"fontSize":"heading-3","fontFamily":"inter","style":{"spacing":{"margin":{"top":"0"}},"typography":{"lineHeight":"1","fontStyle":"normal","fontWeight":"600"}}} /-->	 
 		<?php endif; ?> 
 
 		<!-- wp:post-content {"layout":{"type":"constrained","justifyContent":"left"}} /-->

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/sensei-lesson-columns.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/sensei-lesson-columns.php
@@ -39,7 +39,7 @@ $is_completed = Sensei_Utils::user_completed_lesson( $lesson_id );
 		<?php endif; ?>
 
 		<?php if ( $module ) : ?>
-			<!-- wp:post-title {"level":1,"fontSize":"heading-1"} /-->
+			<!-- wp:post-title {"level":1,"fontSize":"heading-3"} /-->
 		<?php else : ?>
 			<!-- wp:post-title {"level":1,"fontSize":"heading-1","style":{"spacing":{"margin":{"top":"0"}},"typography":{"lineHeight":"1"}}} /-->	 
 		<?php endif; ?> 

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/sensei-lesson-columns.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/sensei-lesson-columns.php
@@ -10,8 +10,8 @@
 <!-- wp:sensei-lms/ui {"elementClass":"sensei-course-theme__columns","className":"sensei-version\u002d\u002d4-16-2"} -->
 <div class="wp-block-sensei-lms-ui sensei-course-theme__columns sensei-version--4-16-2">
 
-	<!-- wp:sensei-lms/ui {"elementClass":"sensei-course-theme__sidebar","className":"","style"={"spacing":{"margin":{"top":"var:preset|spacing|50"},"padding":{"top":"var:preset|spacing|20","right":"var:preset|spacing|30","bottom":"var:preset|spacing|50","left":"var:preset|spacing|edge-space"}}}} -->
-	<div class="wp-block-sensei-lms-ui sensei-course-theme__frame sensei-course-theme__sidebar" style="margin-top:var(--wp--preset--spacing--50);padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--edge-space)">
+	<!-- wp:sensei-lms/ui {"elementClass":"sensei-course-theme__sidebar","className":"","style"={"spacing":{"padding":{"top":"var:preset|spacing|50","right":"var:preset|spacing|30","bottom":"var:preset|spacing|50","left":"var:preset|spacing|edge-space"}}}} -->
+	<div class="wp-block-sensei-lms-ui sensei-course-theme__frame sensei-course-theme__sidebar" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--edge-space)">
 
 		<!-- wp:sensei-lms/course-navigation /-->
 

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/sensei-lesson-columns.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/sensei-lesson-columns.php
@@ -37,19 +37,21 @@
 
 		<!-- wp:post-content {"layout":{"inherit":true}} /-->
 
-		<!-- wp:group {"style":{"spacing":{"margin":{"top":"40px"}}},"layout":{"type":"constrained"},"className":"sensei-lesson-footer"} -->
-		<div class="wp-block-group sensei-lesson-footer" style="margin-top:40px">
-			<!-- wp:sensei-lms/page-actions {"style":{"spacing":{"blockGap":"43px"}}} /-->
+		<?php if ( is_user_logged_in() ) : ?>
+			<!-- wp:group {"style":{"spacing":{"margin":{"top":"40px"}}},"layout":{"type":"constrained"},"className":"sensei-lesson-footer"} -->
+			<div class="wp-block-group sensei-lesson-footer" style="margin-top:40px">
+				<!-- wp:sensei-lms/page-actions {"style":{"spacing":{"blockGap":"43px"}}} /-->
 
-			<!-- wp:group {"style":{"spacing":{"margin":{"top":"20px"}}}} -->
-			<div class="wp-block-group" style="margin-top:20px">
+				<!-- wp:group {"style":{"spacing":{"margin":{"top":"20px"}}}} -->
+				<div class="wp-block-group" style="margin-top:20px">
 
-				<!-- wp:pattern {"slug":"wporg-learn-2024/sensei-lesson-actions"} /-->
+					<!-- wp:pattern {"slug":"wporg-learn-2024/sensei-lesson-actions"} /-->
 
+				</div>
+				<!-- /wp:group -->
 			</div>
 			<!-- /wp:group -->
-		</div>
-		<!-- /wp:group -->
+		<?php endif; ?>
 	</div>
 	<!-- /wp:sensei-lms/ui -->
 </div>

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/sensei-lesson-columns.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/sensei-lesson-columns.php
@@ -32,9 +32,9 @@ $module = Sensei()->modules->get_lesson_module( $lesson_id );
 			<!-- wp:post-title {"level":1,"fontSize":"heading-1","style":{"spacing":{"margin":{"top":"0"}},"typography":{"lineHeight":"1"}}} /-->	 
 		<?php endif; ?> 
 
-		<!-- wp:sensei-lms/course-theme-notices /-->
-
 		<!-- wp:post-content {"layout":{"inherit":true}} /-->
+
+		<!-- wp:sensei-lms/course-theme-notices /-->
 
 		<?php if ( is_user_logged_in() ) : ?>
 			<!-- wp:group {"style":{"spacing":{"margin":{"top":"0","bottom":"var(--wp--preset--spacing--50)"}}},"layout":{"type":"constrained"},"className":"sensei-lesson-footer"} -->
@@ -53,7 +53,7 @@ $module = Sensei()->modules->get_lesson_module( $lesson_id );
 		<?php endif; ?>
 
 		<!-- wp:group {"align":"full","style":{"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"},"right":{},"bottom":{},"left":{}},"spacing":{"margin":{"top":"0"}},"layout":{"type":"constrained"}} -->
-		<div class="wp-block-group alignfull" style="margin-top:0;border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;order:2">
+		<div class="wp-block-group alignfull" style="margin-top:0;border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;width:100%!important">
 
 			<!-- wp:group {"layout":{"type":"constrained"},"spacing":{"margin":{"top":"var(--wp--preset--spacing--30)"}}} -->
 			<div class="wp-block-group alignwide" style="margin-top:var(--wp--preset--spacing--30)">

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/sensei-lesson-columns.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/sensei-lesson-columns.php
@@ -7,6 +7,7 @@
 
 $lesson_id = Sensei_Utils::get_current_lesson();
 $module = Sensei()->modules->get_lesson_module( $lesson_id );
+$is_completed = Sensei_Utils::user_completed_lesson( $lesson_id );
 
 ?>
 
@@ -25,6 +26,17 @@ $module = Sensei()->modules->get_lesson_module( $lesson_id );
 	<div class="wp-block-sensei-lms-ui sensei-course-theme__main-content" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--edge-space)">
 
 		<!-- wp:sensei-lms/course-theme-lesson-module /-->
+
+		<?php if ( $is_completed ) : ?>
+			<!-- wp:wporg/notice {"style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}}} -->
+			<div class="wp-block-wporg-notice is-tip-notice" style="margin-top:var(--wp--preset--spacing--20);width:100%">
+				<div class="wp-block-wporg-notice__icon"></div>
+				<div class="wp-block-wporg-notice__content">
+					<p><?php esc_html_e( 'You already completed this lesson', 'wporg-learn' ); ?></p>
+				</div>
+			</div>
+			<!-- /wp:wporg/notice -->
+		<?php endif; ?>
 
 		<?php if ( $module ) : ?>
 			<!-- wp:post-title {"level":1,"fontSize":"heading-1"} /-->

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/sensei-lesson-columns.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/sensei-lesson-columns.php
@@ -44,7 +44,7 @@ $is_completed = Sensei_Utils::user_completed_lesson( $lesson_id );
 			<!-- wp:post-title {"level":1,"fontSize":"heading-1","style":{"spacing":{"margin":{"top":"0"}},"typography":{"lineHeight":"1"}}} /-->	 
 		<?php endif; ?> 
 
-		<!-- wp:post-content {"layout":{"inherit":true}} /-->
+		<!-- wp:post-content {"layout":{"type":"constrained","justifyContent":"left"}} /-->
 
 		<!-- wp:sensei-lms/course-theme-notices /-->
 

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/sensei-lesson-columns.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/sensei-lesson-columns.php
@@ -5,12 +5,15 @@
  * Inserter: no
  */
 
+$lesson_id = Sensei_Utils::get_current_lesson();
+$module = Sensei()->modules->get_lesson_module( $lesson_id );
+
 ?>
 
 <!-- wp:sensei-lms/ui {"elementClass":"sensei-course-theme__columns","className":"sensei-version\u002d\u002d4-16-2"} -->
 <div class="wp-block-sensei-lms-ui sensei-course-theme__columns sensei-version--4-16-2">
 
-	<!-- wp:sensei-lms/ui {"elementClass":"sensei-course-theme__sidebar","className":"","style"={"spacing":{"padding":{"top":"var:preset|spacing|50","right":"var:preset|spacing|30","bottom":"var:preset|spacing|50","left":"var:preset|spacing|edge-space"}}}} -->
+	<!-- wp:sensei-lms/ui {"elementClass":"sensei-course-theme__sidebar","style"={"spacing":{"padding":{"top":"var:preset|spacing|50","right":"var:preset|spacing|30","bottom":"var:preset|spacing|50","left":"var:preset|spacing|edge-space"}}}} -->
 	<div class="wp-block-sensei-lms-ui sensei-course-theme__frame sensei-course-theme__sidebar" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--edge-space)">
 
 		<!-- wp:sensei-lms/course-navigation /-->
@@ -23,19 +26,23 @@
 
 		<!-- wp:sensei-lms/course-theme-lesson-module /-->
 
-		<!-- wp:post-title {"level":1,"fontSize":"heading-1"} /-->
+		<?php if ( $module ) : ?>
+			<!-- wp:post-title {"level":1,"fontSize":"heading-1"} /-->
+		<?php else : ?>
+			<!-- wp:post-title {"level":1,"fontSize":"heading-1","style":{"spacing":{"margin":{"top":"0"}},"typography":{"lineHeight":"1"}}} /-->	 
+		<?php endif; ?> 
 
 		<!-- wp:sensei-lms/course-theme-notices /-->
 
 		<!-- wp:post-content {"layout":{"inherit":true}} /-->
 
 		<?php if ( is_user_logged_in() ) : ?>
-			<!-- wp:group {"style":{"spacing":{"margin":{"top":"40px"}}},"layout":{"type":"constrained"},"className":"sensei-lesson-footer"} -->
-			<div class="wp-block-group sensei-lesson-footer" style="margin-top:40px">
+			<!-- wp:group {"style":{"spacing":{"margin":{"top":"0","bottom":"var(--wp--preset--spacing--50)"}}},"layout":{"type":"constrained"},"className":"sensei-lesson-footer"} -->
+			<div class="wp-block-group sensei-lesson-footer" style="margin-top:0;margin-bottom:var(--wp--preset--spacing--50)">
 				<!-- wp:sensei-lms/page-actions {"style":{"spacing":{"blockGap":"43px"}}} /-->
 
-				<!-- wp:group {"style":{"spacing":{"margin":{"top":"20px"}}}} -->
-				<div class="wp-block-group" style="margin-top:20px">
+				<!-- wp:group {"style":{"spacing":{"margin":{"top":"0"}}}} -->
+				<div class="wp-block-group" style="margin-top:0">
 
 					<!-- wp:pattern {"slug":"wporg-learn-2024/sensei-lesson-actions"} /-->
 
@@ -45,11 +52,11 @@
 			<!-- /wp:group -->
 		<?php endif; ?>
 
-		<!-- wp:group {"align":"full","style":{"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"},"right":{},"bottom":{},"left":{}},"spacing":{"margin":{"top":"var:preset|spacing|20"},"padding":{"top":"var:preset|spacing|30","right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
-		<div class="wp-block-group alignfull" style="margin-top:var(--wp--preset--spacing--20);padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--edge-space);border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px">
+		<!-- wp:group {"align":"full","style":{"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"},"right":{},"bottom":{},"left":{}},"spacing":{"margin":{"top":"0"}},"layout":{"type":"constrained"}} -->
+		<div class="wp-block-group alignfull" style="margin-top:0;border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;order:2">
 
-			<!-- wp:group {"layout":{"type":"constrained"}} -->
-			<div class="wp-block-group alignwide">
+			<!-- wp:group {"layout":{"type":"constrained"},"spacing":{"margin":{"top":"var(--wp--preset--spacing--30)"}}} -->
+			<div class="wp-block-group alignwide" style="margin-top:var(--wp--preset--spacing--30)">
 
 				<!-- wp:pattern {"slug":"wporg-learn-2024/content-feedback"} /-->
 

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/sensei-lesson-columns.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/sensei-lesson-columns.php
@@ -15,14 +15,6 @@
 
 		<!-- wp:sensei-lms/course-navigation /-->
 
-		<!-- wp:group {"style":{"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"}},"spacing":{"padding":{"top":"var:preset|spacing|20"}}},"layout":{"type":"constrained"}} -->
-		<div class="wp-block-group" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;padding-top:var(--wp--preset--spacing--20)">
-
-			<!-- wp:pattern {"slug":"wporg-learn-2024/content-feedback"} /-->
-
-		</div>
-		<!-- /wp:group -->
-
 	</div>
 	<!-- /wp:sensei-lms/ui -->
 
@@ -52,6 +44,21 @@
 			</div>
 			<!-- /wp:group -->
 		<?php endif; ?>
+
+		<!-- wp:group {"align":"full","style":{"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"},"right":{},"bottom":{},"left":{}},"spacing":{"margin":{"top":"var:preset|spacing|20"},"padding":{"top":"var:preset|spacing|30","right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
+		<div class="wp-block-group alignfull" style="margin-top:var(--wp--preset--spacing--20);padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--edge-space);border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px">
+
+			<!-- wp:group {"layout":{"type":"constrained"}} -->
+			<div class="wp-block-group alignwide">
+
+				<!-- wp:pattern {"slug":"wporg-learn-2024/content-feedback"} /-->
+
+			</div>
+			<!-- /wp:group -->
+
+		</div>
+		<!-- /wp:group -->
+
 	</div>
 	<!-- /wp:sensei-lms/ui -->
 </div>

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/sensei-lesson-columns.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/sensei-lesson-columns.php
@@ -14,8 +14,8 @@ $is_completed = Sensei_Utils::user_completed_lesson( $lesson_id );
 <!-- wp:sensei-lms/ui {"elementClass":"sensei-course-theme__columns","className":"sensei-version\u002d\u002d4-16-2"} -->
 <div class="wp-block-sensei-lms-ui sensei-course-theme__columns sensei-version--4-16-2">
 
-	<!-- wp:sensei-lms/ui {"elementClass":"sensei-course-theme__sidebar","style"={"spacing":{"padding":{"top":"var:preset|spacing|50","right":"var:preset|spacing|30","bottom":"var:preset|spacing|50","left":"var:preset|spacing|edge-space"}}}} -->
-	<div class="wp-block-sensei-lms-ui sensei-course-theme__frame sensei-course-theme__sidebar" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--edge-space)">
+	<!-- wp:sensei-lms/ui {"elementClass":"sensei-course-theme__sidebar","style"={"spacing":{"padding":{"top":"var:preset|spacing|50","right":"var:preset|spacing|30","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50"}}}} -->
+	<div class="wp-block-sensei-lms-ui sensei-course-theme__frame sensei-course-theme__sidebar" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)">
 
 		<!-- wp:sensei-lms/course-navigation /-->
 

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/sensei-lesson-columns.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/sensei-lesson-columns.php
@@ -29,7 +29,7 @@ $is_completed = Sensei_Utils::user_completed_lesson( $lesson_id );
 
 		<?php if ( $is_completed ) : ?>
 			<!-- wp:wporg/notice {"style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}}} -->
-			<div class="wp-block-wporg-notice is-tip-notice" style="margin-top:var(--wp--preset--spacing--20);width:100%">
+			<div class="wp-block-wporg-notice is-tip-notice" style="margin-top:var(--wp--preset--spacing--20)">
 				<div class="wp-block-wporg-notice__icon"></div>
 				<div class="wp-block-wporg-notice__content">
 					<p><?php esc_html_e( 'You already completed this lesson', 'wporg-learn' ); ?></p>
@@ -65,7 +65,7 @@ $is_completed = Sensei_Utils::user_completed_lesson( $lesson_id );
 		<?php endif; ?>
 
 		<!-- wp:group {"align":"full","style":{"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"},"right":{},"bottom":{},"left":{}},"spacing":{"margin":{"top":"0"}},"layout":{"type":"constrained"}} -->
-		<div class="wp-block-group alignfull" style="margin-top:0;border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;width:100%!important">
+		<div class="wp-block-group alignfull" style="margin-top:0;border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px">
 
 			<!-- wp:group {"layout":{"type":"constrained"},"spacing":{"margin":{"top":"var(--wp--preset--spacing--30)"}}} -->
 			<div class="wp-block-group alignwide" style="margin-top:var(--wp--preset--spacing--30)">

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/sensei-lesson-header.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/sensei-lesson-header.php
@@ -12,8 +12,8 @@
 <!-- wp:sensei-lms/ui {"elementClass":"sensei-course-theme__header","className":"sensei-version\u002d\u002d4-16-2"} -->
 <div class="wp-block-sensei-lms-ui sensei-course-theme__frame sensei-version--4-16-2 sensei-course-theme__header">
 	
-	<!-- wp:group {"style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space","top":"0px","bottom":"0px"}}},"backgroundColor":"white","className":"sensei-course-theme-header-content","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
-	<div class="wp-block-group sensei-course-theme-header-content has-white-background-color has-background" style="padding-top:0px;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:0px;padding-left:var(--wp--preset--spacing--edge-space)">
+	<!-- wp:group {"style":{"spacing":{"padding":{"left":"var:preset|spacing|30","right":"var:preset|spacing|30","top":"0px","bottom":"0px"}}},"backgroundColor":"white","className":"sensei-course-theme-header-content","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+	<div class="wp-block-group sensei-course-theme-header-content has-white-background-color has-background" style="padding-top:0px;padding-right:var(--wp--preset--spacing--30);padding-bottom:0px;padding-left:var(--wp--preset--spacing--30)">
 
 		<!-- wp:wporg/site-breadcrumbs {"fontSize":"small","style":{"spacing":{"padding":{"top":"18px","bottom":"18px"}}}} /-->
 

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/sensei-lesson-standalone.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/sensei-lesson-standalone.php
@@ -34,8 +34,8 @@
 <!-- wp:sensei-lms/ui {"elementClass":"sensei-course-theme__columns","className":"sensei-version\u002d\u002d4-16-2 sensei-course-theme__columns--standalone"} -->
 <div class="wp-block-sensei-lms-ui sensei-course-theme__columns sensei-course-theme__columns--standalone sensei-version--4-16-2">
 
-	<!-- wp:sensei-lms/ui {"elementClass":"sensei-course-theme__main-content","lock":{"move":false,"remove":false},"style"={"spacing":{"margin":{"top":"var:preset|spacing|30"},"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|60","right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space"}}}} -->
-	<div class="wp-block-sensei-lms-ui sensei-course-theme__main-content" style="margin-top:var(--wp--preset--spacing--30);padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)">
+	<!-- wp:sensei-lms/ui {"elementClass":"sensei-course-theme__main-content","lock":{"move":false,"remove":false},"style"={"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space"}}}} -->
+	<div class="wp-block-sensei-lms-ui sensei-course-theme__main-content" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)">
 
 		<!-- wp:post-title {"level":1,"fontSize":"heading-1"} /-->
 
@@ -61,8 +61,8 @@
 </div>
 <!-- /wp:sensei-lms/ui -->
 
-<!-- wp:group {"align":"full","style":{"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"},"right":{},"bottom":{},"left":{}},"spacing":{"margin":{"top":"var:preset|spacing|20"},"padding":{"top":"var:preset|spacing|30","right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull" style="margin-top:var(--wp--preset--spacing--20);padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--edge-space);border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px">
+<!-- wp:group {"align":"full","style":{"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"},"right":{},"bottom":{},"left":{}},"spacing":{"padding":{"top":"var:preset|spacing|30","right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space);border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px">
 	
 	<!-- wp:group {"layout":{"type":"constrained"}} -->
 	<div class="wp-block-group alignwide">

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/sensei-lesson-standalone.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/sensei-lesson-standalone.php
@@ -41,19 +41,21 @@
 
 		<!-- wp:post-content {"layout":{"inherit":true}} /-->
 
-		<!-- wp:group {"style":{"spacing":{"margin":{"top":"40px"}}},"layout":{"type":"constrained"},"className":"sensei-lesson-footer"} -->
-		<div class="wp-block-group sensei-lesson-footer" style="margin-top:40px">
-			<!-- wp:sensei-lms/page-actions {"style":{"spacing":{"blockGap":"43px"}}} /-->
+		<?php if ( is_user_logged_in() ) : ?>
+			<!-- wp:group {"style":{"spacing":{"margin":{"top":"40px"}}},"layout":{"type":"constrained"},"className":"sensei-lesson-footer"} -->
+			<div class="wp-block-group sensei-lesson-footer" style="margin-top:40px">
+				<!-- wp:sensei-lms/page-actions {"style":{"spacing":{"blockGap":"43px"}}} /-->
 
-			<!-- wp:group {"style":{"spacing":{"margin":{"top":"20px"}}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-			<div class="wp-block-group" style="margin-top:20px">
+				<!-- wp:group {"style":{"spacing":{"margin":{"top":"20px"}}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+				<div class="wp-block-group" style="margin-top:20px">
 
-				<!-- wp:pattern {"slug":"wporg-learn-2024/sensei-lesson-actions"} /-->
+					<!-- wp:pattern {"slug":"wporg-learn-2024/sensei-lesson-actions"} /-->
 
+				</div>
+				<!-- /wp:group -->
 			</div>
 			<!-- /wp:group -->
-		</div>
-		<!-- /wp:group -->
+		<?php endif; ?>
 	</div>
 	<!-- /wp:sensei-lms/ui -->
 </div>

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/sensei-lesson-standalone.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/sensei-lesson-standalone.php
@@ -37,7 +37,7 @@
 	<!-- wp:sensei-lms/ui {"elementClass":"sensei-course-theme__main-content","lock":{"move":false,"remove":false},"style"={"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space"}}}} -->
 	<div class="wp-block-sensei-lms-ui sensei-course-theme__main-content" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)">
 
-		<!-- wp:post-title {"level":1,"fontSize":"heading-1"} /-->
+		<!-- wp:post-title {"level":1,"fontSize":"heading-3"} /-->
 
 		<!-- wp:post-content {"layout":{"inherit":true}} /-->
 

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/sensei-lesson-standalone.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/sensei-lesson-standalone.php
@@ -10,8 +10,8 @@
 <!-- wp:sensei-lms/ui {"elementClass":"sensei-course-theme__header","className":"sensei-version\u002d\u002d4-16-2 sensei-course-theme__header--standalone"} -->
 <div class="wp-block-sensei-lms-ui sensei-course-theme__frame sensei-version--4-16-2 sensei-course-theme__header sensei-course-theme__header--standalone">
 	
-	<!-- wp:group {"style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space","top":"0px","bottom":"0px"}}},"backgroundColor":"white","className":"sensei-course-theme-header-content","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
-	<div class="wp-block-group sensei-course-theme-header-content has-white-background-color has-background" style="padding-top:0px;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:0px;padding-left:var(--wp--preset--spacing--edge-space)">
+	<!-- wp:group {"style":{"spacing":{"padding":{"left":"var:preset|spacing|30","right":"var:preset|spacing|30","top":"0px","bottom":"0px"}}},"backgroundColor":"white","className":"sensei-course-theme-header-content","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+	<div class="wp-block-group sensei-course-theme-header-content has-white-background-color has-background" style="padding-top:0px;padding-right:var(--wp--preset--spacing--30);padding-bottom:0px;padding-left:var(--wp--preset--spacing--30)">
 
 		<!-- wp:wporg/site-breadcrumbs {"fontSize":"small","style":{"spacing":{"padding":{"top":"18px","bottom":"18px"}}}} /-->
 

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/sensei-lesson-standalone.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/sensei-lesson-standalone.php
@@ -37,7 +37,7 @@
 	<!-- wp:sensei-lms/ui {"elementClass":"sensei-course-theme__main-content","lock":{"move":false,"remove":false},"style"={"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space"}}}} -->
 	<div class="wp-block-sensei-lms-ui sensei-course-theme__main-content" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)">
 
-		<!-- wp:post-title {"level":1,"fontSize":"heading-3"} /-->
+		<!-- wp:post-title {"level":1,"style":{"spacing":{"margin":{"top":"0"}},"typography":{"fontStyle":"normal","fontWeight":"600"}},"fontSize":"heading-3","fontFamily":"inter"} /-->
 
 		<!-- wp:post-content {"layout":{"inherit":true}} /-->
 

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
@@ -63,13 +63,28 @@ body.sensei {
 		font-size: var(--wp--preset--font-size--xsmall);
 	}
 
-	.sensei-lms-course-navigation-lesson {
-		font-size: var(--wp--preset--font-size--small);
+	.editor-styles-wrapper .sensei-lms-course-navigation-lesson__link,
+	.sensei-lms-course-navigation-lesson__link {
+		color: var(--wp--preset--color--charcoal-4);
+	}
 
-		&.status-in-progress,
-		&.status-not-started {
-			--sensei-module-lesson-color: var(--wp--preset--color--charcoal-4);
+	.sensei-lms-course-navigation__modules {
+		gap: var(--wp--preset--spacing--20);
+
+		.sensei-lms-course-navigation-lesson {
+			font-size: var(--wp--preset--font-size--small);
+			margin-top: 12px;
+			line-height: 24px;
+
+			&.status-in-progress,
+			&.status-not-started {
+				--sensei-module-lesson-color: var(--wp--preset--color--charcoal-4);
+			}
 		}
+	}
+
+	.sensei-lms-course-navigation__lessons {
+		margin-top: var(--wp--preset--spacing--20);
 	}
 
 	&.single-lesson {

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
@@ -55,6 +55,11 @@ body.sensei {
 
 		.sensei-lms-course-navigation-lesson__link {
 			color: var(--wp--preset--color--charcoal-4);
+			align-items: flex-start;
+
+			.sensei-lms-course-navigation-lesson__status {
+				margin-top: 6px;
+			}
 		}
 	}
 

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
@@ -56,7 +56,7 @@ body.sensei {
 			--sensei-lm-sidebar-width: calc(280px + (var(--wp--preset--spacing--edge-space) * 2) - 24px);
 			display: flex;
 			flex-direction: column;
-			align-items: normal;
+			align-items: flex-start;
 			margin-top: 0;
 
 			> * {
@@ -86,8 +86,9 @@ body.sensei {
 			}
 
 			.wp-block-sensei-lms-course-theme-notices {
-				order: 1;
-				margin-bottom: 39px;
+				margin-block-end: 39px;
+				margin-block-start: 0;
+				width: 100% !important;
 
 				&:empty {
 					display: none;

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
@@ -54,9 +54,6 @@ body.sensei {
 
 		.sensei-course-theme__sidebar ~ .sensei-course-theme__main-content {
 			--sensei-lm-sidebar-width: calc(280px + (var(--wp--preset--spacing--edge-space) * 2) - 24px);
-			display: flex;
-			flex-direction: column;
-			align-items: flex-start;
 			margin-top: 0;
 
 			> * {
@@ -93,7 +90,6 @@ body.sensei {
 			.wp-block-sensei-lms-course-theme-notices {
 				margin-block-end: 39px;
 				margin-block-start: 0;
-				width: 100% !important;
 
 				&:empty {
 					display: none;
@@ -229,7 +225,7 @@ body.sensei {
 		}
 
 		@media screen and (max-width: 782px) {
-			.sensei-lesson-footer .sensei-lesson-actions-nav {
+			.sensei-lesson-actions-nav {
 				width: 100%;
 			}
 		}

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
@@ -13,8 +13,28 @@ body.sensei {
 	--sensei-lesson-meta-color: var(--wp--preset--color--charcoal-4);
 	--sensei-module-lesson-color: var(--wp--preset--color--charcoal-1);
 
-	.sensei-course-theme-header-content > .wp-block-group {
-		row-gap: 0;
+	.sensei-course-theme-header-content {
+		> .wp-block-group {
+			row-gap: 0;
+		}
+
+		.sensei-course-theme__header__info {
+			gap: var(--wp--preset--spacing--30);
+		}
+
+		.sensei-course-theme-course-progress::after {
+			content: "";
+			display: inline-block;
+			height: 100%;
+			border-right: 1px solid var(--sensei-course-progress-bar-color);
+			position: absolute;
+			margin-left: 30px;
+			top: 0;
+		}
+
+		.wp-block-sensei-lms-exit-course {
+			margin-left: var(--wp--preset--spacing--30);
+		}
 	}
 
 	.sensei-course-theme-course-progress-bar-inner {
@@ -38,6 +58,7 @@ body.sensei {
 			padding-left: unset;
 			border: none;
 			color: var(--wp--preset--color--charcoal-4);
+			margin-top: revert-layer;
 		}
 
 		h1 {

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
@@ -99,6 +99,10 @@ body.sensei {
 	}
 
 	&.single-lesson {
+		h1 {
+			font-weight: 500;
+		}
+
 		.sensei-lesson-footer {
 			.screen-reader-text {
 				display: none;

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
@@ -85,6 +85,11 @@ body.sensei {
 						font-size: var(--wp--preset--font-size--small);
 						color: var(--wp--preset--color--charcoal-1);
 						margin-top: unset;
+						align-self: center;
+					}
+
+					.sensei-lms-course-navigation-module__collapsible-icon {
+						margin-top: -3px;
 					}
 				}
 			}

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
@@ -27,16 +27,23 @@ body.sensei {
 		@media (min-width: 890px) {
 			padding-right: calc(var(--wp--preset--spacing--edge-space) - 24px);
 		}
+
+		// Remove the border on module title.
+		h3.wp-block-sensei-lms-course-theme-lesson-module {
+			padding-left: unset;
+			border: none;
+			color: var(--wp--preset--color--charcoal-4);
+		}
+
+		h1 {
+			margin-block-start: var(--wp--preset--spacing--50);
+			margin-block-end: var(--wp--preset--spacing--30);
+			font-weight: 500;
+		}
 	}
 
 	.sensei-course-theme__sidebar {
 		row-gap: 40px;
-	}
-
-	// Remove the border on module title.
-	.wp-block-sensei-lms-course-theme-lesson-module {
-		padding-left: unset;
-		border: none;
 	}
 
 	.sensei-lms-course-navigation-module__header {

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
@@ -17,6 +17,11 @@ body.sensei {
 		row-gap: 0;
 	}
 
+	.sensei-course-theme-course-progress-bar-inner {
+		border-top-right-radius: 5px;
+		border-bottom-right-radius: 5px;
+	}
+
 	.sensei-course-theme__columns .sensei-course-theme__sidebar ~ .sensei-course-theme__main-content {
 		--sensei-lm-sidebar-width: calc(280px + (var(--wp--preset--spacing--edge-space) * 2) - 24px);
 

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
@@ -42,56 +42,55 @@ body.sensei {
 		}
 	}
 
+	.sensei-lms-course-navigation-module__summary,
+	.sensei-lms-course-navigation-lesson {
+		margin-top: 12px;
+		font-size: var(--wp--preset--font-size--small);
+		line-height: 24px;
+
+		.sensei-lms-course-navigation-lesson__link {
+			color: var(--wp--preset--color--charcoal-4);
+		}
+	}
+
 	.sensei-course-theme__sidebar {
 		row-gap: 40px;
-	}
 
-	.sensei-lms-course-navigation-module__header {
-		.sensei-collapsible__toggle.sensei-lms-course-navigation-module__button {
-			flex-direction: row-reverse;
-			align-items: flex-start;
-			gap: 0;
-		}
-	}
+		.sensei-lms-course-navigation__modules {
+			gap: var(--wp--preset--spacing--20);
 
-	.sensei-lms-course-navigation-module__title {
-		font-weight: 700;
-		font-size: var(--wp--preset--font-size--small);
-		color: var(--wp--preset--color--charcoal-1);
-		margin-top: unset;
-	}
+			.sensei-lms-course-navigation-module__lessons.sensei-collapsible__content,
+			.sensei-lms-course-navigation-module__summary {
+				padding-left: 24px;
+			}
 
-	.sensei-lms-course-navigation-module__lessons.sensei-collapsible__content,
-	.sensei-lms-course-navigation-module__summary {
-		padding-left: 24px;
-	}
+			.sensei-lms-course-navigation-module__header {
+				.sensei-collapsible__toggle.sensei-lms-course-navigation-module__button {
+					flex-direction: row-reverse;
+					align-items: flex-start;
+					gap: 0;
 
-	.sensei-lms-course-navigation-module__summary {
-		font-size: var(--wp--preset--font-size--xsmall);
-	}
+					.sensei-lms-course-navigation-module__title {
+						font-weight: 700;
+						font-size: var(--wp--preset--font-size--small);
+						color: var(--wp--preset--color--charcoal-1);
+						margin-top: unset;
+					}
+				}
+			}
 
-	.editor-styles-wrapper .sensei-lms-course-navigation-lesson__link,
-	.sensei-lms-course-navigation-lesson__link {
-		color: var(--wp--preset--color--charcoal-4);
-	}
 
-	.sensei-lms-course-navigation__modules {
-		gap: var(--wp--preset--spacing--20);
+			.sensei-lms-course-navigation__lessons {
+				margin-top: var(--wp--preset--spacing--20);
 
-		.sensei-lms-course-navigation-lesson {
-			font-size: var(--wp--preset--font-size--small);
-			margin-top: 12px;
-			line-height: 24px;
-
-			&.status-in-progress,
-			&.status-not-started {
-				--sensei-module-lesson-color: var(--wp--preset--color--charcoal-4);
+				.sensei-lms-course-navigation-lesson {
+					&.status-in-progress,
+					&.status-not-started {
+						--sensei-module-lesson-color: var(--wp--preset--color--charcoal-4);
+					}
+				}
 			}
 		}
-	}
-
-	.sensei-lms-course-navigation__lessons {
-		margin-top: var(--wp--preset--spacing--20);
 	}
 
 	&.single-lesson {

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
@@ -68,6 +68,7 @@ body.sensei {
 
 		.sensei-lms-course-navigation__modules {
 			gap: var(--wp--preset--spacing--20);
+			margin-left: -6px;
 
 			.sensei-lms-course-navigation-module__lessons.sensei-collapsible__content,
 			.sensei-lms-course-navigation-module__summary {
@@ -93,16 +94,15 @@ body.sensei {
 					}
 				}
 			}
+		}
 
+		.sensei-lms-course-navigation__lessons {
+			margin-top: var(--wp--preset--spacing--20);
 
-			.sensei-lms-course-navigation__lessons {
-				margin-top: var(--wp--preset--spacing--20);
-
-				.sensei-lms-course-navigation-lesson {
-					&.status-in-progress,
-					&.status-not-started {
-						--sensei-module-lesson-color: var(--wp--preset--color--charcoal-4);
-					}
+			.sensei-lms-course-navigation-lesson {
+				&.status-in-progress,
+				&.status-not-started {
+					--sensei-module-lesson-color: var(--wp--preset--color--charcoal-4);
 				}
 			}
 		}

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
@@ -84,7 +84,8 @@ body.sensei {
 
 			h1 {
 				margin-block-start: var(--wp--preset--spacing--50);
-				font-weight: 500;
+				font-weight: 600;
+				font-family: var(--wp--preset--font-family--inter);
 			}
 
 			.wp-block-sensei-lms-course-theme-notices {
@@ -161,7 +162,8 @@ body.sensei {
 
 	&.single-lesson {
 		h1 {
-			font-weight: 500;
+			font-weight: 600;
+			font-family: var(--wp--preset--font-family--inter);
 		}
 
 		.sensei-lesson-footer {

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
@@ -192,9 +192,31 @@ body.sensei {
 		}
 	}
 
-	@media screen and (max-width: 782px) {
-		.sensei-lesson-footer .sensei-lesson-actions-nav {
-			width: 100%;
+	.wp-block-sensei-lms-lesson-actions {
+		.wp-block-sensei-lms-button-view-quiz,
+		.wp-block-sensei-lms-button-complete-lesson {
+			background-color: var(--wp--custom--color--green-50) !important;
+			border-color: transparent;
+
+			&:hover {
+				opacity: 0.9;
+			}
+
+			> button {
+				font-weight: 600 !important;
+				line-height: 1;
+
+				&:focus,
+				&:focus-visible {
+					outline: var(--wp--custom--color--green-50);
+				}
+			}
+		}
+
+		@media screen and (max-width: 782px) {
+			.sensei-lesson-footer .sensei-lesson-actions-nav {
+				width: 100%;
+			}
 		}
 	}
 

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
@@ -82,12 +82,6 @@ body.sensei {
 				height: 24px;
 			}
 
-			h1 {
-				margin-block-start: var(--wp--preset--spacing--50);
-				font-weight: 600;
-				font-family: var(--wp--preset--font-family--inter);
-			}
-
 			.wp-block-sensei-lms-course-theme-notices {
 				margin-block-end: 39px;
 				margin-block-start: 0;
@@ -161,11 +155,6 @@ body.sensei {
 	}
 
 	&.single-lesson {
-		h1 {
-			font-weight: 600;
-			font-family: var(--wp--preset--font-family--inter);
-		}
-
 		.sensei-lesson-footer {
 			.screen-reader-text {
 				display: none;

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
@@ -513,8 +513,17 @@ body.sensei-course-theme {
 
 		@media screen and (max-width: 782px) {
 			top: calc(var(--sensei-lm-header-height));
+			left: 0;
+			right: 0;
 			margin-left: unset;
 			margin-right: unset;
+
+			.sensei-course-theme-course-progress-bar-inner {
+				border-top-left-radius: 0;
+				border-bottom-left-radius: 0;
+				position: relative;
+				top: -0.5px;
+			}
 		}
 	}
 

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
@@ -80,6 +80,11 @@ body.sensei {
 				margin-block-start: 0;
 			}
 
+			.wp-block-wporg-notice__icon {
+				background: url(../../assets/icon-check.svg);
+				height: 24px;
+			}
+
 			h1 {
 				margin-block-start: var(--wp--preset--spacing--50);
 				font-weight: 500;

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
@@ -45,6 +45,7 @@ body.sensei {
 		.sensei-course-theme-course-progress-bar-inner {
 			border-top-right-radius: 5px !important;
 			border-bottom-right-radius: 5px !important;
+			height: 4px !important;
 		}
 	}
 

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
@@ -175,6 +175,10 @@ body.sensei {
 				gap: var(--wp--preset--spacing--10);
 				justify-content: space-between;
 
+				@media screen and (max-width: 782px) {
+					flex-direction: column;
+				}
+
 				> *,
 				.sensei-buttons-container__button-block {
 					padding: unset;

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
@@ -51,6 +51,14 @@ body.sensei {
 
 	.sensei-course-theme__columns .sensei-course-theme__sidebar ~ .sensei-course-theme__main-content {
 		--sensei-lm-sidebar-width: calc(280px + (var(--wp--preset--spacing--edge-space) * 2) - 24px);
+		display: flex;
+		flex-direction: column;
+		align-items: normal;
+
+		> * {
+			margin-left: unset;
+			margin-right: unset;
+		}
 
 		@media (max-width: 782px) {
 			--sensei-lm-sidebar-width: 0;
@@ -72,6 +80,10 @@ body.sensei {
 			margin-block-start: var(--wp--preset--spacing--50);
 			margin-block-end: var(--wp--preset--spacing--30);
 			font-weight: 500;
+		}
+
+		.wp-block-sensei-lms-course-theme-notices {
+			order: 1;
 		}
 	}
 

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
@@ -231,8 +231,8 @@ body.sensei {
 		}
 
 		@media screen and (max-width: 782px) {
-			.sensei-lesson-actions-nav {
-				width: 100%;
+			.sensei-lesson-actions-nav a {
+				width: 100% !important;
 			}
 		}
 	}

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
@@ -162,6 +162,7 @@ body.sensei {
 				margin: unset;
 				display: flex;
 				gap: var(--wp--preset--spacing--10);
+				justify-content: space-between;
 
 				> *,
 				.sensei-buttons-container__button-block {

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
@@ -37,9 +37,15 @@ body.sensei {
 		}
 	}
 
-	.sensei-course-theme-course-progress-bar-inner {
-		border-top-right-radius: 5px;
-		border-bottom-right-radius: 5px;
+	.sensei-course-theme-course-progress-bar {
+		height: 1px !important;
+		display: flex;
+		align-items: center;
+
+		.sensei-course-theme-course-progress-bar-inner {
+			border-top-right-radius: 5px !important;
+			border-bottom-right-radius: 5px !important;
+		}
 	}
 
 	.sensei-course-theme__columns .sensei-course-theme__sidebar ~ .sensei-course-theme__main-content {

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
@@ -49,41 +49,50 @@ body.sensei {
 		}
 	}
 
-	.sensei-course-theme__columns .sensei-course-theme__sidebar ~ .sensei-course-theme__main-content {
-		--sensei-lm-sidebar-width: calc(280px + (var(--wp--preset--spacing--edge-space) * 2) - 24px);
-		display: flex;
-		flex-direction: column;
-		align-items: normal;
+	.sensei-course-theme__columns {
+		margin-top: calc(var(--sensei-lm-header-height) + var(--sensei-wpadminbar-offset, 0px)) !important;
 
-		> * {
-			margin-left: unset;
-			margin-right: unset;
-		}
+		.sensei-course-theme__sidebar ~ .sensei-course-theme__main-content {
+			--sensei-lm-sidebar-width: calc(280px + (var(--wp--preset--spacing--edge-space) * 2) - 24px);
+			display: flex;
+			flex-direction: column;
+			align-items: normal;
+			margin-top: 0;
 
-		@media (max-width: 782px) {
-			--sensei-lm-sidebar-width: 0;
-		}
+			> * {
+				margin-left: unset;
+				margin-right: unset;
+			}
 
-		@media (min-width: 890px) {
-			padding-right: calc(var(--wp--preset--spacing--edge-space) - 24px);
-		}
+			@media (max-width: 782px) {
+				--sensei-lm-sidebar-width: 0;
+			}
 
-		// Remove the border on module title.
-		h3.wp-block-sensei-lms-course-theme-lesson-module {
-			padding-left: unset;
-			border: none;
-			color: var(--wp--preset--color--charcoal-4);
-			margin-top: revert-layer;
-		}
+			@media (min-width: 890px) {
+				padding-right: calc(var(--wp--preset--spacing--edge-space) - 24px);
+			}
 
-		h1 {
-			margin-block-start: var(--wp--preset--spacing--50);
-			margin-block-end: var(--wp--preset--spacing--30);
-			font-weight: 500;
-		}
+			// Remove the border on module title.
+			h3.wp-block-sensei-lms-course-theme-lesson-module {
+				padding-left: unset;
+				border: none;
+				color: var(--wp--preset--color--charcoal-4);
+				margin-block-start: 0;
+			}
 
-		.wp-block-sensei-lms-course-theme-notices {
-			order: 1;
+			h1 {
+				margin-block-start: var(--wp--preset--spacing--50);
+				font-weight: 500;
+			}
+
+			.wp-block-sensei-lms-course-theme-notices {
+				order: 1;
+				margin-bottom: 39px;
+
+				&:empty {
+					display: none;
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
Resolves #2638 #2809

This PR goes through the breadcrumbs, sidebar nav, and the main content style to make them align with the latest design, for both non-standalone and standalone lessons.

**Non-Standalone**
| Nav | Main Content |
|-|-|
| <img width="359" alt="Screenshot 2024-08-26 at 13 26 13" src="https://github.com/user-attachments/assets/7fde59ea-1e71-4f41-af1c-85301002f7df"> | <img width="1066" alt="Screenshot 2024-08-26 at 14 17 45" src="https://github.com/user-attachments/assets/73bb357f-e93e-40c1-8bb2-68ff388e7bff"> |

| Rounded Progress Bar |
|-|
| <img width="1595" alt="image" src="https://github.com/user-attachments/assets/aa810e6c-6de1-4f05-a209-b666b464c239"> |

**Standalone**
<img width="1268" alt="image" src="https://github.com/user-attachments/assets/b29acc55-df40-4e91-aa83-0b5f182747b0">
