### PR TITLE
Blocks: Guard against missing post context in dynamic blocks

### DIFF
--- a/wp-content/plugins/wporg-learn/views/block-course-status.php
+++ b/wp-content/plugins/wporg-learn/views/block-course-status.php
@@ -15,13 +15,13 @@ defined( 'WPINC' ) || die();
  * @return string The rendered output.
  */
 function render( $attributes, $content, $block ) {
-	$post_type = $block->context['postType'];
+	$post_type = $block->context['postType'] ?? '';
+	$course_id = $block->context['postId'] ?? 0;
 
-	if ( 'course' !== $post_type || ! class_exists( 'Sensei_Main' ) ) {
+	if ( ! $course_id || 'course' !== $post_type || ! class_exists( 'Sensei_Main' ) ) {
 		return '';
 	}
 
-	$course_id    = $block->context['postId'];
 	$user_id      = get_current_user_id();
 	$is_completed = Sensei_Utils::user_completed_course( $course_id, $user_id );
 

--- a/wp-content/plugins/wporg-learn/views/block-learning-duration.php
+++ b/wp-content/plugins/wporg-learn/views/block-learning-duration.php
@@ -16,13 +16,14 @@ defined( 'WPINC' ) || die();
  * @return string The rendered output.
  */
 function render( $attributes, $content, $block ) {
-	$post_type = $block->context['postType'];
+	$post_type = $block->context['postType'] ?? '';
+	$post_id   = $block->context['postId'] ?? 0;
 
-	if ( 'course' !== $post_type && 'lesson' !== $post_type ) {
+	if ( ! $post_id || ( 'course' !== $post_type && 'lesson' !== $post_type ) ) {
 		return '';
 	}
 
-	$duration = ensure_float( get_post_meta( $block->context['postId'], '_duration', true ) );
+	$duration = ensure_float( get_post_meta( $post_id, '_duration', true ) );
 
 	if ( empty( $duration ) ) {
 		return '';

--- a/wp-content/plugins/wporg-learn/views/block-learning-duration.php
+++ b/wp-content/plugins/wporg-learn/views/block-learning-duration.php
@@ -29,7 +29,7 @@ function render( $attributes, $content, $block ) {
 		return '';
 	}
 
-	if ( 1 === $duration ) {
+	if ( 1.0 === $duration ) {
 		$content = __( '1 hour', 'wporg-learn' );
 	} elseif ( $duration > 1 ) {
 		$content = sprintf(

--- a/wp-content/plugins/wporg-learn/views/block-lesson-count.php
+++ b/wp-content/plugins/wporg-learn/views/block-lesson-count.php
@@ -14,13 +14,14 @@ defined( 'WPINC' ) || die();
  * @return string The rendered output.
  */
 function render( $attributes, $content, $block ) {
-	$post_type = $block->context['postType'];
+	$post_type = $block->context['postType'] ?? '';
+	$post_id   = $block->context['postId'] ?? 0;
 
-	if ( 'course' !== $post_type || ! class_exists( 'Sensei_Main' ) ) {
+	if ( ! $post_id || 'course' !== $post_type || ! class_exists( 'Sensei_Main' ) ) {
 		return '';
 	}
 
-	$lessons = Sensei()->course->course_lessons( $block->context['postId'] );
+	$lessons = Sensei()->course->course_lessons( $post_id );
 
 	if ( empty( $lessons ) ) {
 		return '';


### PR DESCRIPTION
## Problem

Production is logging:

```
E_WARNING: Undefined array key "postType" in
/wp-content/plugins/wporg-learn/views/block-learning-duration.php:19
Source: GET https://learn.wordpress.org/wp-json/wp/v2/created-templates?per_page=1
```

## Root cause

Three render callbacks dereference block context without checking it exists:

| File | Lines |
| --- | --- |
| `views/block-learning-duration.php` | 19, 25 |
| `views/block-lesson-count.php` | 17, 23 |
| `views/block-course-status.php` | 18, 24 |

`usesContext` in `block.json` only *requests* context — it never guarantees the keys are populated. The context can legitimately be empty, and here's the path that triggers it:

1. Gutenberg's `active_templates` experiment (`lib/compat/wordpress-7.0/template-activate.php`) re-registers the `wp_template` post type with `rest_base = 'created-templates'` and the generic `WP_REST_Posts_Controller`. That controller renders `content.rendered` by running the raw *template* markup through `the_content`, and `context=view` is readable unauthenticated — hence the `curl` hit.
2. Core's `_block_template_render_without_post_block_context()` (`wp-includes/block-template.php:437`) is hooked to `render_block_context` and deliberately strips the context when the rendered post is a `wp_template`, so that blocks like Post Content don't recurse infinitely:

   ```php
   if ( isset( $context['postType'] ) && 'wp_template' === $context['postType'] ) {
       unset( $context['postId'] );
       unset( $context['postType'] );
   }
   ```
3. The `single-course` template has `wporg-learn/learning-duration` nested directly in the sidebar (not inside a Query Loop), so nothing re-supplies the context. Every block below renders with `context = []`.

Instrumenting the filter on production confirms it: the filter is entered with `["postId","postType"]` and every descendant block renders with an empty array.

This is our bug, not a core or Gutenberg one — the experiment just exposed a code path that was always latent. The same warning can be hit anywhere these blocks render outside a post/query context.

## Fix

Read both keys with `??` defaults and bail early when the post ID is missing. The `postId` guard matters as much as the `postType` one: `get_post_meta( 0, ... )` and `course_lessons( 0 )` are silently wrong rather than noisy.

### Behavior change: 1-hour durations

`block-learning-duration.php` also changes `1 === $duration` to `1.0 === $duration`. This is a user-visible bugfix, not just cleanup: `ensure_float()` always returns a float, so the strict comparison against the integer `1` could never match — courses and lessons with a duration of exactly one hour have been rendering as "60 minutes". After this change they render as "1 hour", as originally intended.

## Testing

Ran against production data with the patched callbacks swapped in at runtime:

1. **The failing request is clean** — `GET /wp/v2/created-templates?per_page=1` returns 200 with zero `wporg-learn` warnings (previously one `E_WARNING` per request).
2. **No regression when context is present** — rendering with real `postId`/`postType`:
   ```
   wporg-learn/learning-duration  post 323792 => 4 hours
   wporg-learn/lesson-count       post 323792 => 24 lessons
   ```
3. **Empty context returns `''` silently** for all three blocks.

## Note for deploy

The `wporg-learn` plugin reaches production via a manual SVN sync to meta (`Learn: Sync with git WordPress/learn@<sha>`). The last one was 2026-04-24, so this will need a sync after merge to actually land on the site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

