### PR TITLE
Replace FILTER_SANITIZE_STRING into better data sanitisation

### DIFF
--- a/wp-content/plugins/wporg-learn/inc/admin.php
+++ b/wp-content/plugins/wporg-learn/inc/admin.php
@@ -246,10 +246,10 @@ function add_admin_list_table_filters( $post_type, $which ) {
 		return;
 	}
 
-	$audience    = isset( $_GET['wporg_audience'] ) ? sanitize_text_field( $_GET['wporg_audience'] ) : '';
-	$language    = isset( $_GET['language'] ) ? sanitize_text_field( $_GET['language'] ) : '';
-	$level       = isset( $_GET['wporg_experience_level'] ) ? sanitize_text_field( $_GET['wporg_experience_level'] ) : '';
-	$post_status = isset( $_GET['post_status'] ) ? sanitize_text_field( $_GET['post_status'] ) : '';
+	$audience    = sanitize_text_field( wp_unslash( $_GET['wporg_audience'] ?? '' ) );
+	$language    = sanitize_text_field( wp_unslash( $_GET['language'] ?? '' ) );
+	$level       = sanitize_text_field( wp_unslash( $_GET['wporg_experience_level'] ?? '' ) );
+	$post_status = sanitize_text_field( wp_unslash( $_GET['post_status'] ?? '' ) );
 
 	$available_audiences = get_available_taxonomy_terms( 'audience', $post_type, $post_status );
 	$available_levels    = get_available_taxonomy_terms( 'level', $post_type, $post_status );
@@ -326,9 +326,9 @@ function handle_admin_list_table_filters( WP_Query $query ) {
 		'edit-lesson' === $current_screen->id ||
 		'edit-course' === $current_screen->id
 	) {
-		$audience = isset( $_GET['wporg_audience'] ) ? sanitize_text_field( $_GET['wporg_audience'] ) : '';
-		$language = isset( $_GET['language'] ) ? sanitize_text_field( $_GET['language'] ) : '';
-		$level    = isset( $_GET['wporg_experience_level'] ) ? sanitize_text_field( $_GET['wporg_experience_level'] ) : '';
+		$audience = sanitize_text_field( wp_unslash( $_GET['wporg_audience'] ?? '' ) );
+		$language = sanitize_text_field( wp_unslash( $_GET['language'] ?? '' ) );
+		$level    = sanitize_text_field( wp_unslash( $_GET['wporg_experience_level'] ?? '' ) );
 
 		// Tax queries
 		$tax_query = $query->get( 'tax_query', array() );

--- a/wp-content/plugins/wporg-learn/inc/admin.php
+++ b/wp-content/plugins/wporg-learn/inc/admin.php
@@ -246,10 +246,10 @@ function add_admin_list_table_filters( $post_type, $which ) {
 		return;
 	}
 
-	$audience    = filter_input( INPUT_GET, 'wporg_audience', FILTER_SANITIZE_STRING );
-	$language    = filter_input( INPUT_GET, 'language', FILTER_SANITIZE_STRING );
-	$level       = filter_input( INPUT_GET, 'wporg_experience_level', FILTER_SANITIZE_STRING );
-	$post_status = filter_input( INPUT_GET, 'post_status', FILTER_SANITIZE_STRING );
+	$audience    = isset( $_GET['wporg_audience'] ) ? sanitize_text_field( $_GET['wporg_audience'] ) : '';
+	$language    = isset( $_GET['language'] ) ? sanitize_text_field( $_GET['language'] ) : '';
+	$level       = isset( $_GET['wporg_experience_level'] ) ? sanitize_text_field( $_GET['wporg_experience_level'] ) : '';
+	$post_status = isset( $_GET['post_status'] ) ? sanitize_text_field( $_GET['post_status'] ) : '';
 
 	$available_audiences = get_available_taxonomy_terms( 'audience', $post_type, $post_status );
 	$available_levels    = get_available_taxonomy_terms( 'level', $post_type, $post_status );
@@ -326,9 +326,9 @@ function handle_admin_list_table_filters( WP_Query $query ) {
 		'edit-lesson' === $current_screen->id ||
 		'edit-course' === $current_screen->id
 	) {
-		$audience = filter_input( INPUT_GET, 'wporg_audience', FILTER_SANITIZE_STRING );
-		$language = filter_input( INPUT_GET, 'language', FILTER_SANITIZE_STRING );
-		$level    = filter_input( INPUT_GET, 'wporg_experience_level', FILTER_SANITIZE_STRING );
+		$audience = isset( $_GET['wporg_audience'] ) ? sanitize_text_field( $_GET['wporg_audience'] ) : '';
+		$language = isset( $_GET['language'] ) ? sanitize_text_field( $_GET['language'] ) : '';
+		$level    = isset( $_GET['wporg_experience_level'] ) ? sanitize_text_field( $_GET['wporg_experience_level'] ) : '';
 
 		// Tax queries
 		$tax_query = $query->get( 'tax_query', array() );

--- a/wp-content/plugins/wporg-learn/inc/form.php
+++ b/wp-content/plugins/wporg-learn/inc/form.php
@@ -158,8 +158,8 @@ function get_workshop_application_form_submission() {
 	$submission = array();
 
 	foreach ( $schema['properties'] as $field => $config ) {
-		if ( isset( $_POST[ $field ] ) ) {
-			$value = $_POST[ $field ];
+		if ( isset( $_POST[ $field ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+			$value = wp_unslash( $_POST[ $field ] ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
 			if ( isset( $config['sanitize_callback'] ) && is_callable( $config['sanitize_callback'] ) ) {
 				$value = call_user_func( $config['sanitize_callback'], $value );
 			}

--- a/wp-content/plugins/wporg-learn/inc/form.php
+++ b/wp-content/plugins/wporg-learn/inc/form.php
@@ -20,125 +20,129 @@ function get_workshop_application_field_schema() {
 		'label'      => 'submission',
 		'properties' => array(
 			'wporg-user-name'         => array(
-				'input_filters' => FILTER_SANITIZE_STRING,
-				'label'         => __( 'WordPress.org User Name', 'wporg-learn' ),
-				'type'          => 'string',
-				'required'      => true,
-				'default'       => '',
+				'sanitize_callback' => 'sanitize_text_field',
+				'label'             => __( 'WordPress.org User Name', 'wporg-learn' ),
+				'type'              => 'string',
+				'required'          => true,
+				'default'           => '',
 			),
 			'first-name'              => array(
-				'input_filters' => FILTER_SANITIZE_STRING,
-				'label'         => __( 'First Name', 'wporg-learn' ),
-				'type'          => 'string',
-				'required'      => false,
-				'default'       => '',
+				'sanitize_callback' => 'sanitize_text_field',
+				'label'             => __( 'First Name', 'wporg-learn' ),
+				'type'              => 'string',
+				'required'          => false,
+				'default'           => '',
 			),
 			'last-name'               => array(
-				'input_filters' => FILTER_SANITIZE_STRING,
-				'label'         => __( 'Last Name', 'wporg-learn' ),
-				'type'          => 'string',
-				'required'      => false,
-				'default'       => '',
+				'sanitize_callback' => 'sanitize_text_field',
+				'label'             => __( 'Last Name', 'wporg-learn' ),
+				'type'              => 'string',
+				'required'          => false,
+				'default'           => '',
 			),
 			'email'                   => array(
-				'input_filters' => FILTER_SANITIZE_EMAIL,
-				'label'         => __( 'Email', 'wporg-learn' ),
-				'type'          => 'string',
-				'format'        => 'email',
-				'required'      => true,
-				'default'       => '',
+				'sanitize_callback' => 'sanitize_email',
+				'label'             => __( 'Email', 'wporg-learn' ),
+				'type'              => 'string',
+				'format'            => 'email',
+				'required'          => true,
+				'default'           => '',
 			),
 			'online-presence'         => array(
-				'input_filters' => FILTER_SANITIZE_STRING,
-				'label'         => __( 'Where can we find you online? Please share links to your website(s) and as many social media accounts as applicable, including but not limited to Twitter, LinkedIn, Facebook, Instagram, etc.', 'wporg-learn' ),
-				'type'          => 'string',
-				'required'      => true,
-				'default'       => '',
+				'sanitize_callback' => 'sanitize_textarea_field',
+				'label'             => __( 'Where can we find you online? Please share links to your website(s) and as many social media accounts as applicable, including but not limited to Twitter, LinkedIn, Facebook, Instagram, etc.', 'wporg-learn' ),
+				'type'              => 'string',
+				'required'          => true,
+				'default'           => '',
 			),
 			'workshop-title'          => array(
-				'input_filters' => FILTER_SANITIZE_STRING,
-				'label'         => __( 'Workshop Title', 'wporg-learn' ),
-				'type'          => 'string',
-				'required'      => true,
-				'default'       => '',
+				'sanitize_callback' => 'sanitize_text_field',
+				'label'             => __( 'Workshop Title', 'wporg-learn' ),
+				'type'              => 'string',
+				'required'          => true,
+				'default'           => '',
 			),
 			'description'             => array(
-				'input_filters' => FILTER_SANITIZE_STRING,
-				'label'         => __( 'Full workshop description', 'wporg-learn' ),
-				'type'          => 'string',
-				'required'      => true,
-				'default'       => '',
+				'sanitize_callback' => 'sanitize_textarea_field',
+				'label'             => __( 'Full workshop description', 'wporg-learn' ),
+				'type'              => 'string',
+				'required'          => true,
+				'default'           => '',
 			),
 			'description-short'       => array(
-				'input_filters' => FILTER_SANITIZE_STRING,
-				'label'         => __( 'Brief workshop description (less than 150 words)', 'wporg-learn' ),
-				'type'          => 'string',
-				'required'      => true,
-				'default'       => '',
+				'sanitize_callback' => 'sanitize_textarea_field',
+				'label'             => __( 'Brief workshop description (less than 150 words)', 'wporg-learn' ),
+				'type'              => 'string',
+				'required'          => true,
+				'default'           => '',
 			),
 			'learning-objectives'     => array(
-				'input_filters' => FILTER_SANITIZE_STRING,
-				'label'         => __( 'What are the learning objectives for this workshop?', 'wporg-learn' ),
-				'type'          => 'string',
-				'required'      => true,
-				'default'       => '',
+				'sanitize_callback' => 'sanitize_textarea_field',
+				'label'             => __( 'What are the learning objectives for this workshop?', 'wporg-learn' ),
+				'type'              => 'string',
+				'required'          => true,
+				'default'           => '',
 			),
 			'comprehension-questions' => array(
-				'input_filters' => FILTER_SANITIZE_STRING,
-				'label'         => __( 'What comprehension questions should we ask at the end of your workshop? List at least 3 but no more than 10 questions for workshop viewers to answer on their own or discuss with a group to ensure they properly understood the material.', 'wporg-learn' ),
-				'type'          => 'string',
-				'required'      => true,
-				'default'       => '',
+				'sanitize_callback' => 'sanitize_textarea_field',
+				'label'             => __( 'What comprehension questions should we ask at the end of your workshop? List at least 3 but no more than 10 questions for workshop viewers to answer on their own or discuss with a group to ensure they properly understood the material.', 'wporg-learn' ),
+				'type'              => 'string',
+				'required'          => true,
+				'default'           => '',
 			),
 			'audience'                => array(
-				'input_filters' => array(
-					'filter' => FILTER_SANITIZE_STRING,
-					'flags'  => FILTER_REQUIRE_ARRAY,
-				),
-				'label'         => __( 'Who is this workshop intended for?', 'wporg-learn' ),
-				'type'          => 'array',
-				'items'         => array(
+				'sanitize_callback' => function( $value ) {
+					if ( ! is_array( $value ) ) {
+						return array();
+					}
+					return array_map( 'sanitize_text_field', $value );
+				},
+				'label'             => __( 'Who is this workshop intended for?', 'wporg-learn' ),
+				'type'              => 'array',
+				'items'             => array(
 					'type' => 'string',
 				),
-				'minItems'      => 1,
-				'required'      => true,
-				'default'       => array(),
+				'minItems'          => 1,
+				'required'          => true,
+				'default'           => array(),
 			),
 			'experience-level'        => array(
-				'input_filters' => array(
-					'filter' => FILTER_SANITIZE_STRING,
-					'flags'  => FILTER_REQUIRE_ARRAY,
-				),
-				'label'         => __( 'What experience level is this workshop aimed at?', 'wporg-learn' ),
-				'type'          => 'array',
-				'items'         => array(
+				'sanitize_callback' => function( $value ) {
+					if ( ! is_array( $value ) ) {
+						return array();
+					}
+					return array_map( 'sanitize_text_field', $value );
+				},
+				'label'             => __( 'What experience level is this workshop aimed at?', 'wporg-learn' ),
+				'type'              => 'array',
+				'items'             => array(
 					'type' => 'string',
 				),
-				'minItems'      => 1,
-				'required'      => true,
-				'default'       => array(),
+				'minItems'          => 1,
+				'required'          => true,
+				'default'           => array(),
 			),
 			'language'                => array(
-				'input_filters' => FILTER_SANITIZE_STRING,
-				'label'         => __( 'In what language will this workshop be presented?', 'wporg-learn' ),
-				'type'          => 'string',
-				'enum'          => array_keys( get_locales_with_english_names() ),
-				'required'      => true,
-				'default'       => 'en_US',
+				'sanitize_callback' => 'sanitize_text_field',
+				'label'             => __( 'In what language will this workshop be presented?', 'wporg-learn' ),
+				'type'              => 'string',
+				'enum'              => array_keys( get_locales_with_english_names() ),
+				'required'          => true,
+				'default'           => 'en_US',
 			),
 			'comments'                => array(
-				'input_filters' => FILTER_SANITIZE_STRING,
-				'label'         => __( 'Is there anything else you think we should know?', 'wporg-learn' ),
-				'type'          => 'string',
-				'required'      => false,
-				'default'       => '',
+				'sanitize_callback' => 'sanitize_textarea_field',
+				'label'             => __( 'Is there anything else you think we should know?', 'wporg-learn' ),
+				'type'              => 'string',
+				'required'          => false,
+				'default'           => '',
 			),
 			'nonce'                   => array(
-				'input_filters' => FILTER_SANITIZE_STRING,
-				'label'         => '',
-				'type'          => 'string',
-				'required'      => true,
-				'default'       => '',
+				'sanitize_callback' => 'sanitize_text_field',
+				'label'             => '',
+				'type'              => 'string',
+				'required'          => true,
+				'default'           => '',
 			),
 		),
 	);
@@ -150,13 +154,18 @@ function get_workshop_application_field_schema() {
  * @return array
  */
 function get_workshop_application_form_submission() {
-	$schema = get_workshop_application_field_schema();
+	$schema     = get_workshop_application_field_schema();
+	$submission = array();
 
-	$submission = filter_input_array(
-		INPUT_POST,
-		wp_list_pluck( $schema['properties'], 'input_filters' ),
-		false
-	);
+	foreach ( $schema['properties'] as $field => $config ) {
+		if ( isset( $_POST[ $field ] ) ) {
+			$value = $_POST[ $field ];
+			if ( isset( $config['sanitize_callback'] ) && is_callable( $config['sanitize_callback'] ) ) {
+				$value = call_user_func( $config['sanitize_callback'], $value );
+			}
+			$submission[ $field ] = $value;
+		}
+	}
 
 	$submission = array_map(
 		function( $item ) {
@@ -164,7 +173,6 @@ function get_workshop_application_form_submission() {
 			if ( is_array( $item ) ) {
 				$item = array_filter( $item );
 			}
-
 			return $item;
 		},
 		$submission
@@ -207,7 +215,7 @@ function get_workshop_application_form_user_details() {
  * @return array|object|WP_Error
  */
 function validate_workshop_application_form_submission( $submission ) {
-	$validator  = new Validator( get_workshop_application_field_schema() );
+	$validator = new Validator( get_workshop_application_field_schema() );
 
 	return $validator->validate( $submission );
 }
@@ -295,7 +303,7 @@ function process_workshop_application_form_submission( $submission ) {
 function is_submission_rate_limited( $submission ) {
 	$limit = 5;
 
-	$args = array(
+	$args  = array(
 		'post_type'   => 'wporg_workshop',
 		'post_status' => get_default_workshop_status(),
 		'meta_query'  => array(
@@ -329,9 +337,9 @@ function is_submission_rate_limited( $submission ) {
  */
 function get_default_workshop_status() {
 	if ( function_exists( 'EditFlow' ) ) {
-		$status = 'needs-vetting';
-		$all_stati = get_post_stati();
-		$module_data = EditFlow()->get_module_by( 'name', 'custom_status' );
+		$status               = 'needs-vetting';
+		$all_stati            = get_post_stati();
+		$module_data          = EditFlow()->get_module_by( 'name', 'custom_status' );
 		$supported_post_types = EditFlow()->helpers->get_post_types_for_module( $module_data );
 
 		if ( array_key_exists( $status, $all_stati ) && in_array( 'wporg_workshop', $supported_post_types, true ) ) {
@@ -384,15 +392,17 @@ function prepare_post_content_from_submission( $submission ) {
 		// Turn separate lines into list items.
 		$content = str_replace( array( "\r\n", "\r" ), "\n", $blurbs[ $key ] );
 		$split   = explode( "\n", $content );
-		$split   = array_filter( array_map(
-			function( $item ) {
-				// Attempt to strip out list item enumeration characters.
-				$item = preg_replace( '/^([*\-]+|[1-9]{1,2}[\.\)]?|[A-Z]+[\.\)]+) ?/', '', $item );
+		$split   = array_filter(
+			array_map(
+				function( $item ) {
+					// Attempt to strip out list item enumeration characters.
+					$item = preg_replace( '/^([*\-]+|[1-9]{1,2}[\.\)]?|[A-Z]+[\.\)]+) ?/', '', $item );
 
-				return trim( $item );
-			},
-			(array) $split
-		) );
+					return trim( $item );
+				},
+				(array) $split
+			)
+		);
 
 		if ( ! empty( $split ) ) {
 			$blurbs[ $key ] = '<li>' . implode( '</li><li>', $split ) . '</li>';
@@ -410,8 +420,8 @@ function prepare_post_content_from_submission( $submission ) {
  * @return string
  */
 function render_workshop_application_form() {
-	$schema     = get_workshop_application_field_schema();
-	$defaults   = wp_parse_args(
+	$schema   = get_workshop_application_field_schema();
+	$defaults = wp_parse_args(
 		get_workshop_application_form_user_details(),
 		wp_list_pluck( $schema['properties'], 'default' )
 	);
@@ -435,8 +445,8 @@ function render_workshop_application_form() {
 	$messages     = array();
 
 	if ( 'error' === $state ) {
-		$form = wp_parse_args( $submission, $defaults );
-		$errors = $processed;
+		$form         = wp_parse_args( $submission, $defaults );
+		$errors       = $processed;
 		$error_fields = array_map(
 			function( $code ) {
 				return preg_replace(
@@ -450,10 +460,10 @@ function render_workshop_application_form() {
 			},
 			$processed->get_error_data( 'error' ) ?? array()
 		);
-		$messages = $errors->get_error_messages( 'submission_error' );
+		$messages     = $errors->get_error_messages( 'submission_error' );
 	}
 
-	$audience = array(
+	$audience       = array(
 		'contributors' => __( 'Contributors', 'wporg-learn' ),
 		'designers'    => __( 'Designers', 'wporg-learn' ),
 		'developers'   => __( 'Developers', 'wporg-learn' ),
@@ -462,7 +472,7 @@ function render_workshop_application_form() {
 	$audience_other = array_diff( $form['audience'], array_keys( $audience ) );
 	$audience_other = array_shift( $audience_other );
 
-	$experience_level = array(
+	$experience_level       = array(
 		'beginner'     => __( 'Beginner', 'wporg-learn' ),
 		'intermediate' => __( 'Intermediate', 'wporg-learn' ),
 		'expert'       => __( 'Expert', 'wporg-learn' ),

--- a/wp-content/plugins/wporg-learn/inc/post-meta.php
+++ b/wp-content/plugins/wporg-learn/inc/post-meta.php
@@ -213,9 +213,7 @@ function register_common_meta() {
 				'description'       => __( 'The date when the content of the post may be obsolete.', 'wporg_learn' ),
 				'type'              => 'string',
 				'single'            => true,
-				'sanitize_callback' => function( $value ) {
-					return filter_var( $value, FILTER_SANITIZE_STRING );
-				},
+				'sanitize_callback' => 'sanitize_text_field',
 				'show_in_rest'      => true,
 			)
 		);


### PR DESCRIPTION
# Replace FILTER_SANITIZE_STRING with WordPress Sanitization Functions

## Changes Made

1. Replaced all instances of `FILTER_SANITIZE_STRING` with WordPress's built-in sanitization functions:
   - `sanitize_text_field()` for single-line text inputs
   - `sanitize_textarea_field()` for multi-line text inputs
   - `sanitize_email()` for email fields

2. Updated form submission handling in `inc/form.php`:
   - Replaced `filter_input_array()` with direct `$_POST` handling
   - Added proper sanitization callbacks for each field type
   - Maintained array handling for multi-select fields

3. Updated admin filters in `inc/admin.php`:
   - Replaced `filter_input()` calls with `sanitize_text_field()`
   - Simplified GET parameter handling
   - Maintained default empty string values

4. Updated post meta handling in `inc/post-meta.php`:
   - Replaced custom sanitization callback using `FILTER_SANITIZE_STRING`
   - Now using `sanitize_text_field()` directly

## Why This Change?

1. `FILTER_SANITIZE_STRING` is deprecated in PHP 8.1
2. WordPress's sanitization functions are:
   - Better maintained
   - More secure
   - Consistent with WordPress coding standards
   - Not affected by PHP version changes
   - Specifically designed for WordPress data

## Testing

The changes maintain the same functionality while improving security and future compatibility. All form submissions, admin filters, and post meta handling should work as before but with better sanitization.

!! Since we don't have testunit, this still needs a manual testing. Make sure that it has been tested thoroughly before merging!

## Related Issues

- Addresses PHP 8.1 deprecation warnings
- Improves security by using WordPress's recommended sanitization methods
- Makes the code more maintainable and consistent with WordPress standards

Issue reported: https://github.com/WordPress/Learn/issues/2525