### PR TITLE
Bin: i18n.php: Sort & Fetch >100 terms

### DIFF
--- a/bin/i18n.php
+++ b/bin/i18n.php
@@ -50,11 +50,12 @@ function get_taxonomies( array $valid_post_types = array() ) {
  * Get data about a taxonomy's terms from a REST API endpoint.
  *
  * @param string $taxonomy
+ * @param int    $page Internal use only, do not pass. This function will recursively fetch all pages of terms.
  *
  * @return array
  */
-function get_taxonomy_terms( $taxonomy ) {
-	$endpoint = ENDPOINT_BASE . $taxonomy . '?per_page=100';
+function get_taxonomy_terms( $taxonomy, $page = 1 ) {
+	$endpoint = ENDPOINT_BASE . $taxonomy . '?per_page=100&page=' . $page;
 
 	$response = Requests::get( $endpoint );
 
@@ -72,6 +73,15 @@ function get_taxonomy_terms( $taxonomy ) {
 			'Terms request for %s returned unexpected data.',
 			$taxonomy // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		) );
+	}
+
+	// If there are more pages, recursively fetch them.
+	$max_pages = $response->headers['X-WP-TotalPages'] ?? 1;
+	if ( $max_pages > $page ) {
+		$terms = array_merge(
+			$terms,
+			get_taxonomy_terms( $taxonomy, $page + 1 )
+		);
 	}
 
 	return $terms;
@@ -113,6 +123,14 @@ function main() {
 	$file_content = '';
 	foreach ( $terms_by_tax as $tax_label => $terms ) {
 		$label = addcslashes( $tax_label, "'" );
+
+		// Sort the terms by slug for consistency.
+		usort(
+			$terms,
+			function( $a, $b ) {
+				return strcmp( $a['slug'], $b['slug'] );
+			}
+		);
 
 		foreach ( $terms as $term ) {
 


### PR DESCRIPTION
Once, or Twice a day, a workflow has been [committing string updates that flip the order of two identical named terms](https://github.com/WordPress/Learn/commits/trunk/?author=github-actions%5Bbot%5D) (They have different slugs). This is silly.

Additionally, some taxonomies now have >100 terms, which this script hasn't been keeping up with, so now it'll fetch page 2 of the taxonomy content too.