### PR TITLE
Navigation: Add "log in" link to local nav

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2024/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2024/functions.php
@@ -334,6 +334,14 @@ function add_site_navigation_menus( $menus ) {
 			'className' => 'has-separator',
 		),
 	);
+	if ( ! is_user_logged_in() ) {
+		global $wp;
+		$redirect_url = home_url( $wp->request );
+		$menu[] = array(
+			'label' => __( 'Log in', 'wporg-learn' ),
+			'url' => wp_login_url( $redirect_url ),
+		);
+	}
 
 	$learning_pathways = get_terms(
 		array(


### PR DESCRIPTION
This updates Learn to include the "Log in" link in the local navigation across the site. The link only appears when you're logged out, once logged in, you can manage your account/login status in the admin bar. Once logged in, the "Log in" link disappears.

Once merged, the "Logged out admin bar" plugin should be disabled.

See https://github.com/WordPress/wporg-mu-plugins/issues/647

### How to test the changes in this Pull Request:

1. Be logged out
2. There should be a "log in" link
3. Clicking it and signing in should redirect you back to the page you were just on
4. The "log in" link should not appear
5. You should see the admin bar
