### PR TITLE
fix the first query item doesn't display except

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2024/patterns/archive-lessons-content.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/archive-lessons-content.php
@@ -5,6 +5,8 @@
  * Inserter: no
  */
 
+get_the_excerpt();
+
 ?>
 
 <!-- wp:group {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|50"}}},"layout":{"type":"constrained","justifyContent":"left","contentSize":"750px"}} -->

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/archive-lessons-content.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/archive-lessons-content.php
@@ -5,6 +5,7 @@
  * Inserter: no
  */
 
+// Workaround for the first lesson in the grid not having an automatic excerpt generated.
 get_the_excerpt();
 
 ?>


### PR DESCRIPTION
Fixes #2682

It appears that the first post result of a query doesn't render an automatically generated excerpt due to an ordering issue or because `get_the_excerpt` is not being called. The automatic excerpt will only be generated after a get_the_excerpt call.

I couldn't find a relevant hook to solve this in the source code for the post-template block and post-excerpt block, so a `get_the_excpert` is added at the start.

**Screenshots**
Tested in the sandboxed environment, and everything looks fine. I also went through 20 pages, and they look good.

![Screenshot 2024-09-06 at 05 05 57](https://github.com/user-attachments/assets/700d8ff5-dbc8-4235-b3a6-4735a1dc5033)
![Screenshot 2024-09-06 at 05 06 17](https://github.com/user-attachments/assets/8a430907-4230-4941-ba60-f459d2770b32)
