### PR TITLE
Make course lessons publicly previewable by default

### DIFF
--- a/wp-content/plugins/wporg-learn/inc/post-meta.php
+++ b/wp-content/plugins/wporg-learn/inc/post-meta.php
@@ -22,6 +22,7 @@ add_action( 'save_post_wporg_workshop', __NAMESPACE__ . '\save_workshop_meta_fie
 add_action( 'save_post_meeting', __NAMESPACE__ . '\save_meeting_metabox_fields' );
 add_action( 'admin_footer', __NAMESPACE__ . '\render_locales_list' );
 add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_editor_assets' );
+add_action( 'wp_insert_post', __NAMESPACE__ . '\set_default_lesson_preview', 10, 3 );
 
 /**
  * Register all post meta keys.
@@ -51,6 +52,34 @@ function register_lesson_meta() {
 			},
 		),
 	);
+}
+
+/**
+ * Set public preview to be enabled on lessons created within a course by default.
+ * This post meta is registered by Sensei with no default value, so we set it here on lesson creation.
+ *
+ * @param int     $post_ID Post ID.
+ * @param WP_Post $post    Post object.
+ * @param bool    $update  Whether this is an existing post being updated.
+ */
+function set_default_lesson_preview( $post_ID, $post, $update ) {
+	// Only run for new lessons.
+	if ( $update || 'lesson' !== $post->post_type ) {
+		return;
+	}
+
+	// Check if the lesson belongs to a course.
+	$course_id = get_post_meta( $post_ID, '_lesson_course', true );
+
+	if ( empty( $course_id ) ) {
+		return;
+	}
+
+	$existing_value = get_post_meta( $post_ID, '_lesson_preview', true );
+
+	if ( '' === $existing_value ) {
+		update_post_meta( $post_ID, '_lesson_preview', 'preview' );
+	}
 }
 
 /**


### PR DESCRIPTION
Closes #2807

Use the `wp_insert_post` hook to set public preview to be enabled by default on lessons which belong a course.

@jonathanbossenger we could enable public preview by default for all lessons, but your [comment](https://github.com/WordPress/Learn/issues/2446#issuecomment-2122057499) made me think we only want to do it for course lessons. Let me know if this isn't a requirement 🙏 

| Admin | Frontend |
|--------|--------|
| ![Screenshot 2024-08-30 at 5 42 05 PM](https://github.com/user-attachments/assets/519dca03-0b85-4848-a582-b3ffe6a4be19) | ![Screenshot 2024-08-30 at 5 43 45 PM](https://github.com/user-attachments/assets/99690971-5112-4130-be6b-44a10aeb02e1) | 

### Testing

#### Course lesson
1. Create a course and add a lesson to the course outline
2. When the draft is created it should have `_lesson_preview` meta set. The 'preview' pill should appear in the editor on the lesson in the outline.
3. Edit the lesson and check that the Preview checkbox is ticked
4. Logout and view the lesson on the frontend. You should be able to view the content without being logged in.

#### Standalone lesson
1. Create a lesson outside of a course
2. Preview post meta should not be set