### PR TITLE
Plugin: Validate attachment MIME type for activity kit PDF and ZIP fields

### DIFF
--- a/wp-content/plugins/wporg-learn/inc/post-meta.php
+++ b/wp-content/plugins/wporg-learn/inc/post-meta.php
@@ -337,6 +337,32 @@ function sanitize_locale( $meta_value, $meta_key, $object_type, $object_subtype 
 }
 
 /**
+ * Sanitize an attachment ID, returning 0 when the attachment MIME type is not in the allowed list.
+ *
+ * Used as the sanitize_callback for activity kit attachment meta fields so that
+ * editors cannot save an arbitrary attachment ID that does not match the expected
+ * file type — even when bypassing the block-editor UI.
+ *
+ * @param mixed    $value         Raw meta value (expected integer attachment ID).
+ * @param string[] $allowed_mimes Allowed MIME types, e.g. array( 'application/pdf' ).
+ * @return int Validated attachment ID, or 0 if the ID is invalid or the MIME type is not allowed.
+ */
+function sanitize_attachment_id_by_mime( $value, array $allowed_mimes ) {
+	$id = absint( $value );
+	if ( ! $id ) {
+		return 0;
+	}
+
+	$mime = get_post_mime_type( $id );
+
+	if ( ! $mime || ! in_array( $mime, $allowed_mimes, true ) ) {
+		return 0;
+	}
+
+	return $id;
+}
+
+/**
  * Get the duration of a workshop in a specified format.
  *
  * @param WP_Post $workshop The workshop post to get the duration for.
@@ -999,7 +1025,9 @@ function register_activity_kit_meta() {
 			'type'              => 'integer',
 			'single'            => true,
 			'default'           => 0,
-			'sanitize_callback' => 'absint',
+			'sanitize_callback' => function ( $value ) {
+				return sanitize_attachment_id_by_mime( $value, array( 'application/pdf' ) );
+			},
 			'show_in_rest'      => true,
 			'auth_callback'     => $auth_callback,
 		)
@@ -1013,7 +1041,9 @@ function register_activity_kit_meta() {
 			'type'              => 'integer',
 			'single'            => true,
 			'default'           => 0,
-			'sanitize_callback' => 'absint',
+			'sanitize_callback' => function ( $value ) {
+				return sanitize_attachment_id_by_mime( $value, array( 'application/pdf' ) );
+			},
 			'show_in_rest'      => true,
 			'auth_callback'     => $auth_callback,
 		)
@@ -1027,7 +1057,9 @@ function register_activity_kit_meta() {
 			'type'              => 'integer',
 			'single'            => true,
 			'default'           => 0,
-			'sanitize_callback' => 'absint',
+			'sanitize_callback' => function ( $value ) {
+				return sanitize_attachment_id_by_mime( $value, array( 'application/zip', 'application/x-zip', 'application/x-zip-compressed' ) );
+			},
 			'show_in_rest'      => true,
 			'auth_callback'     => $auth_callback,
 		)


### PR DESCRIPTION
## What does this PR do?

Adds server-side MIME type validation to the three activity kit attachment meta fields so that only the correct file types can be saved — both through the editor UI and directly via the REST API.

### The gap this closes

The `MediaUpload` components in the block editor already set `allowedTypes` to filter the media library:
- Facilitator Guide PDF → `application/pdf`
- Slide Deck PDF → `application/pdf`
- Download ZIP → `application/zip`, `application/x-zip-compressed`

However, the `sanitize_callback` for all three meta fields was `absint` — which only checks that the value is a non-negative integer. Any attachment ID could be saved via the REST API regardless of its MIME type.

### What changed

Added `sanitize_attachment_id_by_mime( $value, $allowed_mimes )` helper to `inc/post-meta.php` and used it as the `sanitize_callback` for each field:

| Meta key | Allowed MIME types |
|---|---|
| `_activity_guide_pdf_id` | `application/pdf` |
| `_activity_slides_pdf_id` | `application/pdf` |
| `_activity_zip_id` | `application/zip`, `application/x-zip`, `application/x-zip-compressed` |

The helper calls `get_post_mime_type()` on the submitted ID and returns `0` if the attachment doesn't exist or its MIME type isn't in the allowed list.

## How to test

**Editor UI (already worked):** Open an activity kit in the block editor, try to attach a JPEG to the Facilitator Guide field — the media library only shows PDFs.

**REST API (new protection):** 
```bash
# Get attachment IDs of a JPEG and a PDF already in the media library
wp media list --post_type=attachment --format=table

# Try to save a JPEG as the guide PDF — should save as 0
wp post meta update <kit-id> _activity_guide_pdf_id <jpeg-attachment-id>
wp post meta get <kit-id> _activity_guide_pdf_id  # should return 0

# Save a PDF — should work
wp post meta update <kit-id> _activity_guide_pdf_id <pdf-attachment-id>
wp post meta get <kit-id> _activity_guide_pdf_id  # should return the PDF's ID
```

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)