### PR TITLE
Theme: Add Activity Library to site navigation menu

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2024/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2024/functions.php
@@ -344,6 +344,10 @@ function add_site_navigation_menus( $menus ) {
 			'url'   => '/online-workshops/',
 		),
 		array(
+			'label' => __( 'Activity Library', 'wporg-learn' ),
+			'url'   => '/activity-library/',
+		),
+		array(
 			'label'     => __( 'My courses', 'wporg-learn' ),
 			'url'       => get_my_courses_page_url(),
 			'className' => 'has-separator',

--- a/wp-content/themes/pub/wporg-learn-2024/functions.php
+++ b/wp-content/themes/pub/wporg-learn-2024/functions.php
@@ -345,7 +345,7 @@ function add_site_navigation_menus( $menus ) {
 		),
 		array(
 			'label' => __( 'Activity Library', 'wporg-learn' ),
-			'url'   => '/activity-library/',
+			'url'   => get_post_type_archive_link( 'activity_kit' ) ?: '/activity-library/',
 		),
 		array(
 			'label'     => __( 'My courses', 'wporg-learn' ),


### PR DESCRIPTION
## What does this PR do?

Adds an **Activity Library** link to the learn.wordpress.org local navigation bar, positioned after Online Workshops.

The navigation is generated by the `add_site_navigation_menus()` filter callback in the theme's `functions.php`. This adds a fourth content link to the list before the separator item (My Courses / Log in).

**Before:**
Courses · Lessons · Online Workshops · My courses

**After:**
Courses · Lessons · Online Workshops · **Activity Library** · My courses

## How to test

1. Visit https://learn.wordpress.org and confirm the local navigation bar now shows **Activity Library** after Online Workshops.
2. Click the link and confirm it takes you to https://learn.wordpress.org/activity-library/.
3. Verify the menu order is correct and the separator before My Courses is intact.

## Related

Adds navigation access to the Activity Library introduced in #3496.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)