### PR TITLE
Add tutorial to lesson migration command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@
 !/wp-content/mu-plugins/pub/class-validator.php
 !/wp-content/mu-plugins/pub/locale-switcher
 !/wp-content/mu-plugins/pub/locale-switcher/.eslintrc.js
+!/wp-content/mu-plugins/pub/wporg-learn-cli.php
 !/wp-content/plugins
 !/wp-content/plugins/wporg-learn
 !/wp-content/plugins/sensei-pro

--- a/wp-content/mu-plugins/pub/wporg-learn-cli.php
+++ b/wp-content/mu-plugins/pub/wporg-learn-cli.php
@@ -24,11 +24,11 @@ class WPORG_Learn_Tutorial_To_Lesson_Command extends WP_CLI_Command {
 	 *
 	 * ## EXAMPLES
 	 *
-	 * wp wporg-learn-tutorial-to-lesson convert https://learn.wordpress.org/tutorial/slug
-	 * wp wporg-learn-tutorial-to-lesson convert urls.txt --file
-	 * wp wporg-learn-tutorial-to-lesson convert urls.txt --file --live
+	 * wp wporg-learn convert-tutorial-to-lesson https://learn.wordpress.org/tutorial/slug
+	 * wp wporg-learn convert-tutorial-to-lesson urls.txt --file
+	 * wp wporg-learn convert-tutorial-to-lesson urls.txt --file --live
 	 */
-	public function convert( $args, $assoc_args ) {
+	public function __invoke( $args, $assoc_args ) {
 		$source = $args[0];
 		$is_dry_run = ! isset( $assoc_args['live'] );
 		$is_file = isset( $assoc_args['file'] );
@@ -110,4 +110,4 @@ class WPORG_Learn_Tutorial_To_Lesson_Command extends WP_CLI_Command {
 	}
 }
 
-WP_CLI::add_command( 'wporg-learn-tutorial-to-lesson', 'WPORG_Learn_Tutorial_To_Lesson_Command' );
+WP_CLI::add_command( 'wporg-learn convert-tutorial-to-lesson', 'WPORG_Learn_Tutorial_To_Lesson_Command' );

--- a/wp-content/mu-plugins/pub/wporg-learn-cli.php
+++ b/wp-content/mu-plugins/pub/wporg-learn-cli.php
@@ -1,0 +1,85 @@
+<?php
+
+if ( ! defined( 'WP_CLI' ) ) {
+	return;
+}
+
+/**
+ * Converts a tutorial post to a lesson post type.
+ */
+class WPORG_Learn_Tutorial_To_Lesson_Command extends WP_CLI_Command {
+	/**
+	 * Converts a tutorial post to a lesson based on the provided URL.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <url>
+	 * : The URL of the tutorial post to convert
+	 *
+	 * [--live]
+	 * : Actually perform the conversion (default is dry-run)
+	 *
+	 * ## EXAMPLES
+	 *
+	 * wp wporg-learn-tutorial-to-lesson convert https://learn.wordpress.org/tutorial/slug
+	 * wp wporg-learn-tutorial-to-lesson convert https://learn.wordpress.org/tutorial/slug --live
+	 *
+	 * @param array $args Command arguments.
+	 * @param array $assoc_args Associative arguments.
+	 */
+	public function convert( $args, $assoc_args ) {
+		$url = $args[0];
+		$is_dry_run = ! isset( $assoc_args['live'] );
+
+		// Get post ID from URL
+		$post_id = url_to_postid( $url );
+
+		if ( ! $post_id ) {
+			WP_CLI::error( "No post found for URL: $url" );
+			return;
+		}
+
+		$post = get_post( $post_id );
+
+		if ( ! $post ) {
+			WP_CLI::error( "Could not retrieve post with ID: $post_id" );
+			return;
+		}
+
+		if ( 'wporg_workshop' !== $post->post_type ) {
+			WP_CLI::error( "Post is not a tutorial (Post ID: $post_id)" );
+			return;
+		}
+
+		if ( 'lesson' === $post->post_type ) {
+			WP_CLI::error( "Post is already a lesson (Post ID: $post_id)" );
+			return;
+		}
+
+		if ( $is_dry_run ) {
+			WP_CLI::line( sprintf(
+				"Dry run for:\nURL: %s\nTitle: %s\nPost ID: %d\nPost Type: %s\n---------------",
+				$url,
+				$post->post_title,
+				$post_id,
+				$post->post_type
+			) );
+			return;
+		}
+
+		// Update the post type
+		$updated = wp_update_post( array(
+			'ID' => $post_id,
+			'post_type' => 'lesson',
+		) );
+
+		if ( is_wp_error( $updated ) ) {
+			WP_CLI::error( 'Failed to update post type: ' . $updated->get_error_message() );
+			return;
+		}
+
+		WP_CLI::success( "Successfully converted tutorial to lesson (Post ID: $post_id)" );
+	}
+}
+
+WP_CLI::add_command( 'wporg-learn-tutorial-to-lesson', 'WPORG_Learn_Tutorial_To_Lesson_Command' );

--- a/wp-content/mu-plugins/pub/wporg-learn-cli.php
+++ b/wp-content/mu-plugins/pub/wporg-learn-cli.php
@@ -9,50 +9,78 @@ if ( ! defined( 'WP_CLI' ) ) {
  */
 class WPORG_Learn_Tutorial_To_Lesson_Command extends WP_CLI_Command {
 	/**
-	 * Converts a tutorial post to a lesson based on the provided URL.
+	 * Converts tutorials to lessons based on the provided URL or file.
 	 *
 	 * ## OPTIONS
 	 *
-	 * <url>
-	 * : The URL of the tutorial post to convert
+	 * <source>
+	 * : The URL of the tutorial post to convert, or path to a file containing URLs (one per line)
 	 *
 	 * [--live]
 	 * : Actually perform the conversion (default is dry-run)
 	 *
+	 * [--file]
+	 * : Indicates that the source is a file containing URLs
+	 *
 	 * ## EXAMPLES
 	 *
 	 * wp wporg-learn-tutorial-to-lesson convert https://learn.wordpress.org/tutorial/slug
-	 * wp wporg-learn-tutorial-to-lesson convert https://learn.wordpress.org/tutorial/slug --live
-	 *
-	 * @param array $args Command arguments.
-	 * @param array $assoc_args Associative arguments.
+	 * wp wporg-learn-tutorial-to-lesson convert urls.txt --file
+	 * wp wporg-learn-tutorial-to-lesson convert urls.txt --file --live
 	 */
 	public function convert( $args, $assoc_args ) {
-		$url = $args[0];
+		$source = $args[0];
 		$is_dry_run = ! isset( $assoc_args['live'] );
+		$is_file = isset( $assoc_args['file'] );
 
+		$urls = array();
+		if ( $is_file ) {
+			if ( ! file_exists( $source ) ) {
+				WP_CLI::error( "File not found: $source" );
+				return;
+			}
+			$urls = array_filter( explode( "\n", file_get_contents( $source ) ) );
+		} else {
+			$urls = array( $source );
+		}
+
+		foreach ( $urls as $url ) {
+			$url = trim( $url );
+			if ( empty( $url ) ) {
+				continue;
+			}
+
+			// Process each URL
+			$this->process_url( $url, $is_dry_run );
+		}
+	}
+
+	/**
+	 * Process a single URL.
+	 */
+	private function process_url( $url, $is_dry_run ) {
 		// Get post ID from URL
 		$post_id = url_to_postid( $url );
 
 		if ( ! $post_id ) {
-			WP_CLI::error( "No post found for URL: $url" );
+			WP_CLI::warning( "No post found for URL: $url" );
 			return;
 		}
 
 		$post = get_post( $post_id );
 
 		if ( ! $post ) {
-			WP_CLI::error( "Could not retrieve post with ID: $post_id" );
+			WP_CLI::warning( "Could not retrieve post with ID: $post_id" );
 			return;
 		}
 
 		if ( 'wporg_workshop' !== $post->post_type ) {
-			WP_CLI::error( "Post is not a tutorial (Post ID: $post_id)" );
+			WP_CLI::warning( "Post is not a tutorial (Post ID: $post_id)" );
 			return;
 		}
 
 		if ( 'lesson' === $post->post_type ) {
-			WP_CLI::error( "Post is already a lesson (Post ID: $post_id)" );
+			WP_CLI::warning( "Post is already a lesson (Post ID: $post_id)" );
 			return;
 		}
 
@@ -74,7 +102,7 @@ class WPORG_Learn_Tutorial_To_Lesson_Command extends WP_CLI_Command {
 		) );
 
 		if ( is_wp_error( $updated ) ) {
-			WP_CLI::error( 'Failed to update post type: ' . $updated->get_error_message() );
+			WP_CLI::warning( 'Failed to update post type: ' . $updated->get_error_message() );
 			return;
 		}
 


### PR DESCRIPTION
See #2393 
Closes https://github.com/WordPress/Learn/issues/3043

Adds a CLI command to mu-plugins for converting tutorials to lessons, by changing the post type. Takes a single post URL, or file with a list of URLs, which will be created from this [sheet](https://docs.google.com/spreadsheets/d/1D_caQxJs55eIinGTlIb7du_vE5FBxn4ri7pAWI5K2RE/edit?gid=0#gid=0).

By default runs in dry mode, which prints the details of the post(s).

I plan to update the sync script to copy this into `wporg/public_html/wp-content/mu-plugins/pub`