### PR TITLE
Allow ZIP uploads on learn.wordpress.org only

### DIFF
--- a/wp-content/plugins/wporg-learn/inc/upload.php
+++ b/wp-content/plugins/wporg-learn/inc/upload.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Upload settings for Learn.WordPress.org.
+ *
+ * @package WPOrg_Learn
+ */
+
+namespace WPOrg_Learn\Upload;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Actions and filters.
+ */
+add_filter( 'upload_mimes', __NAMESPACE__ . '\allow_zip_uploads' );
+
+/**
+ * Allow ZIP file uploads on Learn.WordPress.org only.
+ *
+ * Activity Kit editors need to upload ZIP archives containing kit materials.
+ * The filter is gated on blog ID 7 (learn.wordpress.org on the WordPress.org
+ * network) so it does not enable ZIP uploads across the entire network.
+ *
+ * @param string[] $mimes Allowed MIME types keyed by file extension.
+ * @return string[]
+ */
+function allow_zip_uploads( $mimes ) {
+	if ( 7 !== get_current_blog_id() ) {
+		return $mimes;
+	}
+
+	$mimes['zip'] = 'application/zip';
+
+	return $mimes;
+}

--- a/wp-content/plugins/wporg-learn/wporg-learn.php
+++ b/wp-content/plugins/wporg-learn/wporg-learn.php
@@ -88,6 +88,7 @@ function load_files() {
 	require_once get_includes_path() . 'sensei.php';
 	require_once get_includes_path() . 'taxonomy.php';
 	require_once get_includes_path() . 'export.php';
+	require_once get_includes_path() . 'upload.php';
 	require_once get_includes_path() . 'utils.php';
 }
 


### PR DESCRIPTION
## Description

Activity Kit editors need to attach ZIP archives of kit materials to posts. ZIP file uploads are disabled by default across the WordPress.org network.

This adds an `upload_mimes` filter in the `wporg-learn` plugin that enables the `application/zip` MIME type, gated on `get_current_blog_id() === 7` (learn.wordpress.org) so that the rest of the WordPress.org network is unaffected.

## Changes

- New file `inc/upload.php` — `WPOrg_Learn\Upload\allow_zip_uploads()` filter callback
- `wporg-learn.php` — `require_once` for `inc/upload.php`

## Testing

1. On learn.wordpress.org: open the media library or a post's "Add Media" dialog → ZIP should appear in the list of allowed types and upload successfully.
2. On any other WordPress.org network site (blog ID ≠ 7): confirm ZIP is still absent from the allowed types.

---
> 🤖 Written with [Claude Code](https://claude.ai/claude-code)