### PR TITLE
GitHub Actions workflow updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,10 +5,16 @@ on:
     branches: [trunk]
   workflow_dispatch:
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required to push the build branch
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write # Required to push the build branch
     steps:

--- a/.github/workflows/comment-with-checklist.yml
+++ b/.github/workflows/comment-with-checklist.yml
@@ -15,6 +15,7 @@ permissions: {}
 jobs:
   add-comment:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       issues: write # Required to comment on issues and add labels
     steps:

--- a/.github/workflows/comment-with-checklist.yml
+++ b/.github/workflows/comment-with-checklist.yml
@@ -8,11 +8,15 @@ on:
       content-type:
         type: string
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   add-comment:
     runs-on: ubuntu-latest
     permissions:
-      issues: write
+      issues: write # Required to comment on issues and add labels
     steps:
       - uses: peter-evans/create-or-update-comment@v3
         if: contains(inputs.content-type, 'tutorial')  

--- a/.github/workflows/content-checklist-from-comment.yml
+++ b/.github/workflows/content-checklist-from-comment.yml
@@ -6,33 +6,47 @@ on:
     types:  created
     # types: [created, edited] <= Use this if we want the workflow to run when a comment is edited, too
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   tutorial-issue:
     if: ${{ contains(github.event.comment.body, '//tutorial') }}
+    permissions:
+      issues: write # Required to comment on issues and add labels
     uses: ./.github/workflows/comment-with-checklist.yml
     with:
       content-type: 'tutorial'
       
   online-workshop-issue:
     if: ${{ contains(github.event.comment.body, '//online-workshop') }}
+    permissions:
+      issues: write # Required to comment on issues and add labels
     uses: ./.github/workflows/comment-with-checklist.yml
     with:
       content-type: 'online-workshop'
   
   lesson-plan-issue:
     if: ${{ contains(github.event.comment.body, '//lesson-plan') }}
+    permissions:
+      issues: write # Required to comment on issues and add labels
     uses: ./.github/workflows/comment-with-checklist.yml
     with:
       content-type: 'lesson-plan'
   
   course-issue:
     if: ${{ contains(github.event.comment.body, '//course') }}
+    permissions:
+      issues: write # Required to comment on issues and add labels
     uses: ./.github/workflows/comment-with-checklist.yml
     with:
       content-type: 'course'
 
   lesson-issue:
     if: ${{ contains(github.event.comment.body, '//lesson') }}
+    permissions:
+      issues: write # Required to comment on issues and add labels
     uses: ./.github/workflows/comment-with-checklist.yml
     with:
       content-type: 'lesson'

--- a/.github/workflows/content-checklist-from-issue.yml
+++ b/.github/workflows/content-checklist-from-issue.yml
@@ -6,33 +6,47 @@ on:
     types:  opened
     # types: [opened, edited] <= Use this if we want the workflow to run when an issue is edited, too
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   tutorial-issue:
     if: ${{ contains(github.event.issue.body, '//tutorial') }}
+    permissions:
+      issues: write # Required to comment on issues and add labels
     uses: ./.github/workflows/comment-with-checklist.yml
     with:
       content-type: 'tutorial'
       
   online-workshop-issue:
     if: ${{ contains(github.event.issue.body, '//online-workshop') }}
+    permissions:
+      issues: write # Required to comment on issues and add labels
     uses: ./.github/workflows/comment-with-checklist.yml
     with:
       content-type: 'online-workshop'
   
   lesson-plan-issue:
     if: ${{ contains(github.event.issue.body, '//teach') }}
+    permissions:
+      issues: write # Required to comment on issues and add labels
     uses: ./.github/workflows/comment-with-checklist.yml
     with:
       content-type: 'teach'
   
   course-issue:
     if: ${{ contains(github.event.issue.body, '//course') }}
+    permissions:
+      issues: write # Required to comment on issues and add labels
     uses: ./.github/workflows/comment-with-checklist.yml
     with:
       content-type: 'course'
 
   lesson-issue:
     if: ${{ contains(github.event.issue.body, '//lesson') }}
+    permissions:
+      issues: write # Required to comment on issues and add labels
     uses: ./.github/workflows/comment-with-checklist.yml
     with:
       content-type: 'lesson'

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -5,11 +5,17 @@ on:
     - cron: '0 6,18 * * *'
   workflow_dispatch:
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   translation-strings:
     name: Translation strings
 
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required to commit and push updated translation strings
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -14,6 +14,7 @@ jobs:
     name: Translation strings
 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write # Required to commit and push updated translation strings
 

--- a/.github/workflows/incomplete-workflows/add-to-project-when-labeled.yml
+++ b/.github/workflows/incomplete-workflows/add-to-project-when-labeled.yml
@@ -17,6 +17,7 @@ jobs:
   add-to-web-development-project:
     name: Add issues labeled "[Type] Bug" to web development project
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       issues: read    # Required to read issue data
       projects: write # Required to add issues to the GitHub project
@@ -31,6 +32,7 @@ jobs:
   add-to-content-feedback-project:
     name: Add issues labeled "Content Feedback" to LearnWP Content - Feedback project
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       issues: read    # Required to read issue data
       projects: write # Required to add issues to the GitHub project
@@ -45,6 +47,7 @@ jobs:
   add-to-admin-project:
     name: Add handbook issues to Training Team Administration project
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       issues: read    # Required to read issue data
       projects: write # Required to add issues to the GitHub project

--- a/.github/workflows/incomplete-workflows/add-to-project-when-labeled.yml
+++ b/.github/workflows/incomplete-workflows/add-to-project-when-labeled.yml
@@ -9,10 +9,17 @@ on:
     types:
       - labeled
       
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   add-to-web-development-project:
     name: Add issues labeled "[Type] Bug" to web development project
     runs-on: ubuntu-latest
+    permissions:
+      issues: read    # Required to read issue data
+      projects: write # Required to add issues to the GitHub project
     steps:
       - uses: actions/add-to-project@v0.5.0
         if: contains(github.event.issue.labels.*.name, 'Awaiting Triage')
@@ -24,6 +31,9 @@ jobs:
   add-to-content-feedback-project:
     name: Add issues labeled "Content Feedback" to LearnWP Content - Feedback project
     runs-on: ubuntu-latest
+    permissions:
+      issues: read    # Required to read issue data
+      projects: write # Required to add issues to the GitHub project
     steps:
       - uses: actions/add-to-project@v0.5.0
         if: contains(github.event.issue.labels.*.name, 'Awaiting Triage')
@@ -35,6 +45,9 @@ jobs:
   add-to-admin-project:
     name: Add handbook issues to Training Team Administration project
     runs-on: ubuntu-latest
+    permissions:
+      issues: read    # Required to read issue data
+      projects: write # Required to add issues to the GitHub project
     steps:
       - uses: actions/add-to-project@v0.5.0
         if: contains(github.event.issue.labels.*.name, 'Awaiting Triage') || contains(github.event.issue.labels.*.name, '[Admin] Meeting Agenda')

--- a/.github/workflows/incomplete-workflows/automate-review-documentation.yml
+++ b/.github/workflows/incomplete-workflows/automate-review-documentation.yml
@@ -23,6 +23,7 @@ jobs:
   add-comment:
     if: github.event.label.name == 'Ready for Review'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       issues: write # Required to post comments on issues
     steps:

--- a/.github/workflows/incomplete-workflows/automate-review-documentation.yml
+++ b/.github/workflows/incomplete-workflows/automate-review-documentation.yml
@@ -14,12 +14,17 @@ on:
   issues:
     types:
       - labeled
+
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   add-comment:
     if: github.event.label.name == 'Ready for Review'
     runs-on: ubuntu-latest
     permissions:
-      issues: write
+      issues: write # Required to post comments on issues
     steps:
       - name: Add comment
         uses: peter-evans/create-or-update-comment@5f728c3dae25f329afbe34ee4d08eef25569d79f

--- a/.github/workflows/label-feedback-from-comment.yml
+++ b/.github/workflows/label-feedback-from-comment.yml
@@ -5,13 +5,17 @@ on:
   issue_comment:
     types: [created, edited]
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
 
   label_issues:
     if: ${{ !github.event.issue.pull_request }}
     runs-on: ubuntu-latest
     permissions:
-      issues: write
+      issues: write # Required to add labels to issues
     steps:
       - uses: actions/github-script@v7.0.1
         with:

--- a/.github/workflows/label-feedback-from-comment.yml
+++ b/.github/workflows/label-feedback-from-comment.yml
@@ -14,6 +14,7 @@ jobs:
   label_issues:
     if: ${{ !github.event.issue.pull_request }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       issues: write # Required to add labels to issues
     steps:

--- a/.github/workflows/label-feedback-from-issue.yml
+++ b/.github/workflows/label-feedback-from-issue.yml
@@ -5,13 +5,17 @@ on:
   issues:
     types: [opened, edited]
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
 
   label_issues:
     if: ${{ !github.event.issue.pull_request }}
     runs-on: ubuntu-latest
     permissions:
-      issues: write
+      issues: write # Required to add labels to issues
     steps:
       - uses: actions/github-script@v7.0.1
         with:

--- a/.github/workflows/label-feedback-from-issue.yml
+++ b/.github/workflows/label-feedback-from-issue.yml
@@ -14,6 +14,7 @@ jobs:
   label_issues:
     if: ${{ !github.event.issue.pull_request }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       issues: write # Required to add labels to issues
     steps:

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -7,10 +7,16 @@ on:
   pull_request:
   workflow_dispatch:
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   check:
     name: Lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required to clone the repo
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -15,6 +15,7 @@ jobs:
   check:
     name: Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read # Required to clone the repo
     steps:

--- a/.github/workflows/published-content.yml
+++ b/.github/workflows/published-content.yml
@@ -7,10 +7,16 @@ on:
   issue_comment:
     types: [created, edited]
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   publish-commment:
     runs-on: ubuntu-latest
     if: contains(github.event.comment.body, '//publish')
+    permissions:
+      issues: write # Required to add/remove labels and close issues
     steps:
       - name: Remove co-host label
         if: contains(github.event.issue.labels.*.name, '[Content] Needs Co-host')

--- a/.github/workflows/published-content.yml
+++ b/.github/workflows/published-content.yml
@@ -12,7 +12,7 @@ on:
 permissions: {}
 
 jobs:
-  publish-commment:
+  publish-comment:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: contains(github.event.comment.body, '//publish')

--- a/.github/workflows/published-content.yml
+++ b/.github/workflows/published-content.yml
@@ -14,6 +14,7 @@ permissions: {}
 jobs:
   publish-commment:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: contains(github.event.comment.body, '//publish')
     permissions:
       issues: write # Required to add/remove labels and close issues

--- a/.github/workflows/review-instructions.yml
+++ b/.github/workflows/review-instructions.yml
@@ -10,6 +10,7 @@ permissions: {}
 jobs:
   add-comment:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       issues: write # Required to post comments on issues
     steps:

--- a/.github/workflows/review-instructions.yml
+++ b/.github/workflows/review-instructions.yml
@@ -15,7 +15,7 @@ jobs:
       issues: write # Required to post comments on issues
     steps:
       - uses: peter-evans/create-or-update-comment@v3
-        if: ${{ contains(github.event.comment.body, '//review') }}  
+        if: ${{ contains(github.event.comment.body, '//review') }}
         with:
           issue-number: ${{ github.event.issue.number }}
           body: |

--- a/.github/workflows/review-instructions.yml
+++ b/.github/workflows/review-instructions.yml
@@ -3,11 +3,15 @@ on:
   issue_comment:
     types:  [created, edited]
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   add-comment:
     runs-on: ubuntu-latest
     permissions:
-      issues: write
+      issues: write # Required to post comments on issues
     steps:
       - uses: peter-evans/create-or-update-comment@v3
         if: ${{ contains(github.event.comment.body, '//review') }}  

--- a/.github/workflows/self-assign-issue.yml
+++ b/.github/workflows/self-assign-issue.yml
@@ -13,6 +13,7 @@ jobs:
   assign-issue:
     if: contains(github.event.comment.body, '//assign')
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       issues: write # Required to assign issues, add labels, and post comments
     steps:

--- a/.github/workflows/self-assign-issue.yml
+++ b/.github/workflows/self-assign-issue.yml
@@ -5,10 +5,16 @@ on:
   issue_comment:
     types: [created, edited]
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   assign-issue:
     if: contains(github.event.comment.body, '//assign')
     runs-on: ubuntu-latest
+    permissions:
+      issues: write # Required to assign issues, add labels, and post comments
     steps:
       - name: Assign the comment author
         uses: takanome-dev/assign-issue-action@v2.0.0


### PR DESCRIPTION
This updates the GitHub Actions workflow files to:

- Grant minimally-scoped permissions to each job to adhere to the principle of least privilege
- Specify a timeout on each job to prevent runaway processes consuming too many minutes (the default is 360)

Once this PR is merged, [the Settings -> Actions -> Workflow permissions setting](https://github.com/WordPress/Learn/settings/actions) can be changed by a repo admin to "Read repository contents and packages permissions".

## References

- https://docs.github.com/en/actions/reference/security/secure-use
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idtimeout-minutes