### PR TITLE
Avoid PHP Fatal when duration fields are left blank.

### DIFF
--- a/wp-content/plugins/wporg-learn/inc/post-meta.php
+++ b/wp-content/plugins/wporg-learn/inc/post-meta.php
@@ -664,6 +664,7 @@ function save_workshop_meta_fields( $post_id ) {
 
 	$duration = filter_input( INPUT_POST, 'duration', FILTER_SANITIZE_NUMBER_INT, FILTER_REQUIRE_ARRAY );
 	if ( isset( $duration['h'], $duration['m'], $duration['s'] ) ) {
+		$duration = array_map( 'absint', $duration );
 		$duration = $duration['h'] * HOUR_IN_SECONDS + $duration['m'] * MINUTE_IN_SECONDS + $duration['s'];
 		update_post_meta( $post_id, 'duration', $duration );
 	}


### PR DESCRIPTION
If the duration fields are left blank, under PHP8 a fatal will be thrown:

> E_ERROR: Uncaught TypeError: Unsupported operand types: string * int

This can be shown in PHP as such:
```
$in = [ "h" => "4", "m" => "", "s" => "" ];
$in = filter_var( $in, FILTER_SANITIZE_NUMBER_INT, FILTER_REQUIRE_ARRAY );
var_dump( $in );
var_dump( $in['h'] * 1 + $in['m'] * 1 + $in['s'] );
```

which results in:
```
array(3) {
  'h' =>
  string(1) "4"
  'm' =>
  string(0) ""
  's' =>
  string(0) ""
}

Fatal error: Uncaught TypeError: Unsupported operand types: string * int
```