### PR TITLE
Fix activity kit stats: switch to get_total_post_views() for per-kit view counts

### DIFF
--- a/wp-content/plugins/wporg-learn/inc/activity-kit-rest.php
+++ b/wp-content/plugins/wporg-learn/inc/activity-kit-rest.php
@@ -169,6 +169,8 @@ function handle_stats( $request ) {
  * To cover ranges longer than 30 days, multiple 30-day windows are issued with
  * a date offset and the results are summed. Kit IDs are chunked into groups of
  * 100 so the library can grow past 100 kits without silently losing data.
+ * '90d' uses 3 windows (90 days); 'all' uses 6 windows (≈ 180 days) to give a
+ * meaningful distinction from the 90-day range.
  *
  * @param string $range   One of '7d', '30d', '90d', 'all'.
  * @param int[]  $kit_ids Post IDs of the activity kits to fetch views for.
@@ -183,9 +185,10 @@ function get_jetpack_post_views( $range, array $kit_ids ) {
 
 	/*
 	 * Map the UI range to one or more 30-day windows. Each window is defined by
-	 * how many days back its end-date is offset from today. The 'all' range is
-	 * capped at 90 days (3 × 30) — covering more would require an unreasonable
-	 * number of sequential API calls.
+	 * how many days back its end-date is offset from today. 'all' uses 6 windows
+	 * (≈ 6 months) rather than 3, giving a meaningful distinction from '90d'.
+	 * Extending further would multiply sequential API calls proportionally; 6 is
+	 * a reasonable ceiling for an admin-only dashboard with a small post count.
 	 */
 	switch ( $range ) {
 		case '7d':
@@ -205,6 +208,21 @@ function get_jetpack_post_views( $range, array $kit_ids ) {
 			);
 			break;
 		case '90d':
+			$windows = array(
+				array(
+					'num'    => 30,
+					'offset' => 0,
+				),
+				array(
+					'num'    => 30,
+					'offset' => 30,
+				),
+				array(
+					'num'    => 30,
+					'offset' => 60,
+				),
+			);
+			break;
 		case 'all':
 		default:
 			$windows = array(
@@ -219,6 +237,18 @@ function get_jetpack_post_views( $range, array $kit_ids ) {
 				array(
 					'num'    => 30,
 					'offset' => 60,
+				),
+				array(
+					'num'    => 30,
+					'offset' => 90,
+				),
+				array(
+					'num'    => 30,
+					'offset' => 120,
+				),
+				array(
+					'num'    => 30,
+					'offset' => 150,
 				),
 			);
 			break;

--- a/wp-content/plugins/wporg-learn/inc/activity-kit-rest.php
+++ b/wp-content/plugins/wporg-learn/inc/activity-kit-rest.php
@@ -161,6 +161,15 @@ function handle_stats( $request ) {
  * posts ranked by all-time views, which means newly published activity kits
  * never appear — they're outranked by years of established content.
  *
+ * API constraints (Jetpack / WPCOM /stats/views/posts endpoint):
+ *   - `period` is silently discarded; only daily granularity is returned.
+ *   - `num` is capped at 30 days per call (422 if larger).
+ *   - `post_ids` accepts at most 100 IDs per call.
+ *
+ * To cover ranges longer than 30 days, multiple 30-day windows are issued with
+ * a date offset and the results are summed. Kit IDs are chunked into groups of
+ * 100 so the library can grow past 100 kits without silently losing data.
+ *
  * @param string $range   One of '7d', '30d', '90d', 'all'.
  * @param int[]  $kit_ids Post IDs of the activity kits to fetch views for.
  * @return array          Map of post_id (int) => view_count (int). Empty on failure.
@@ -172,37 +181,81 @@ function get_jetpack_post_views( $range, array $kit_ids ) {
 
 	$stats = new \Automattic\Jetpack\Stats\WPCOM_Stats();
 
-	if ( 'all' === $range ) {
-		$period = 'month';
-		$num    = 36;
-	} else {
-		$period = 'day';
-		$num    = intval( str_replace( 'd', '', $range ) );
+	/*
+	 * Map the UI range to one or more 30-day windows. Each window is defined by
+	 * how many days back its end-date is offset from today. The 'all' range is
+	 * capped at 90 days (3 × 30) — covering more would require an unreasonable
+	 * number of sequential API calls.
+	 */
+	switch ( $range ) {
+		case '7d':
+			$windows = array(
+				array(
+					'num'    => 7,
+					'offset' => 0,
+				),
+			);
+			break;
+		case '30d':
+			$windows = array(
+				array(
+					'num'    => 30,
+					'offset' => 0,
+				),
+			);
+			break;
+		case '90d':
+		case 'all':
+		default:
+			$windows = array(
+				array(
+					'num'    => 30,
+					'offset' => 0,
+				),
+				array(
+					'num'    => 30,
+					'offset' => 30,
+				),
+				array(
+					'num'    => 30,
+					'offset' => 60,
+				),
+			);
+			break;
 	}
 
-	$result = $stats->get_total_post_views(
-		array(
-			'post_ids' => implode( ',', array_map( 'absint', $kit_ids ) ),
-			'period'   => $period,
-			'num'      => $num,
-			'date'     => gmdate( 'Y-m-d' ),
-		)
-	);
+	$chunks = array_chunk( $kit_ids, 100 );
+	$map    = array();
 
-	if ( is_wp_error( $result ) || ! is_array( $result ) ) {
-		return array();
-	}
+	foreach ( $chunks as $chunk ) {
+		$post_ids_str = implode( ',', array_map( 'absint', $chunk ) );
 
-	$post_views = isset( $result['posts'] ) ? $result['posts'] : array();
-	if ( ! is_array( $post_views ) ) {
-		return array();
-	}
+		foreach ( $windows as $window ) {
+			$date   = gmdate( 'Y-m-d', time() - $window['offset'] * DAY_IN_SECONDS );
+			$result = $stats->get_total_post_views(
+				array(
+					'post_ids' => $post_ids_str,
+					'num'      => $window['num'],
+					'date'     => $date,
+				)
+			);
 
-	$map = array();
-	foreach ( $post_views as $post_data ) {
-		// The views/posts API uses uppercase 'ID' (unlike top-posts which uses 'id').
-		if ( isset( $post_data['ID'], $post_data['views'] ) ) {
-			$map[ (int) $post_data['ID'] ] = (int) $post_data['views'];
+			if ( is_wp_error( $result ) || ! is_array( $result ) ) {
+				continue;
+			}
+
+			$post_views = isset( $result['posts'] ) ? $result['posts'] : array();
+			if ( ! is_array( $post_views ) ) {
+				continue;
+			}
+
+			foreach ( $post_views as $post_data ) {
+				// The views/posts API uses uppercase 'ID' (unlike top-posts which uses 'id').
+				if ( isset( $post_data['ID'], $post_data['views'] ) ) {
+					$id         = (int) $post_data['ID'];
+					$map[ $id ] = ( isset( $map[ $id ] ) ? $map[ $id ] : 0 ) + (int) $post_data['views'];
+				}
+			}
 		}
 	}
 

--- a/wp-content/plugins/wporg-learn/inc/activity-kit-rest.php
+++ b/wp-content/plugins/wporg-learn/inc/activity-kit-rest.php
@@ -295,6 +295,11 @@ function get_jetpack_post_views( $range, array $kit_ids ) {
 /**
  * Get per-kit download click counts from Jetpack Clicks report.
  *
+ * Clicks are scoped to the same window as get_jetpack_post_views() so that the
+ * download rate (downloads / views) divides two figures covering the same span.
+ * For 'all' that means ~6 months, matching the 6 x 30-day view windows, rather
+ * than the 36 months the Clicks report is otherwise happy to return.
+ *
  * @param string $range       One of '7d', '30d', '90d', 'all'.
  * @param array  $zip_url_map Map of zip_url (string) => array of post_ids (int[]).
  * @return array              Map of post_id (int) => click_count (int). Empty on failure.
@@ -308,7 +313,7 @@ function get_jetpack_download_clicks( $range, $zip_url_map ) {
 
 	if ( 'all' === $range ) {
 		$period = 'month';
-		$num    = 36;
+		$num    = 6;
 	} else {
 		$period = 'day';
 		$num    = intval( str_replace( 'd', '', $range ) );

--- a/wp-content/plugins/wporg-learn/inc/activity-kit-rest.php
+++ b/wp-content/plugins/wporg-learn/inc/activity-kit-rest.php
@@ -280,19 +280,19 @@ function get_jetpack_post_views( $range, array $kit_ids ) {
 				)
 			);
 
-			if ( is_wp_error( $result ) ) {
-				// Real API failure — return empty so the caller shows 0 for all
-				// kits (a visible failure signal) rather than a plausible-looking
-				// undercount that is harder to detect.
+			/*
+			 * Any unusable response — API failure or unexpected shape — returns empty
+			 * so the caller shows 0 for all kits (a visible failure signal) rather
+			 * than a plausible-looking undercount. Skipping just the bad window would
+			 * drop its views from a sum the other windows still make look reasonable.
+			 */
+			if ( is_wp_error( $result ) || ! is_array( $result ) ) {
 				return array();
-			}
-			if ( ! is_array( $result ) ) {
-				continue;
 			}
 
 			$post_views = isset( $result['posts'] ) ? $result['posts'] : array();
 			if ( ! is_array( $post_views ) ) {
-				continue;
+				return array();
 			}
 
 			foreach ( $post_views as $post_data ) {

--- a/wp-content/plugins/wporg-learn/inc/activity-kit-rest.php
+++ b/wp-content/plugins/wporg-learn/inc/activity-kit-rest.php
@@ -110,7 +110,8 @@ function handle_stats( $request ) {
 		add_filter( 'jetpack_fetch_stats_cache_expiration', __NAMESPACE__ . '\stats_cache_expiration' );
 
 		if ( 'both' === $metric || 'views' === $metric ) {
-			$views_map = get_jetpack_post_views( $range );
+			$kit_ids   = wp_list_pluck( $kits, 'ID' );
+			$views_map = get_jetpack_post_views( $range, $kit_ids );
 		}
 		if ( 'both' === $metric || 'downloads' === $metric ) {
 			$downloads_map = get_jetpack_download_clicks( $range, $zip_url_map );
@@ -155,11 +156,17 @@ function handle_stats( $request ) {
 /**
  * Get per-post view counts from Jetpack Stats for a given time range.
  *
- * @param string $range One of '7d', '30d', '90d', 'all'.
- * @return array        Map of post_id (int) => view_count (int). Empty on failure.
+ * Uses get_total_post_views() rather than get_top_posts() so that views are
+ * fetched by post ID directly. get_top_posts() only returns the site-wide top N
+ * posts ranked by all-time views, which means newly published activity kits
+ * never appear — they're outranked by years of established content.
+ *
+ * @param string $range   One of '7d', '30d', '90d', 'all'.
+ * @param int[]  $kit_ids Post IDs of the activity kits to fetch views for.
+ * @return array          Map of post_id (int) => view_count (int). Empty on failure.
  */
-function get_jetpack_post_views( $range ) {
-	if ( ! class_exists( '\Automattic\Jetpack\Stats\WPCOM_Stats' ) ) {
+function get_jetpack_post_views( $range, array $kit_ids ) {
+	if ( ! class_exists( '\Automattic\Jetpack\Stats\WPCOM_Stats' ) || empty( $kit_ids ) ) {
 		return array();
 	}
 
@@ -173,13 +180,12 @@ function get_jetpack_post_views( $range ) {
 		$num    = intval( str_replace( 'd', '', $range ) );
 	}
 
-	$result = $stats->get_top_posts(
+	$result = $stats->get_total_post_views(
 		array(
-			'period'    => $period,
-			'num'       => $num,
-			'date'      => gmdate( 'Y-m-d' ),
-			'summarize' => true,
-			'max'       => 1000,
+			'post_ids' => implode( ',', array_map( 'absint', $kit_ids ) ),
+			'period'   => $period,
+			'num'      => $num,
+			'date'     => gmdate( 'Y-m-d' ),
 		)
 	);
 
@@ -187,15 +193,16 @@ function get_jetpack_post_views( $range ) {
 		return array();
 	}
 
-	$post_views = isset( $result['summary']['postviews'] ) ? $result['summary']['postviews'] : array();
+	$post_views = isset( $result['posts'] ) ? $result['posts'] : array();
 	if ( ! is_array( $post_views ) ) {
 		return array();
 	}
 
 	$map = array();
 	foreach ( $post_views as $post_data ) {
-		if ( isset( $post_data['id'], $post_data['views'] ) ) {
-			$map[ (int) $post_data['id'] ] = (int) $post_data['views'];
+		// The views/posts API uses uppercase 'ID' (unlike top-posts which uses 'id').
+		if ( isset( $post_data['ID'], $post_data['views'] ) ) {
+			$map[ (int) $post_data['ID'] ] = (int) $post_data['views'];
 		}
 	}
 

--- a/wp-content/plugins/wporg-learn/inc/activity-kit-rest.php
+++ b/wp-content/plugins/wporg-learn/inc/activity-kit-rest.php
@@ -254,23 +254,39 @@ function get_jetpack_post_views( $range, array $kit_ids ) {
 			break;
 	}
 
+	// Pre-compute window end-dates once so every chunk uses the same calendar
+	// day, even if a UTC midnight falls between chunk iterations.
+	$now           = time();
+	$dated_windows = array();
+	foreach ( $windows as $window ) {
+		$dated_windows[] = array(
+			'num'  => $window['num'],
+			'date' => gmdate( 'Y-m-d', $now - $window['offset'] * DAY_IN_SECONDS ),
+		);
+	}
+
 	$chunks = array_chunk( $kit_ids, 100 );
 	$map    = array();
 
 	foreach ( $chunks as $chunk ) {
 		$post_ids_str = implode( ',', array_map( 'absint', $chunk ) );
 
-		foreach ( $windows as $window ) {
-			$date   = gmdate( 'Y-m-d', time() - $window['offset'] * DAY_IN_SECONDS );
+		foreach ( $dated_windows as $window ) {
 			$result = $stats->get_total_post_views(
 				array(
 					'post_ids' => $post_ids_str,
 					'num'      => $window['num'],
-					'date'     => $date,
+					'date'     => $window['date'],
 				)
 			);
 
-			if ( is_wp_error( $result ) || ! is_array( $result ) ) {
+			if ( is_wp_error( $result ) ) {
+				// Real API failure — return empty so the caller shows 0 for all
+				// kits (a visible failure signal) rather than a plausible-looking
+				// undercount that is harder to detect.
+				return array();
+			}
+			if ( ! is_array( $result ) ) {
 				continue;
 			}
 
@@ -297,8 +313,9 @@ function get_jetpack_post_views( $range, array $kit_ids ) {
  *
  * Clicks are scoped to the same window as get_jetpack_post_views() so that the
  * download rate (downloads / views) divides two figures covering the same span.
- * For 'all' that means ~6 months, matching the 6 x 30-day view windows, rather
- * than the 36 months the Clicks report is otherwise happy to return.
+ * For 'all' that means exactly 180 days (period=day, num=180), matching the
+ * 6 × 30-day view windows — calendar-month boundaries would give 181–184 days
+ * and introduce a slight rate inflation relative to the view window.
  *
  * @param string $range       One of '7d', '30d', '90d', 'all'.
  * @param array  $zip_url_map Map of zip_url (string) => array of post_ids (int[]).
@@ -312,8 +329,11 @@ function get_jetpack_download_clicks( $range, $zip_url_map ) {
 	$stats = new \Automattic\Jetpack\Stats\WPCOM_Stats();
 
 	if ( 'all' === $range ) {
-		$period = 'month';
-		$num    = 6;
+		// Use day granularity for 'all' so the window is exactly 180 days,
+		// matching the 6 × 30-day view windows in get_jetpack_post_views().
+		// period=month would give 181–184 days depending on the calendar.
+		$period = 'day';
+		$num    = 180;
 	} else {
 		$period = 'day';
 		$num    = intval( str_replace( 'd', '', $range ) );

--- a/wp-content/plugins/wporg-learn/js/activity-kit-stats/index.js
+++ b/wp-content/plugins/wporg-learn/js/activity-kit-stats/index.js
@@ -71,9 +71,12 @@ if ( filterKit && tableBody && chartCanvas ) {
 			'7d': 'Last 7 days',
 			'30d': 'Last 30 days',
 			'90d': 'Last 90 days',
-			all: 'All time',
+			// 'All time' covers ~6 months (6 × 30-day windows) — the WPCOM
+			// /stats/views/posts API caps each call at 30 days; see
+			// get_jetpack_post_views() in activity-kit-rest.php.
+			all: 'All time (max ~6 months)',
 		};
-		return labels[ activeRange ] || 'All time';
+		return labels[ activeRange ] || 'All time (max ~6 months)';
 	}
 
 	const metricLabel = {
@@ -118,7 +121,9 @@ if ( filterKit && tableBody && chartCanvas ) {
 		const isSingle = !! activeKit;
 		const totalV = data.reduce( ( sum, row ) => sum + ( row.views ?? 0 ), 0 );
 		const totalD = data.reduce( ( sum, row ) => sum + ( row.downloads ?? 0 ), 0 );
-		const rate = totalV > 0 ? ( ( totalD / totalV ) * 100 ).toFixed( 1 ) + '%' : '—';
+		// Downloads are an all-time cumulative counter; rate is only meaningful
+		// when views cover the same all-time window.
+		const rate = activeRange === 'all' && totalV > 0 ? ( ( totalD / totalV ) * 100 ).toFixed( 1 ) + '%' : '—';
 
 		if ( summaryViews ) {
 			summaryViews.textContent = fmt( totalV );
@@ -142,8 +147,9 @@ if ( filterKit && tableBody && chartCanvas ) {
 		if ( boxDownloads ) {
 			boxDownloads.style.display = activeMetric === 'views' ? 'none' : '';
 		}
+		// Rate is only valid when views cover the same window as the all-time download counter.
 		if ( boxRate ) {
-			boxRate.style.display = isSingle ? '' : 'none';
+			boxRate.style.display = isSingle && activeRange === 'all' ? '' : 'none';
 		}
 	}
 
@@ -294,7 +300,8 @@ if ( filterKit && tableBody && chartCanvas ) {
 		sorted.forEach( ( row ) => {
 			const views = row.views ?? 0;
 			const downloads = row.downloads ?? 0;
-			const rate = views > 0 ? ( ( downloads / views ) * 100 ).toFixed( 1 ) + '%' : '—';
+			// Suppress rate when views are range-scoped but downloads are all-time.
+			const rate = activeRange === 'all' && views > 0 ? ( ( downloads / views ) * 100 ).toFixed( 1 ) + '%' : '—';
 			const isSelected = row.slug === activeKit;
 			const tableRow = document.createElement( 'tr' );
 			if ( isSelected ) {
@@ -380,6 +387,22 @@ if ( filterKit && tableBody && chartCanvas ) {
 		}
 		if ( thDownloads ) {
 			thDownloads.classList.toggle( 'ak-hidden-col', activeMetric === 'views' );
+			// Label the column so admins know downloads are always all-time when a
+			// range-scoped view window is selected.
+			const arrow = thDownloads.querySelector( '.ak-sort-arrow' );
+			thDownloads.textContent = activeRange === 'all' ? 'Downloads' : 'Downloads (all time)';
+			if ( arrow ) {
+				thDownloads.appendChild( arrow );
+			}
+		}
+		// Mirror the same label on the summary box.
+		if ( summaryDownloads ) {
+			const dlLabel = summaryDownloads.closest( '.ak-summary-box' )
+				? summaryDownloads.closest( '.ak-summary-box' ).querySelector( '.ak-stat-label' )
+				: null;
+			if ( dlLabel ) {
+				dlLabel.textContent = activeRange === 'all' ? 'Total Downloads' : 'Total Downloads (all time)';
+			}
 		}
 
 		if ( backLinkBar ) {
@@ -467,11 +490,15 @@ if ( filterKit && tableBody && chartCanvas ) {
 
 	function exportCSV() {
 		const data = activeKit ? allData.filter( ( row ) => row.slug === activeKit ) : allData;
-		const rows = [ [ 'Kit Name', 'Views', 'Downloads', 'Download Rate', 'Last Updated' ] ];
+		// Downloads column header clarifies scope when views are range-filtered.
+		const dlHeader = activeRange === 'all' ? 'Downloads' : 'Downloads (all time)';
+		const rows = [ [ 'Kit Name', 'Views', dlHeader, 'Download Rate', 'Last Updated' ] ];
 		data.forEach( ( row ) => {
 			const views = row.views ?? 0;
 			const downloads = row.downloads ?? 0;
-			const rate = views > 0 ? ( ( downloads / views ) * 100 ).toFixed( 1 ) + '%' : '0%';
+			// Rate is only meaningful when views and downloads cover the same window.
+			const rate =
+				activeRange === 'all' && views > 0 ? ( ( downloads / views ) * 100 ).toFixed( 1 ) + '%' : 'N/A';
 			rows.push( [ row.title, views, downloads, rate, row.updated || '' ] );
 		} );
 		const csv = rows.map( ( row ) => row.map( csvCell ).join( ',' ) ).join( '\n' );

--- a/wp-content/plugins/wporg-learn/js/activity-kit-stats/index.js
+++ b/wp-content/plugins/wporg-learn/js/activity-kit-stats/index.js
@@ -71,9 +71,11 @@ if ( filterKit && tableBody && chartCanvas ) {
 			'7d': 'Last 7 days',
 			'30d': 'Last 30 days',
 			'90d': 'Last 90 days',
-			// 'All time' covers ~6 months (6 × 30-day windows) — the WPCOM
-			// /stats/views/posts API caps each call at 30 days; see
-			// get_jetpack_post_views() in activity-kit-rest.php.
+			/*
+			 * 'All time' covers ~6 months (6 x 30-day windows) — the WPCOM
+			 * /stats/views/posts API caps each call at 30 days; see
+			 * get_jetpack_post_views() in activity-kit-rest.php.
+			 */
 			all: 'All time (max ~6 months)',
 		};
 		return labels[ activeRange ] || 'All time (max ~6 months)';
@@ -121,9 +123,7 @@ if ( filterKit && tableBody && chartCanvas ) {
 		const isSingle = !! activeKit;
 		const totalV = data.reduce( ( sum, row ) => sum + ( row.views ?? 0 ), 0 );
 		const totalD = data.reduce( ( sum, row ) => sum + ( row.downloads ?? 0 ), 0 );
-		// Downloads are an all-time cumulative counter; rate is only meaningful
-		// when views cover the same all-time window.
-		const rate = activeRange === 'all' && totalV > 0 ? ( ( totalD / totalV ) * 100 ).toFixed( 1 ) + '%' : '—';
+		const rate = totalV > 0 ? ( ( totalD / totalV ) * 100 ).toFixed( 1 ) + '%' : '—';
 
 		if ( summaryViews ) {
 			summaryViews.textContent = fmt( totalV );
@@ -147,9 +147,8 @@ if ( filterKit && tableBody && chartCanvas ) {
 		if ( boxDownloads ) {
 			boxDownloads.style.display = activeMetric === 'views' ? 'none' : '';
 		}
-		// Rate is only valid when views cover the same window as the all-time download counter.
 		if ( boxRate ) {
-			boxRate.style.display = isSingle && activeRange === 'all' ? '' : 'none';
+			boxRate.style.display = isSingle ? '' : 'none';
 		}
 	}
 
@@ -300,8 +299,7 @@ if ( filterKit && tableBody && chartCanvas ) {
 		sorted.forEach( ( row ) => {
 			const views = row.views ?? 0;
 			const downloads = row.downloads ?? 0;
-			// Suppress rate when views are range-scoped but downloads are all-time.
-			const rate = activeRange === 'all' && views > 0 ? ( ( downloads / views ) * 100 ).toFixed( 1 ) + '%' : '—';
+			const rate = views > 0 ? ( ( downloads / views ) * 100 ).toFixed( 1 ) + '%' : '—';
 			const isSelected = row.slug === activeKit;
 			const tableRow = document.createElement( 'tr' );
 			if ( isSelected ) {
@@ -387,22 +385,6 @@ if ( filterKit && tableBody && chartCanvas ) {
 		}
 		if ( thDownloads ) {
 			thDownloads.classList.toggle( 'ak-hidden-col', activeMetric === 'views' );
-			// Label the column so admins know downloads are always all-time when a
-			// range-scoped view window is selected.
-			const arrow = thDownloads.querySelector( '.ak-sort-arrow' );
-			thDownloads.textContent = activeRange === 'all' ? 'Downloads' : 'Downloads (all time)';
-			if ( arrow ) {
-				thDownloads.appendChild( arrow );
-			}
-		}
-		// Mirror the same label on the summary box.
-		if ( summaryDownloads ) {
-			const dlLabel = summaryDownloads.closest( '.ak-summary-box' )
-				? summaryDownloads.closest( '.ak-summary-box' ).querySelector( '.ak-stat-label' )
-				: null;
-			if ( dlLabel ) {
-				dlLabel.textContent = activeRange === 'all' ? 'Total Downloads' : 'Total Downloads (all time)';
-			}
 		}
 
 		if ( backLinkBar ) {
@@ -490,15 +472,11 @@ if ( filterKit && tableBody && chartCanvas ) {
 
 	function exportCSV() {
 		const data = activeKit ? allData.filter( ( row ) => row.slug === activeKit ) : allData;
-		// Downloads column header clarifies scope when views are range-filtered.
-		const dlHeader = activeRange === 'all' ? 'Downloads' : 'Downloads (all time)';
-		const rows = [ [ 'Kit Name', 'Views', dlHeader, 'Download Rate', 'Last Updated' ] ];
+		const rows = [ [ 'Kit Name', 'Views', 'Downloads', 'Download Rate', 'Last Updated' ] ];
 		data.forEach( ( row ) => {
 			const views = row.views ?? 0;
 			const downloads = row.downloads ?? 0;
-			// Rate is only meaningful when views and downloads cover the same window.
-			const rate =
-				activeRange === 'all' && views > 0 ? ( ( downloads / views ) * 100 ).toFixed( 1 ) + '%' : 'N/A';
+			const rate = views > 0 ? ( ( downloads / views ) * 100 ).toFixed( 1 ) + '%' : '0%';
 			rows.push( [ row.title, views, downloads, rate, row.updated || '' ] );
 		} );
 		const csv = rows.map( ( row ) => row.map( csvCell ).join( ',' ) ).join( '\n' );


### PR DESCRIPTION
## Problem

The Activity Kit Stats page shows 0 views for all kits despite Jetpack being connected and the site receiving thousands of daily page views (confirmed via Jetpack Stats).

## Root cause

`get_jetpack_post_views()` was calling `WPCOM_Stats::get_top_posts()` — which returns the top 1,000 most-viewed posts on the **entire site**, ranked by accumulated all-time view count. Activity kits went live on Aug 11 and have only 1–2 days of traffic. With years of established courses, lessons, and learning pathways outranking them, the kits don't appear in the top 1,000 and the function silently returns 0 for every kit.

This was confirmed by checking the Jetpack Stats admin page, which shows the site receiving ~5,000–8,000 views per day but only lists long-standing content (Beginner WordPress User, Introduction to WordPress, etc.) as top posts — no activity kits in sight.

## Fix

Switch to `WPCOM_Stats::get_total_post_views()`, which hits the `stats/views/posts` endpoint and fetches view counts for **specific post IDs** directly, regardless of site-wide ranking. The kit post IDs are already known from the `get_posts()` query, so they are passed as a `post_ids` comma-separated parameter.

Also corrects the response key: the `views/posts` API uses uppercase `'ID'` for the post identifier; `top-posts` used lowercase `'id'`.

## Testing

1. Visit the [Activity Kit Stats page](https://learn.wordpress.org/wp-admin/edit.php?post_type=activity_kit&page=activity-kit-stats)
2. Views should now show non-zero counts for kits that have been visited

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)