### PR TITLE
Fix Button Alignment Issue on Report Feedback Page in Learn WordPress

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_jetpack.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_jetpack.scss
@@ -8,6 +8,10 @@
 	font-weight: 600;
 }
 
+.wp-block-jetpack-contact-form .wp-block-button__link {
+	height: auto;
+}
+
 .wp-block-jetpack-contact-form-container .contact-form {
 	.grunion-checkbox-multiple-options legend,
 	.grunion-radio-options legend,

--- a/wp-content/themes/pub/wporg-learn-2024/src/style/_jetpack.scss
+++ b/wp-content/themes/pub/wporg-learn-2024/src/style/_jetpack.scss
@@ -8,10 +8,6 @@
 	font-weight: 600;
 }
 
-.wp-block-jetpack-contact-form .wp-block-button__link {
-	height: auto;
-}
-
 .wp-block-jetpack-contact-form-container .contact-form {
 	.grunion-checkbox-multiple-options legend,
 	.grunion-radio-options legend,
@@ -29,5 +25,11 @@
 	.contact-form__select-wrapper::after {
 		inset-inline-end: calc(var(--jetpack--contact-form--input-padding-left) + 3px);
 		top: calc(var(--jetpack--contact-form--input-padding-top) + var(--jetpack--contact-form--line-height) / 2);
+	}
+
+	.wp-block-jetpack-button {
+		.wp-block-button__link {
+			height: auto;
+		}
 	}
 }


### PR DESCRIPTION
## What

Fixes https://github.com/WordPress/Learn/issues/3056

This PR addresses the issue where the Submit button's design mismatches when error messages are displayed on the Report Feedback page after form submission.

## Why

The design inconsistency arises due to the .contact-form__error div inserted above the button, which alters its alignment and style.
This fix ensures a consistent design for the Submit button in all states (normal and error).


## How

Fixed by adding custom css overriding the button css.

## Testing Instructions

1. Visit the Report Feedback page at https://learn.wordpress.org/report-content-feedback/.
2. Submit the form with invalid inputs to trigger error messages.
3. The Submit button retains its design.
4. The layout and alignment remain consistent.

## Before 
 
![form_button_before](https://github.com/user-attachments/assets/b7721ba8-b938-4989-b912-4111415baab0)


## After

![form_button_fix](https://github.com/user-attachments/assets/af1e639e-b42d-4221-aab2-d9485391be41)
