### PR TITLE
Use cross-env to set environment variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,11 +30,14 @@
 		"lint:css": "yarn workspaces run lint:css",
 		"lint:js": "yarn workspaces run lint:js",
 		"lint:php": "composer run lint",
-		"setup:tools": "TEXTDOMAIN=wporg-learn composer exec update-configs",
+		"setup:tools": "cross-env TEXTDOMAIN=wporg-learn composer exec update-configs",
 		"start:locale-switcher": "yarn workspace wporg-locale-switcher start",
 		"start:plugin": "yarn workspace wporg-learn-plugin start",
 		"start:theme": "yarn workspace wporg-learn-2024 start",
 		"wp-env": "wp-env"
 	},
-	"main": "index.js"
+	"main": "index.js",
+	"devDependencies": {
+		"cross-env": "^7.0.3"
+	}
 }


### PR DESCRIPTION
Closes #3188

Needs testing

 - [ ] macOS
 - [ ] Windows
 - [ ] Linux (Ubuntu)

Testing instructions:

1. Clone this repository (if you haven't already): `git clone https://github.com/WordPress/Learn.git`
2. Check out the `cross-env` branch: `git checkout cross-env`
3. Follow the [setup instructions](https://github.com/WordPress/Learn?tab=readme-ov-file#setup) in the readme. The local environment should be successfully set up