### PR TITLE
Search Results Context: Allowlist the tagName attribute

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2024/src/search-results-context/block.json
+++ b/wp-content/themes/pub/wporg-learn-2024/src/search-results-context/block.json
@@ -11,6 +11,7 @@
 	"attributes": {
 		"tagName": {
 			"type": "string",
+			"enum": [ "p", "div", "span" ],
 			"default": "p"
 		}
 	},

--- a/wp-content/themes/pub/wporg-learn-2024/src/search-results-context/index.php
+++ b/wp-content/themes/pub/wporg-learn-2024/src/search-results-context/index.php
@@ -58,9 +58,13 @@ function render( $attributes ) {
 
 	$wrapper_attributes = get_block_wrapper_attributes();
 
+	$tag_name = in_array( $attributes['tagName'], array( 'p', 'div', 'span' ), true )
+		? $attributes['tagName']
+		: 'p';
+
 	return sprintf(
 		'<%1$s %2$s>%3$s %4$s %5$s</%1$s>',
-		esc_attr( $attributes['tagName'] ),
+		tag_escape( $tag_name ),
 		$wrapper_attributes,
 		$content,
 		$filters,


### PR DESCRIPTION
## What

`wporg/search-results-context` interpolates its `tagName` attribute into element-name position:

```php
return sprintf(
	'<%1$s %2$s>%3$s %4$s %5$s</%1$s>',
	esc_attr( $attributes['tagName'] ),
```

`esc_attr()` is the wrong escaper for that position — it encodes `&`, `<`, `>`, `"` and `'`, but not a space and not `=`. The attribute is also declared as a plain `string` with no `enum`, so `prepare_attributes_for_render()` passes any value straight through to the callback.

## Change

Restrict `tagName` to the tags the block is actually meant to render and escape with `tag_escape()`:

```php
$tag_name = in_array( $attributes['tagName'], array( 'p', 'div', 'span' ), true )
	? $attributes['tagName']
	: 'p';
```

This matches the approach `wporg/global-footer` already uses for its own `tagName` attribute in `wporg-mu-plugins`. A matching `"enum"` is added to `block.json` so a non-conforming value is dropped before the render callback runs — defence in depth rather than a substitute for the allowlist, since `block.json` only constrains registered attributes.

No behaviour change for any valid value: `p` remains the default, and `div` / `span` continue to work.

## Notes

`build/` is generated and not tracked here, so only `src/` is changed. The same block is mirrored into the meta repo, which additionally carries a built copy — that side will pick this up on the next Learn sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)