### PR TITLE
Update taxonomy.php

### DIFF
--- a/wp-content/plugins/wporg-learn/inc/taxonomy.php
+++ b/wp-content/plugins/wporg-learn/inc/taxonomy.php
@@ -682,7 +682,7 @@ function tax_edit_term_fields( $term, $taxonomy ) {
  * @param int $term_id the term id to update.
  */
 function tax_save_term_fields( $term_id ) {
-	$wp_list_table = _get_list_table( 'WP_Terms_List_Table' );
+	$wp_list_table = \_get_list_table( 'WP_Terms_List_Table' );
 
 	if ( 'add-tag' === $wp_list_table->current_action() ) {
 		check_admin_referer( 'add-tag', '_wpnonce_add-tag' );


### PR DESCRIPTION
Avoid fatal error for WP core function in namespace.

```
E_ERROR: Uncaught Error: Call to undefined function WPOrg_Learn\Taxonomy\_get_list_table() in [..]/plugins/wporg-learn/inc/taxonomy.php:685
```

cc @adamwoodnz 