### PR TITLE
Only send Profile activity when transitioning to a publish/complete status.

### DIFF
--- a/wp-content/plugins/wporg-learn/inc/profiles.php
+++ b/wp-content/plugins/wporg-learn/inc/profiles.php
@@ -18,7 +18,7 @@ if ( 'local' === wp_get_environment_type() ) {
 	return;
 }
 
-add_action( 'sensei_course_status_updated', __NAMESPACE__ . '\add_course_completed_activity', 9, 3 ); // Before `redirect_to_course_completed_page()`.
+add_action( 'sensei_course_status_updated', __NAMESPACE__ . '\add_course_completed_activity', 9, 5 ); // Before `redirect_to_course_completed_page()`.
 add_action( 'transition_post_status', __NAMESPACE__ . '\maybe_notify_new_published_post', 10, 3 );
 
 /**
@@ -29,7 +29,7 @@ add_action( 'transition_post_status', __NAMESPACE__ . '\maybe_notify_new_publish
  * @param WP_Post $post The post.
  */
 function maybe_notify_new_published_post( $new_status, $old_status, $post ) {
-	if ( 'publish' != $new_status ) {
+	if ( 'publish' != $new_status || 'publish' === $old_status ) {
 		return;
 	}
 
@@ -103,8 +103,8 @@ function notify_workshop_presenter( $post ) {
 /**
  * Add an activity to a user's profile when they complete a course.
  */
-function add_course_completed_activity( string $status, int $user_id, int $course_id ) : void {
-	if ( 'complete' !== $status ) {
+function add_course_completed_activity( string $status, int $user_id, int $course_id, int $comment_id, ?string $previous_status ) : void {
+	if ( 'complete' !== $status || 'complete' === $previous_status ) {
 		return;
 	}
 


### PR DESCRIPTION
Only send Profile activity when transitioning to a publish/complete status., not if it's just being updated again.

See https://meta.trac.wordpress.org/ticket/8015
> when a user marks a course as "Completed," multiple, duplicate activity logs are being generated and displayed in the user's profile. Instead of a single log entry reflecting the completion, the system creates several duplicate entries, leading to cluttered and inaccurate activity tracking for these specific courses. This issue affects the proper display of user progress and activity logs.
>  <img width="2902" height="1582" alt="image" src="https://github.com/user-attachments/assets/6481fc1b-d911-4ade-97af-85fe106552f4" />
