### PR TITLE
2871 follow-up style updates

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2024/patterns/sensei-lesson-header.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/sensei-lesson-header.php
@@ -7,6 +7,9 @@
  * Original source: https://github.com/Automattic/sensei/blob/af62fb1115daf2063bc56331a7d8b1b3ea805866/themes/sensei-course-theme/patterns/header.html
  */
 
+$course_id = Sensei()->lesson->get_course_id( get_the_ID() );
+$is_user_enrolled = Sensei_Course::is_user_enrolled( $course_id );
+
 ?>
 
 <!-- wp:sensei-lms/ui {"elementClass":"sensei-course-theme__header","className":"sensei-version\u002d\u002d4-16-2"} -->
@@ -22,7 +25,9 @@
 
 			<!-- wp:group {"style":{"spacing":{"blockGap":"16px"}},"className":"sensei-course-theme__header__info","layout":{"type":"flex","flexWrap":"nowrap"}} -->
 			<div class="wp-block-group sensei-course-theme__header__info">
-				<!-- wp:sensei-lms/course-theme-course-progress-counter {"fontSize":"small"} /-->
+				<?php if ( $is_user_enrolled ) : ?>
+					<!-- wp:sensei-lms/course-theme-course-progress-counter {"fontSize":"small"} /-->
+				<?php endif; ?>
 
 				<!-- wp:sensei-lms/exit-course {"fontSize":"small"} /-->
 			</div>

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
@@ -316,11 +316,11 @@ body.sensei {
 								outline-offset: 2.5px;
 								outline: 1.5px solid var(--wp--preset--color--blueberry-1);
 								color: var(--wp--preset--color--white);
-								background-color: (var(--wp--preset--color--blueberry-1));
+								background-color: var(--wp--preset--color--blueberry-1);
 
 								&:hover {
-									color: var(--wp--preset--color--white) !important;
-									background-color: var(--wp--preset--color--deep-blueberry) !important;
+									background-color: var(--sensei-button-outline-hover-color) !important;
+									outline: none;
 								}
 							}
 						}
@@ -411,6 +411,7 @@ body.sensei {
 
 
 		.sensei-course-theme__quiz__footer__wrapper {
+			a,
 			button {
 				font-weight: 600 !important;
 				line-height: 1;
@@ -423,6 +424,30 @@ body.sensei {
 				@media screen and (max-width: 782px) {
 					flex-direction: column;
 					gap: var(--wp--preset--spacing--20);
+				}
+
+				.wp-block-button {
+
+					@media screen and (max-width: 782px) {
+						width: 100%;
+					}
+
+					> a {
+						width: 100%;
+
+						&:focus,
+						&:focus-visible {
+							outline-offset: 4.5px;
+							outline: 1.5px solid var(--wp--preset--color--blueberry-1);
+							color: var(--wp--preset--color--white);
+							background-color: var(--wp--preset--color--blueberry-1);
+							border: none;
+						}
+
+						&:hover {
+							background-color: var(--wp--preset--color--deep-blueberry) !important;
+						}
+					}
 				}
 
 				.sensei-quiz-actions-primary {

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
@@ -218,17 +218,27 @@ body.sensei {
 	.wp-block-sensei-lms-lesson-actions {
 		.wp-block-sensei-lms-button-view-quiz,
 		.wp-block-sensei-lms-button-complete-lesson {
+			> button {
+				font-weight: 600 !important;
+				line-height: 1;
+			}
+		}
+
+		.wp-block-sensei-lms-button-view-quiz {
+			&:hover {
+				background-color: var(--wp--preset--color--deep-blueberry) !important;
+			}
+		}
+
+		.wp-block-sensei-lms-button-complete-lesson {
 			background-color: var(--wp--custom--color--green-50) !important;
 			border-color: transparent;
 
 			&:hover {
-				opacity: 0.9;
+				background-color: var(--wp--custom--color--green-60) !important;
 			}
 
 			> button {
-				font-weight: 600 !important;
-				line-height: 1;
-
 				&:focus,
 				&:focus-visible {
 					outline: var(--wp--custom--color--green-50);

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
@@ -121,7 +121,7 @@ body.sensei {
 			}
 		}
 
-		.sensei-lms-course-navigation-lesson__extra {
+		.sensei-lms-course-navigation-lesson__extra[aria-label^="Preview"] {
 			display: none;
 		}
 	}

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
@@ -411,6 +411,8 @@ body.sensei {
 
 
 		.sensei-course-theme__quiz__footer__wrapper {
+			padding-bottom: var(--wp--preset--spacing--50);
+
 			a,
 			button {
 				font-weight: 600 !important;

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
@@ -259,6 +259,7 @@ body.sensei {
 
 			.sensei-course-theme-quiz-graded-notice {
 				padding: 40px;
+				margin-bottom: var(--wp--preset--spacing--40);
 
 				.sensei-course-theme-quiz-graded-notice__title {
 					font-size: var(--wp--preset--font-size--heading-5);
@@ -398,6 +399,11 @@ body.sensei {
 								margin-left: 0;
 							}
 						}
+					}
+
+					.sensei-lms-question__answer-feedback {
+						margin-bottom: 0;
+						font-size: var(--wp--preset--font-size--small);
 					}
 				}
 			}

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
@@ -12,6 +12,7 @@ body.sensei {
 	--sensei-course-progress-bar-inner-color: var(--wp--custom--color--green-50);
 	--sensei-lesson-meta-color: var(--wp--preset--color--charcoal-4);
 	--sensei-module-lesson-color: var(--wp--preset--color--charcoal-1);
+	--sensei-lm-mobile-header-height: 60px;
 
 	.wp-block-sensei-lms-course-theme-notices:empty {
 		display: none;
@@ -26,18 +27,18 @@ body.sensei {
 			gap: var(--wp--preset--spacing--30);
 		}
 
-		.sensei-course-theme-course-progress::after {
-			content: "";
-			display: inline-block;
-			height: 100%;
-			border-right: 1px solid var(--sensei-course-progress-bar-color);
-			position: absolute;
-			margin-left: 30px;
-			top: 0;
-		}
-
 		.wp-block-sensei-lms-exit-course {
 			margin-left: var(--wp--preset--spacing--30);
+
+			&::before {
+				content: "";
+				display: inline-block;
+				height: 100%;
+				border-right: 1px solid var(--sensei-course-progress-bar-color);
+				position: absolute;
+				margin-left: -30px;
+				top: 0;
+			}
 		}
 	}
 
@@ -692,6 +693,16 @@ body.sensei {
 	.sensei-course-theme__header--standalone {
 		.sensei-course-theme-header-content {
 			border-bottom: 1px solid var(--wp--custom--color--border);
+
+			div:nth-of-type(2)::before {
+				content: "";
+				display: inline-block;
+				height: 100%;
+				border-right: 1px solid var(--sensei-course-progress-bar-color);
+				position: absolute;
+				margin-left: -30px;
+				top: 0;
+			}
 		}
 
 		// Also hide the leading slash for the Lesson title breadcrumb when it is hidden.

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
@@ -337,47 +337,73 @@ body.sensei {
 				padding: 17px 32px !important;
 			}
 
-			.sensei-quiz-actions-primary .sensei-quiz-action {
-				background-color: var(--wp--custom--color--green-50);
-				border-color: transparent !important;
+			.wp-block-sensei-lms-quiz-actions {
 
-				&:hover {
-					background-color: var(--wp--custom--color--green-60);
+				@media screen and (max-width: 782px) {
+					flex-direction: column;
+					gap: var(--wp--preset--spacing--20);
 				}
 
-				> button {
-					&:focus,
-					&:focus-visible {
-						outline: var(--wp--custom--color--green-50);
+				.sensei-quiz-actions-primary {
+
+					@media screen and (max-width: 782px) {
+						width: 100%;
+					}
+
+					.sensei-quiz-action {
+						background-color: var(--wp--custom--color--green-50);
+						border-color: transparent !important;
+
+						&:hover {
+							background-color: var(--wp--custom--color--green-60);
+						}
+
+						> button {
+							&:focus,
+							&:focus-visible {
+								outline: var(--wp--custom--color--green-50);
+							}
+						}
 					}
 				}
-			}
 
-			.sensei-quiz-actions-secondary {
-				gap: var(--wp--preset--spacing--20);
+				.sensei-quiz-actions-secondary {
 
-				.sensei-quiz-action {
-					border: solid 1px var(--sensei-secondary-color);
-					border-radius: 2px;
-
-					&:hover {
-						background-color: var(--sensei-button-outline-hover-color);
+					@media screen and (max-width: 782px) {
+						flex-direction: column;
+						width: 100%;
 					}
+					gap: var(--wp--preset--spacing--20);
 
-					> button {
-						color: var(--sensei-primary-color);
-						text-decoration: none !important;
+					.sensei-quiz-action {
+						border: solid 1px var(--sensei-secondary-color);
+						border-radius: 2px;
+						text-align: center;
 
-						&:focus,
-						&:focus-visible {
-							background-color: var(--wp--custom--button--outline--focus--color--background);
-							outline: -webkit-focus-ring-color auto 1px;
-							color: var(--wp--custom--button--outline--hover--color--text);
-							box-shadow: inset 0 0 0 3px var(--wp--preset--color--white);
+						@media screen and (max-width: 782px) {
+							width: 100%;
+						}
 
-							&:hover {
-								background-color: var(--sensei-button-outline-hover-color);
-								color: var(--sensei-primary-color);
+						&:hover {
+							background-color: var(--sensei-button-outline-hover-color);
+						}
+
+						> button {
+							color: var(--sensei-primary-color);
+							text-decoration: none !important;
+							width: 100%;
+
+							&:focus,
+							&:focus-visible {
+								background-color: var(--wp--custom--button--outline--focus--color--background);
+								outline: -webkit-focus-ring-color auto 1px;
+								color: var(--wp--custom--button--outline--hover--color--text);
+								box-shadow: inset 0 0 0 3px var(--wp--preset--color--white);
+
+								&:hover {
+									background-color: var(--sensei-button-outline-hover-color);
+									color: var(--sensei-primary-color);
+								}
 							}
 						}
 					}

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
@@ -105,7 +105,24 @@ body.sensei {
 
 			.sensei-lms-course-navigation-lesson__status {
 				margin-top: 6px;
+
+				&[aria-label="Preview"] {
+					display: none;
+
+					+ .sensei-lms-course-navigation-lesson__title {
+						padding-left: 0;
+						margin-left: 18px;
+						text-decoration: none;
+						display: list-item;
+						list-style-type: disc;
+						list-style-position: outside;
+					}
+				}
 			}
+		}
+
+		.sensei-lms-course-navigation-lesson__extra {
+			display: none;
 		}
 	}
 

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
@@ -13,6 +13,10 @@ body.sensei {
 	--sensei-lesson-meta-color: var(--wp--preset--color--charcoal-4);
 	--sensei-module-lesson-color: var(--wp--preset--color--charcoal-1);
 
+	.wp-block-sensei-lms-course-theme-notices:empty {
+		display: none;
+	}
+
 	.sensei-course-theme-header-content {
 		> .wp-block-group {
 			row-gap: 0;
@@ -85,10 +89,6 @@ body.sensei {
 			.wp-block-sensei-lms-course-theme-notices {
 				margin-block-end: 39px;
 				margin-block-start: var(--wp--preset--spacing--40);
-
-				&:empty {
-					display: none;
-				}
 			}
 		}
 	}
@@ -254,59 +254,62 @@ body.sensei {
 	}
 
 	&.quiz {
-		#sensei-quiz-list .question-title {
-			font-size: var(--wp--preset--font-size--heading-4);
-		}
+		entry-content {
+			#sensei-quiz-list .wp-block-sensei-lms-quiz-question {
+				margin-top: var(--wp--preset--spacing--40);
 
-		.wp-block-sensei-lms-quiz .wp-block-sensei-lms-quiz-question {
-			margin-top: var(--wp--preset--spacing--40);
-		}
+				.sensei-lms-question-block__header {
+					margin-bottom: var(--wp--preset--spacing--20);
 
-		.wp-block-sensei-lms-quiz .sensei-lms-question-block__header {
-			margin-bottom: var(--wp--preset--spacing--20);
-		}
+					.question-title {
+						font-size: var(--wp--preset--font-size--heading-4);
+					}
+				}
 
-		#sensei-quiz-list fieldset {
-			padding: 0;
-			border: none;
+				fieldset {
+					padding: 0;
+					border: none;
 
-			ul {
-				margin-top: 0;
+					ul {
+						margin-top: 0;
+
+						li input,
+						.sensei-multiple-choice-answer-option-checkbox + label::before {
+							flex-shrink: 0;
+						}
+
+						li input:focus,
+						.sensei-multiple-choice-answer-option-checkbox:focus + label::before {
+							outline: 1.5px solid var(--wp--preset--color--blueberry-1);
+							outline-offset: 1.5px;
+						}
+
+						.sensei-multiple-choice-answer-option-checkbox {
+							// Checkboxes need to be displayed, otherwise keyboard nav will not work.
+							// The following code is copied from `screen-reader-text` so that the checkboxes
+							// exist on the page, but are not shown visually. The visual checkboxes are added
+							// by `::before` on the label.
+							display: initial !important;
+							clip: rect(1px, 1px, 1px, 1px);
+							word-wrap: normal !important;
+							border: 0;
+							clip-path: inset(50%);
+							height: 1px;
+							margin: -1px;
+							overflow: hidden;
+							padding: 0;
+							position: absolute;
+							width: 1px;
+
+							+ label {
+								margin-left: 0;
+							}
+						}
+					}
+				}
 			}
 		}
 
-		#sensei-quiz-list li ul li input,
-		#sensei-quiz-list .sensei-multiple-choice-answer-option-checkbox + label::before {
-			flex-shrink: 0;
-		}
-
-		#sensei-quiz-list li ul li input:focus,
-		#sensei-quiz-list .sensei-multiple-choice-answer-option-checkbox:focus + label::before {
-			outline: 1.5px solid var(--wp--preset--color--blueberry-1);
-			outline-offset: 1.5px;
-		}
-
-		#sensei-quiz-list .sensei-multiple-choice-answer-option-checkbox {
-			// Checkboxes need to be displayed, otherwise keyboard nav will not work.
-			// The following code is copied from `screen-reader-text` so that the checkboxes
-			// exist on the page, but are not shown visually. The visual checkboxes are added
-			// by `::before` on the label.
-			display: initial !important;
-			clip: rect(1px, 1px, 1px, 1px);
-			word-wrap: normal !important;
-			border: 0;
-			clip-path: inset(50%);
-			height: 1px;
-			margin: -1px;
-			overflow: hidden;
-			padding: 0;
-			position: absolute;
-			width: 1px;
-
-			+ label {
-				margin-left: 0;
-			}
-		}
 
 		.sensei-course-theme__quiz__footer__wrapper {
 			button {

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
@@ -84,7 +84,7 @@ body.sensei {
 
 			.wp-block-sensei-lms-course-theme-notices {
 				margin-block-end: 39px;
-				margin-block-start: 0;
+				margin-block-start: var(--wp--preset--spacing--40);
 
 				&:empty {
 					display: none;

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
@@ -51,6 +51,7 @@ body.sensei {
 			border-top-right-radius: 5px !important;
 			border-bottom-right-radius: 5px !important;
 			height: 4px !important;
+			z-index: 1;
 		}
 	}
 

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
@@ -254,15 +254,27 @@ body.sensei {
 	}
 
 	&.quiz {
-		entry-content {
-			#sensei-quiz-list .wp-block-sensei-lms-quiz-question {
-				margin-top: var(--wp--preset--spacing--40);
+		.entry-content {
+			margin-top: 0;
+
+			#sensei-quiz-list {
+				margin-block-end: 0;
+
+				.wp-block-sensei-lms-quiz-question {
+					margin-top: 0;
+
+					&:not(:first-of-type) {
+						margin-top: var(--wp--preset--spacing--40);
+					}
+				}
 
 				.sensei-lms-question-block__header {
 					margin-bottom: var(--wp--preset--spacing--20);
 
 					.question-title {
-						font-size: var(--wp--preset--font-size--heading-4);
+						font-size: var(--wp--preset--font-size--heading-6);
+						font-family: var(--wp--preset--font-family--inter);
+						font-weight: 600;
 					}
 				}
 
@@ -270,15 +282,21 @@ body.sensei {
 					padding: 0;
 					border: none;
 
-					ul {
+					.answers {
 						margin-top: 0;
 
-						li input,
+						li > label {
+							font-family: var(--wp--preset--font-family--inter);
+							font-size: 16px;
+							font-weight: 400;
+						}
+
+						li > input,
 						.sensei-multiple-choice-answer-option-checkbox + label::before {
 							flex-shrink: 0;
 						}
 
-						li input:focus,
+						li > input:focus,
 						.sensei-multiple-choice-answer-option-checkbox:focus + label::before {
 							outline: 1.5px solid var(--wp--preset--color--blueberry-1);
 							outline-offset: 1.5px;

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
@@ -396,7 +396,7 @@ body.sensei {
 							&:focus,
 							&:focus-visible {
 								background-color: var(--wp--custom--button--outline--focus--color--background);
-								outline: -webkit-focus-ring-color auto 1px;
+								outline: var(--wp--custom--button--outline--focus--color--background) auto 1px;
 								color: var(--wp--custom--button--outline--hover--color--text);
 								box-shadow: inset 0 0 0 3px var(--wp--preset--color--white);
 

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
@@ -307,6 +307,62 @@ body.sensei {
 				margin-left: 0;
 			}
 		}
+
+		.sensei-course-theme__quiz__footer__wrapper {
+			button {
+				font-weight: 600 !important;
+				line-height: 1;
+				font-size: var(--wp--preset--font-size--normal);
+				padding: 17px 32px !important;
+			}
+
+			.sensei-quiz-actions-primary .sensei-quiz-action {
+				background-color: var(--wp--custom--color--green-50);
+				border-color: transparent !important;
+
+				&:hover {
+					background-color: var(--wp--custom--color--green-60);
+				}
+
+				> button {
+					&:focus,
+					&:focus-visible {
+						outline: var(--wp--custom--color--green-50);
+					}
+				}
+			}
+
+			.sensei-quiz-actions-secondary {
+				gap: var(--wp--preset--spacing--20);
+
+				.sensei-quiz-action {
+					border: solid 1px var(--sensei-secondary-color);
+					border-radius: 2px;
+
+					&:hover {
+						background-color: var(--sensei-button-outline-hover-color);
+					}
+
+					> button {
+						color: var(--sensei-primary-color);
+						text-decoration: none !important;
+
+						&:focus,
+						&:focus-visible {
+							background-color: var(--wp--custom--button--outline--focus--color--background);
+							outline: -webkit-focus-ring-color auto 1px;
+							color: var(--wp--custom--button--outline--hover--color--text);
+							box-shadow: inset 0 0 0 3px var(--wp--preset--color--white);
+
+							&:hover {
+								background-color: var(--sensei-button-outline-hover-color);
+								color: var(--sensei-primary-color);
+							}
+						}
+					}
+				}
+			}
+		}
 	}
 
 	section.wp-block-sensei-lms-course-outline {

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
@@ -254,6 +254,81 @@ body.sensei {
 	}
 
 	&.quiz {
+		.wp-block-sensei-lms-course-theme-notices {
+			margin-block-start: 0;
+
+			.sensei-course-theme-quiz-graded-notice {
+				padding: 40px;
+
+				.sensei-course-theme-quiz-graded-notice__title {
+					font-size: var(--wp--preset--font-size--heading-5);
+					font-weight: 600;
+					margin-block-start: 0;
+				}
+
+				.sensei-course-theme-quiz-graded-notice__text {
+					font-size: var(--wp--preset--font-size--normal);
+				}
+
+				.sensei-course-theme-quiz-graded-notice__actions {
+					gap: var(--wp--preset--spacing--20);
+
+					.wp-block-button {
+
+						@media screen and (max-width: 782px) {
+							width: 100%;
+						}
+
+						> a {
+							font-size: var(--wp--preset--font-size--normal);
+							font-weight: 600;
+							width: 100%;
+
+							&:focus,
+							&:focus-visible {
+								border: none;
+								outline-offset: 3.5px;
+								outline: 1.5px solid var(--wp--preset--color--blueberry-1);
+							}
+
+							&:hover {
+								background-color: var(--wp--preset--color--deep-blueberry) !important;
+							}
+						}
+					}
+
+					.sensei-course-theme-quiz-graded-notice__reset-quiz-form {
+						margin-left: 0;
+
+						@media screen and (max-width: 782px) {
+							width: 100%;
+						}
+
+						> button {
+							font-size: var(--wp--preset--font-size--normal);
+							font-weight: 600;
+							border: 1px solid var(--wp--preset--color--blueberry-1);
+							width: 100%;
+
+							&:focus,
+							&:focus-visible {
+								outline-offset: 2.5px;
+								outline: 1.5px solid var(--wp--preset--color--blueberry-1);
+								color: var(--wp--preset--color--white);
+								background-color: (var(--wp--preset--color--blueberry-1));
+
+								&:hover {
+									color: var(--wp--preset--color--white) !important;
+									background-color: var(--wp--preset--color--deep-blueberry) !important;
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+
+
 		.entry-content {
 			margin-top: 0;
 

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_sensei.scss
@@ -506,7 +506,6 @@ body.sensei {
 							&:focus,
 							&:focus-visible {
 								background-color: var(--wp--custom--button--outline--focus--color--background);
-								outline: var(--wp--custom--button--outline--focus--color--background) auto 1px;
 								color: var(--wp--custom--button--outline--hover--color--text);
 								box-shadow: inset 0 0 0 3px var(--wp--preset--color--white);
 

--- a/wp-content/themes/pub/wporg-learn-2024/templates/single-quiz.html
+++ b/wp-content/themes/pub/wporg-learn-2024/templates/single-quiz.html
@@ -2,8 +2,8 @@
 
 <!-- wp:pattern {"slug":"wporg-learn-2024/sensei-lesson-header"} /-->
 
-<!-- wp:group {"className":"sensei-course-theme__quiz__main-content sensei-version\u002d\u002d4-16-2 sensei-course-theme__main-content", "tagName": "main","style"={"spacing":{"padding":{"top":"var:preset|spacing|80","bottom":"var:preset|spacing|edge-space"}}}} -->
-<main class="wp-block-group sensei-course-theme__quiz__main-content sensei-version--4-16-2 sensei-course-theme__main-content" style="padding-top:var(--wp--preset--spacing--80);padding-bottom:var(--wp--preset--spacing--edge-space)">
+<!-- wp:group {"className":"sensei-course-theme__quiz__main-content sensei-version\u002d\u002d4-16-2 sensei-course-theme__main-content", "tagName": "main","style"={"spacing":{"padding":{"top":"var:preset|spacing|80","bottom":"var:preset|spacing|40"}}}} -->
+<main class="wp-block-group sensei-course-theme__quiz__main-content sensei-version--4-16-2 sensei-course-theme__main-content" style="padding-top:var(--wp--preset--spacing--80);padding-bottom:var(--wp--preset--spacing--40)">
 
 	<!-- wp:sensei-lms/quiz-back-to-lesson /-->
 

--- a/wp-content/themes/pub/wporg-learn-2024/templates/single-quiz.html
+++ b/wp-content/themes/pub/wporg-learn-2024/templates/single-quiz.html
@@ -10,7 +10,7 @@
 	<!-- wp:group {"style":{"spacing":{"padding":{"top":"0","bottom":"0"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
 	<div class="wp-block-group" style="margin-top:0;margin-bottom:0;padding-top:0;padding-bottom:0">
 		
-		<!-- wp:post-title {"level":1,"style":{"spacing":{"margin":{"bottom":"0"},"padding":{"bottom":"0"}}},"fontSize":"heading-1"} /-->
+		<!-- wp:post-title {"level":1,"style":{"spacing":{"margin":{"top":"var:preset|spacing|50"}},"typography":{"fontStyle":"normal","fontWeight":"600"}},"fontSize":"heading-3","fontFamily":"inter"} /-->
 
 		<!-- wp:group {"style":{"spacing":{"margin":{"top":"0","bottom":"0"},"padding":{"right":"0","left":"0","top":"0","bottom":"0"}}},"className":"sensei-course-theme__quiz__header__right","layout":{"type":"constrained"}} -->
 		<div class="wp-block-group sensei-course-theme__quiz__header__right" style="margin-top:0;margin-bottom:0;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"></div>

--- a/wp-content/themes/pub/wporg-learn-2024/theme.json
+++ b/wp-content/themes/pub/wporg-learn-2024/theme.json
@@ -48,6 +48,7 @@
 			"color": {
 				"border": "var(--wp--preset--color--light-grey-1)",
 				"green-50": "#008A20",
+				"green-60": "#007017",
 				"green-70": "#005C12"
 			},
 			"form": {


### PR DESCRIPTION
Resolves #2871

**Replace eye icon with bullet point**

![Screenshot 2024-09-06 at 07 22 03](https://github.com/user-attachments/assets/4297e54d-9d94-4a59-8ec4-61d55cfcafcd)

**Single quiz**


https://github.com/user-attachments/assets/4a049f77-3e8d-4dc0-affc-2c2ebd6b4118

**Separator on the standalone lesson page**

![image](https://github.com/user-attachments/assets/024f1dd4-9ccb-4a62-b36f-ef8dac8773a3)

Only shows course progress counter when user is not enrolled

![image](https://github.com/user-attachments/assets/30e55254-ff9b-4f59-bfd9-a867d28a5b79)
