### PR TITLE
Activity kits: server-side download tracking

### DIFF
--- a/wp-content/plugins/wporg-learn/inc/activity-kit-rest.php
+++ b/wp-content/plugins/wporg-learn/inc/activity-kit-rest.php
@@ -71,11 +71,6 @@ function register_routes() {
 /**
  * Get the tracked download URL for an activity kit.
  *
- * Templates must link kit ZIPs through this endpoint (rather than the raw
- * attachment URL) so the download is counted before the redirect. Keeping the
- * route path in one place next to its registration means a route change cannot
- * leave a template linking to a 404.
- *
  * @param int $kit_id Post ID of the activity kit.
  * @return string     URL of the counting download endpoint.
  */
@@ -151,15 +146,9 @@ function handle_download( $request ) {
 
 	if ( ! $is_bot ) {
 		/*
-		 * Downloads are stored in one meta row per kit per UTC day so the stats
-		 * endpoint can sum them over the same day span as the Jetpack view
-		 * ranges (see get_download_counts()). Seed today's bucket ($unique=true
-		 * is a no-op once it exists), then increment with a direct UPDATE —
-		 * update_post_meta()'s $prev_value CAS drops its WHERE clause when the
-		 * previous value is 0, so two concurrent downloads would both write 1.
-		 * If two first-downloads of the day race the seed into duplicate rows,
-		 * every UPDATE increments both and reads take MAX per bucket, so no
-		 * download is lost.
+		 * Seed today's bucket, then increment atomically — update_post_meta()'s
+		 * CAS is racy when the previous value is 0, and a seed race is harmless
+		 * because reads take MAX per bucket.
 		 */
 		$meta_key = '_activity_downloads_' . gmdate( 'Ymd' );
 		add_post_meta( $kit_post->ID, $meta_key, 0, true );
@@ -267,12 +256,8 @@ function handle_stats( $request ) {
 /**
  * Get the day span a stats range covers.
  *
- * Single source of truth for both metrics: get_jetpack_post_views() derives
- * its API windows from this and get_download_counts() sums bucket rows over
- * it, so the download rate always divides two figures covering the identical
- * period. 'all' caps at 180 days — each extra 30-day window is another
- * sequential API call, and 6 is a reasonable ceiling for an admin-only
- * dashboard with a small post count.
+ * Shared by get_jetpack_post_views() and get_download_counts() so views and
+ * downloads always cover the same period.
  *
  * @param string $range One of '7d', '30d', '90d', 'all'.
  * @return int          Number of days the range covers.

--- a/wp-content/plugins/wporg-learn/inc/activity-kit-rest.php
+++ b/wp-content/plugins/wporg-learn/inc/activity-kit-rest.php
@@ -144,10 +144,22 @@ function handle_download( $request ) {
 			)
 		);
 		if ( 0 === $updated ) {
-			// No row yet — insert with an initial count of 1.
-			// $wpdb->query() returns false on DB error and 0 when no rows matched;
-			// strict comparison avoids falling into this branch on a real error.
-			add_post_meta( $kit_post->ID, '_activity_download_count', 1, true );
+			// No row yet (e.g. a kit published before the pre-seeding hook was
+			// added). Insert with an initial count of 1. If a concurrent
+			// first-download wins the INSERT race, add_post_meta() returns false
+			// ($unique=true blocks the duplicate); re-run the UPDATE so this
+			// download is still counted.
+			$inserted = add_post_meta( $kit_post->ID, '_activity_download_count', 1, true );
+			if ( ! $inserted ) {
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Atomic fallback after concurrent INSERT collision; cache invalidated immediately below.
+				$wpdb->query(
+					$wpdb->prepare(
+						"UPDATE {$wpdb->postmeta} SET meta_value = meta_value + 1 WHERE post_id = %d AND meta_key = %s",
+						$kit_post->ID,
+						'_activity_download_count'
+					)
+				);
+			}
 		}
 		wp_cache_delete( $kit_post->ID, 'post_meta' );
 	}

--- a/wp-content/plugins/wporg-learn/inc/activity-kit-rest.php
+++ b/wp-content/plugins/wporg-learn/inc/activity-kit-rest.php
@@ -69,6 +69,21 @@ function register_routes() {
 }
 
 /**
+ * Get the tracked download URL for an activity kit.
+ *
+ * Templates must link kit ZIPs through this endpoint (rather than the raw
+ * attachment URL) so the download is counted before the redirect. Keeping the
+ * route path in one place next to its registration means a route change cannot
+ * leave a template linking to a 404.
+ *
+ * @param int $kit_id Post ID of the activity kit.
+ * @return string     URL of the counting download endpoint.
+ */
+function get_download_url( $kit_id ) {
+	return rest_url( 'activity-kits/v1/download/' . absint( $kit_id ) );
+}
+
+/**
  * Shorten Jetpack's stats API cache so the activity kit dashboard tracks
  * WordPress.com's near-real-time counts more closely. Registered only for the
  * duration of the activity kit stats REST request (see handle_stats()), so it
@@ -109,7 +124,11 @@ function handle_download( $request ) {
 	 * download, not a failed one.
 	 */
 	$user_agent = sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ?? '' ) );
-	$is_bot     = empty( $user_agent ) || preg_match( '/bot|crawl|slurp|spider|mediapartners|facebookexternalhit|linkedinbot|twitterbot|whatsapp|slack|discord|prefetch/i', $user_agent );
+	// Browsers signal speculative loads via headers, not the User-Agent: Sec-Purpose (standard), Purpose (WebKit), X-moz (older Firefox).
+	$purpose = sanitize_text_field( wp_unslash( $_SERVER['HTTP_SEC_PURPOSE'] ?? $_SERVER['HTTP_PURPOSE'] ?? $_SERVER['HTTP_X_MOZ'] ?? '' ) );
+	$is_bot  = empty( $user_agent )
+		|| preg_match( '/bot|crawl|slurp|spider|mediapartners|facebookexternalhit|linkedinbot|twitterbot|whatsapp|slack|discord|prefetch/i', $user_agent )
+		|| preg_match( '/prefetch|prerender|preview/i', $purpose );
 
 	$kit_id   = absint( $request->get_param( 'id' ) );
 	$kit_post = get_post( $kit_id );
@@ -246,6 +265,32 @@ function handle_stats( $request ) {
 }
 
 /**
+ * Get the day span a stats range covers.
+ *
+ * Single source of truth for both metrics: get_jetpack_post_views() derives
+ * its API windows from this and get_download_counts() sums bucket rows over
+ * it, so the download rate always divides two figures covering the identical
+ * period. 'all' caps at 180 days — each extra 30-day window is another
+ * sequential API call, and 6 is a reasonable ceiling for an admin-only
+ * dashboard with a small post count.
+ *
+ * @param string $range One of '7d', '30d', '90d', 'all'.
+ * @return int          Number of days the range covers.
+ */
+function get_range_days( $range ) {
+	switch ( $range ) {
+		case '7d':
+			return 7;
+		case '30d':
+			return 30;
+		case '90d':
+			return 90;
+		default:
+			return 180;
+	}
+}
+
+/**
  * Get per-post view counts from Jetpack Stats for a given time range.
  *
  * Uses get_total_post_views() to query specific post IDs directly, rather than
@@ -273,74 +318,17 @@ function get_jetpack_post_views( $range, array $kit_ids ) {
 	$stats = new \Automattic\Jetpack\Stats\WPCOM_Stats();
 
 	/*
-	 * Map the UI range to one or more 30-day windows. Each window is defined by
-	 * how many days back its end-date is offset from today. 'all' uses 6 windows
-	 * (≈ 6 months) rather than 3, giving a meaningful distinction from '90d'.
-	 * Extending further would multiply sequential API calls proportionally; 6 is
-	 * a reasonable ceiling for an admin-only dashboard with a small post count.
+	 * Break the range's day span into windows of at most 30 days — the WPCOM
+	 * /stats/views/posts API caps `num` at 30 per call. Each window is defined
+	 * by how many days back its end-date is offset from today.
 	 */
-	switch ( $range ) {
-		case '7d':
-			$windows = array(
-				array(
-					'num'    => 7,
-					'offset' => 0,
-				),
-			);
-			break;
-		case '30d':
-			$windows = array(
-				array(
-					'num'    => 30,
-					'offset' => 0,
-				),
-			);
-			break;
-		case '90d':
-			$windows = array(
-				array(
-					'num'    => 30,
-					'offset' => 0,
-				),
-				array(
-					'num'    => 30,
-					'offset' => 30,
-				),
-				array(
-					'num'    => 30,
-					'offset' => 60,
-				),
-			);
-			break;
-		case 'all':
-		default:
-			$windows = array(
-				array(
-					'num'    => 30,
-					'offset' => 0,
-				),
-				array(
-					'num'    => 30,
-					'offset' => 30,
-				),
-				array(
-					'num'    => 30,
-					'offset' => 60,
-				),
-				array(
-					'num'    => 30,
-					'offset' => 90,
-				),
-				array(
-					'num'    => 30,
-					'offset' => 120,
-				),
-				array(
-					'num'    => 30,
-					'offset' => 150,
-				),
-			);
-			break;
+	$days    = get_range_days( $range );
+	$windows = array();
+	for ( $offset = 0; $offset < $days; $offset += 30 ) {
+		$windows[] = array(
+			'num'    => min( 30, $days - $offset ),
+			'offset' => $offset,
+		);
 	}
 
 	// Pre-compute window end-dates once so every chunk uses the same calendar
@@ -416,15 +404,7 @@ function get_download_counts( $range, array $kit_ids ) {
 		return array();
 	}
 
-	// Day spans matching the view windows in get_jetpack_post_views().
-	$range_days = array(
-		'7d'  => 7,
-		'30d' => 30,
-		'90d' => 90,
-		'all' => 180,
-	);
-	$days       = isset( $range_days[ $range ] ) ? $range_days[ $range ] : 180;
-
+	$days      = get_range_days( $range );
 	$now       = time();
 	$first_key = '_activity_downloads_' . gmdate( 'Ymd', $now - ( $days - 1 ) * DAY_IN_SECONDS );
 	$last_key  = '_activity_downloads_' . gmdate( 'Ymd', $now );

--- a/wp-content/plugins/wporg-learn/inc/activity-kit-rest.php
+++ b/wp-content/plugins/wporg-learn/inc/activity-kit-rest.php
@@ -45,18 +45,23 @@ function register_routes() {
 		)
 	);
 
+	/*
+	 * Route on post ID (integer) rather than slug so that kits with underscores,
+	 * percent-encoded non-Latin characters, or other slug forms not matched by a
+	 * narrow character class all resolve correctly.
+	 */
 	register_rest_route(
 		'activity-kits/v1',
-		'/download/(?P<slug>[a-z0-9-]+)',
+		'/download/(?P<id>\d+)',
 		array(
 			'methods'             => 'GET',
 			'callback'            => __NAMESPACE__ . '\handle_download',
 			'permission_callback' => '__return_true',
 			'args'                => array(
-				'slug' => array(
+				'id' => array(
 					'required'          => true,
-					'type'              => 'string',
-					'sanitize_callback' => 'sanitize_title',
+					'type'              => 'integer',
+					'sanitize_callback' => 'absint',
 				),
 			),
 		)
@@ -84,33 +89,36 @@ function stats_cache_expiration( $expiration ) {
 }
 
 /**
- * Handle GET /activity-kits/v1/download/{slug}
+ * Handle GET /activity-kits/v1/download/{id}
  *
  * Increments the kit's download counter (stored in post meta) and redirects
- * the browser to the actual ZIP file URL. Using a server-side redirect lets
- * us track same-domain downloads that Jetpack's outbound-click tracker misses.
+ * the browser to the actual ZIP file URL. Using a server-side redirect lets us
+ * track same-domain downloads that Jetpack's outbound-click tracker misses.
  *
  * @param \WP_REST_Request $request The REST request.
  * @return \WP_REST_Response|\WP_Error 302 redirect on success, WP_Error on failure.
  */
 function handle_download( $request ) {
-	$slug = $request->get_param( 'slug' );
+	global $wpdb;
 
-	$kits = get_posts(
-		array(
-			'post_type'      => 'activity_kit',
-			'posts_per_page' => 1,
-			'post_status'    => 'publish',
-			'name'           => $slug,
-		)
-	);
+	/*
+	 * Reject obvious crawler / link-unfurler User-Agents so that Slack previews,
+	 * email scanners, and browser prefetch rules do not increment the counter.
+	 * Empty User-Agent also suggests an automated tool rather than a real download.
+	 */
+	$user_agent = sanitize_text_field( wp_unslash( isset( $_SERVER['HTTP_USER_AGENT'] ) ? $_SERVER['HTTP_USER_AGENT'] : '' ) );
+	if ( empty( $user_agent ) || preg_match( '/bot|crawl|slurp|spider|mediapartners|facebookexternalhit|linkedinbot|twitterbot|whatsapp|slack|discord|prefetch/i', $user_agent ) ) {
+		return new \WP_Error( 'activity_kit_bot', '', array( 'status' => 404 ) );
+	}
 
-	if ( empty( $kits ) ) {
+	$kit_id   = absint( $request->get_param( 'id' ) );
+	$kit_post = get_post( $kit_id );
+
+	if ( ! $kit_post || 'activity_kit' !== $kit_post->post_type || 'publish' !== $kit_post->post_status ) {
 		return new \WP_Error( 'activity_kit_not_found', __( 'Activity kit not found.', 'wporg-learn' ), array( 'status' => 404 ) );
 	}
 
-	$kit_post = $kits[0];
-	$zip_id   = (int) get_post_meta( $kit_post->ID, '_activity_zip_id', true );
+	$zip_id = (int) get_post_meta( $kit_post->ID, '_activity_zip_id', true );
 
 	if ( ! $zip_id ) {
 		return new \WP_Error( 'activity_kit_no_zip', __( 'No downloadable file attached to this activity kit.', 'wporg-learn' ), array( 'status' => 404 ) );
@@ -122,17 +130,38 @@ function handle_download( $request ) {
 		return new \WP_Error( 'activity_kit_zip_url', __( 'Could not resolve the download URL.', 'wporg-learn' ), array( 'status' => 500 ) );
 	}
 
-	// Increment the download counter stored in post meta.
-	// Use a compare-and-swap retry loop (update_post_meta's $prev_value arg) to avoid
-	// lost increments when two requests arrive simultaneously.
-	$retries = 0;
-	do {
-		$current_count = (int) get_post_meta( $kit_post->ID, '_activity_download_count', true );
-		$updated       = update_post_meta( $kit_post->ID, '_activity_download_count', $current_count + 1, $current_count );
-		$retries++;
-	} while ( ! $updated && $retries < 5 );
+	/*
+	 * Atomic increment via a direct UPDATE — avoids the read-then-write race where
+	 * two simultaneous downloads overwrite each other. update_post_meta()'s
+	 * $prev_value CAS skips the WHERE clause when $prev_value is 0 (so two
+	 * concurrent first-downloads both write 1), and a genuine CAS failure leaves
+	 * the object cache stale so retries keep issuing the same failing UPDATE.
+	 * A single UPDATE with no read is safe. The object cache is invalidated after
+	 * either path so subsequent get_post_meta() calls see the new value.
+	 */
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Atomic increment; cache invalidated immediately below.
+	$updated = $wpdb->query(
+		$wpdb->prepare(
+			"UPDATE {$wpdb->postmeta} SET meta_value = meta_value + 1 WHERE post_id = %d AND meta_key = %s",
+			$kit_post->ID,
+			'_activity_download_count'
+		)
+	);
+	if ( ! $updated ) {
+		// No row yet — insert with an initial count of 1.
+		add_post_meta( $kit_post->ID, '_activity_download_count', 1, true );
+	}
+	wp_cache_delete( $kit_post->ID, 'post_meta' );
 
-	return new \WP_REST_Response( null, 302, array( 'Location' => esc_url_raw( $zip_url ) ) );
+	return new \WP_REST_Response(
+		null,
+		302,
+		array(
+			'Location'      => esc_url_raw( $zip_url ),
+			'Cache-Control' => 'no-store, no-cache, must-revalidate, max-age=0',
+			'Pragma'        => 'no-cache',
+		)
+	);
 }
 
 /**
@@ -203,13 +232,22 @@ function handle_stats( $request ) {
 /**
  * Get per-post view counts from Jetpack Stats for a given time range.
  *
- * Uses get_total_post_views() to query specific post IDs directly, rather
- * than get_top_posts() which only returns site-wide top posts and misses
- * recently published kits with low overall traffic.
+ * Uses get_total_post_views() to query specific post IDs directly, rather than
+ * get_top_posts() which only returns the site-wide top-N posts by all-time views
+ * and misses recently published kits with low overall traffic.
  *
- * @param string $range    One of '7d', '30d', '90d', 'all'.
- * @param array  $kit_ids  Array of post IDs to query.
- * @return array           Map of post_id (int) => view_count (int). Empty on failure.
+ * API constraints (Jetpack 13.3.1 / WPCOM /stats/views/posts endpoint):
+ *   - `period` is ignored; only daily granularity is returned.
+ *   - `num` is capped at 30 days per call.
+ *   - `post_ids` accepts at most 100 IDs per call.
+ *
+ * To cover ranges longer than 30 days, multiple 30-day windows are issued with
+ * a date offset and the results are summed. post_ids are chunked into groups of
+ * 100 so the library can grow past 100 kits without silently losing data.
+ *
+ * @param string $range   One of '7d', '30d', '90d', 'all'.
+ * @param int[]  $kit_ids Post IDs of the activity kits to fetch views for.
+ * @return array          Map of post_id (int) => view_count (int). Empty on failure.
  */
 function get_jetpack_post_views( $range, array $kit_ids ) {
 	if ( ! class_exists( '\Automattic\Jetpack\Stats\WPCOM_Stats' ) || empty( $kit_ids ) ) {
@@ -218,36 +256,76 @@ function get_jetpack_post_views( $range, array $kit_ids ) {
 
 	$stats = new \Automattic\Jetpack\Stats\WPCOM_Stats();
 
-	if ( 'all' === $range ) {
-		$period = 'month';
-		$num    = 36;
-	} else {
-		$period = 'day';
-		$num    = intval( str_replace( 'd', '', $range ) );
+	/*
+	 * Map the UI range to one or more 30-day windows. Each window is defined by
+	 * how many days back its end-date is offset from today. The 'all' range is
+	 * capped at 90 days (3 × 30) — covering more would require an unreasonable
+	 * number of sequential API calls.
+	 */
+	switch ( $range ) {
+		case '7d':
+			$windows = array(
+				array(
+					'num' => 7, 'offset' => 0,
+				),
+			);
+			break;
+		case '30d':
+			$windows = array(
+				array(
+					'num' => 30, 'offset' => 0,
+				),
+			);
+			break;
+		case '90d':
+		case 'all':
+		default:
+			$windows = array(
+				array(
+					'num' => 30, 'offset' => 0,
+				),
+				array(
+					'num' => 30, 'offset' => 30,
+				),
+				array(
+					'num' => 30, 'offset' => 60,
+				),
+			);
+			break;
 	}
 
-	$result = $stats->get_total_post_views(
-		array(
-			'post_ids' => implode( ',', array_map( 'absint', $kit_ids ) ),
-			'period'   => $period,
-			'num'      => $num,
-			'date'     => gmdate( 'Y-m-d' ),
-		)
-	);
+	$chunks = array_chunk( $kit_ids, 100 );
+	$map    = array();
 
-	if ( is_wp_error( $result ) || ! is_array( $result ) ) {
-		return array();
-	}
+	foreach ( $chunks as $chunk ) {
+		$post_ids_str = implode( ',', array_map( 'absint', $chunk ) );
 
-	$post_views = isset( $result['posts'] ) ? $result['posts'] : array();
-	if ( ! is_array( $post_views ) ) {
-		return array();
-	}
+		foreach ( $windows as $window ) {
+			$date   = gmdate( 'Y-m-d', time() - $window['offset'] * DAY_IN_SECONDS );
+			$result = $stats->get_total_post_views(
+				array(
+					'post_ids' => $post_ids_str,
+					'num'      => $window['num'],
+					'date'     => $date,
+				)
+			);
 
-	$map = array();
-	foreach ( $post_views as $post_data ) {
-		if ( isset( $post_data['ID'], $post_data['views'] ) ) {
-			$map[ (int) $post_data['ID'] ] = (int) $post_data['views'];
+			if ( is_wp_error( $result ) || ! is_array( $result ) ) {
+				continue;
+			}
+
+			$post_views = isset( $result['posts'] ) ? $result['posts'] : array();
+			if ( ! is_array( $post_views ) ) {
+				continue;
+			}
+
+			foreach ( $post_views as $post_data ) {
+				// The views/posts API uses uppercase 'ID' (unlike top-posts which uses 'id').
+				if ( isset( $post_data['ID'], $post_data['views'] ) ) {
+					$id         = (int) $post_data['ID'];
+					$map[ $id ] = ( isset( $map[ $id ] ) ? $map[ $id ] : 0 ) + (int) $post_data['views'];
+				}
+			}
 		}
 	}
 

--- a/wp-content/plugins/wporg-learn/inc/activity-kit-rest.php
+++ b/wp-content/plugins/wporg-learn/inc/activity-kit-rest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * REST API routes for activity kits: stats endpoint backed by Jetpack Stats.
+ * REST API routes for activity kits: stats and download-tracking endpoints.
  *
  * @package WPOrg_Learn
  */
@@ -44,6 +44,23 @@ function register_routes() {
 			),
 		)
 	);
+
+	register_rest_route(
+		'activity-kits/v1',
+		'/download/(?P<slug>[a-z0-9-]+)',
+		array(
+			'methods'             => 'GET',
+			'callback'            => __NAMESPACE__ . '\handle_download',
+			'permission_callback' => '__return_true',
+			'args'                => array(
+				'slug' => array(
+					'required'          => true,
+					'type'              => 'string',
+					'sanitize_callback' => 'sanitize_title',
+				),
+			),
+		)
+	);
 }
 
 /**
@@ -64,6 +81,52 @@ function register_routes() {
  */
 function stats_cache_expiration( $expiration ) {
 	return (int) max( 1, min( $expiration, MINUTE_IN_SECONDS ) );
+}
+
+/**
+ * Handle GET /activity-kits/v1/download/{slug}
+ *
+ * Increments the kit's download counter (stored in post meta) and redirects
+ * the browser to the actual ZIP file URL. Using a server-side redirect lets
+ * us track same-domain downloads that Jetpack's outbound-click tracker misses.
+ *
+ * @param \WP_REST_Request $request The REST request.
+ * @return \WP_REST_Response|\WP_Error 302 redirect on success, WP_Error on failure.
+ */
+function handle_download( $request ) {
+	$slug = $request->get_param( 'slug' );
+
+	$kits = get_posts(
+		array(
+			'post_type'      => 'activity_kit',
+			'posts_per_page' => 1,
+			'post_status'    => 'publish',
+			'name'           => $slug,
+		)
+	);
+
+	if ( empty( $kits ) ) {
+		return new \WP_Error( 'activity_kit_not_found', __( 'Activity kit not found.', 'wporg-learn' ), array( 'status' => 404 ) );
+	}
+
+	$kit_post = $kits[0];
+	$zip_id   = (int) get_post_meta( $kit_post->ID, '_activity_zip_id', true );
+
+	if ( ! $zip_id ) {
+		return new \WP_Error( 'activity_kit_no_zip', __( 'No downloadable file attached to this activity kit.', 'wporg-learn' ), array( 'status' => 404 ) );
+	}
+
+	$zip_url = wp_get_attachment_url( $zip_id );
+
+	if ( ! $zip_url ) {
+		return new \WP_Error( 'activity_kit_zip_url', __( 'Could not resolve the download URL.', 'wporg-learn' ), array( 'status' => 500 ) );
+	}
+
+	// Increment the download counter stored in post meta.
+	$current_count = (int) get_post_meta( $kit_post->ID, '_activity_download_count', true );
+	update_post_meta( $kit_post->ID, '_activity_download_count', $current_count + 1 );
+
+	return new \WP_REST_Response( null, 302, array( 'Location' => $zip_url ) );
 }
 
 /**
@@ -89,33 +152,12 @@ function handle_stats( $request ) {
 
 	$jetpack_unavailable = ! class_exists( '\Automattic\Jetpack\Stats\WPCOM_Stats' );
 
-	// Build ZIP URL => post IDs map for download click matching.
-	// A URL maps to an array of kit IDs so that if multiple kits share a zip,
-	// each kit is credited rather than silently dropped by a key collision.
-	$zip_url_map = array();
-	foreach ( $kits as $kit_post ) {
-		$zip_id = (int) get_post_meta( $kit_post->ID, '_activity_zip_id', true );
-		if ( $zip_id ) {
-			$zip_url = wp_get_attachment_url( $zip_id );
-			if ( $zip_url ) {
-				$zip_url_map[ $zip_url ][] = $kit_post->ID;
-			}
-		}
-	}
+	$kit_ids   = wp_list_pluck( $kits, 'ID' );
+	$views_map = array();
 
-	$views_map     = array();
-	$downloads_map = array();
-
-	if ( ! $jetpack_unavailable ) {
+	if ( ! $jetpack_unavailable && ( 'both' === $metric || 'views' === $metric ) ) {
 		add_filter( 'jetpack_fetch_stats_cache_expiration', __NAMESPACE__ . '\stats_cache_expiration' );
-
-		if ( 'both' === $metric || 'views' === $metric ) {
-			$views_map = get_jetpack_post_views( $range );
-		}
-		if ( 'both' === $metric || 'downloads' === $metric ) {
-			$downloads_map = get_jetpack_download_clicks( $range, $zip_url_map );
-		}
-
+		$views_map = get_jetpack_post_views( $range, $kit_ids );
 		remove_filter( 'jetpack_fetch_stats_cache_expiration', __NAMESPACE__ . '\stats_cache_expiration' );
 	}
 
@@ -142,7 +184,7 @@ function handle_stats( $request ) {
 				$data['views'] = $views_map[ $kit_post->ID ] ?? 0;
 			}
 			if ( 'both' === $metric || 'downloads' === $metric ) {
-				$data['downloads'] = $downloads_map[ $kit_post->ID ] ?? 0;
+				$data['downloads'] = (int) get_post_meta( $kit_post->ID, '_activity_download_count', true );
 			}
 		}
 
@@ -155,11 +197,16 @@ function handle_stats( $request ) {
 /**
  * Get per-post view counts from Jetpack Stats for a given time range.
  *
- * @param string $range One of '7d', '30d', '90d', 'all'.
- * @return array        Map of post_id (int) => view_count (int). Empty on failure.
+ * Uses get_total_post_views() to query specific post IDs directly, rather
+ * than get_top_posts() which only returns site-wide top posts and misses
+ * recently published kits with low overall traffic.
+ *
+ * @param string $range    One of '7d', '30d', '90d', 'all'.
+ * @param array  $kit_ids  Array of post IDs to query.
+ * @return array           Map of post_id (int) => view_count (int). Empty on failure.
  */
-function get_jetpack_post_views( $range ) {
-	if ( ! class_exists( '\Automattic\Jetpack\Stats\WPCOM_Stats' ) ) {
+function get_jetpack_post_views( $range, array $kit_ids ) {
+	if ( ! class_exists( '\Automattic\Jetpack\Stats\WPCOM_Stats' ) || empty( $kit_ids ) ) {
 		return array();
 	}
 
@@ -173,13 +220,12 @@ function get_jetpack_post_views( $range ) {
 		$num    = intval( str_replace( 'd', '', $range ) );
 	}
 
-	$result = $stats->get_top_posts(
+	$result = $stats->get_total_post_views(
 		array(
-			'period'    => $period,
-			'num'       => $num,
-			'date'      => gmdate( 'Y-m-d' ),
-			'summarize' => true,
-			'max'       => 1000,
+			'post_ids' => implode( ',', array_map( 'absint', $kit_ids ) ),
+			'period'   => $period,
+			'num'      => $num,
+			'date'     => gmdate( 'Y-m-d' ),
 		)
 	);
 
@@ -187,85 +233,15 @@ function get_jetpack_post_views( $range ) {
 		return array();
 	}
 
-	$post_views = isset( $result['summary']['postviews'] ) ? $result['summary']['postviews'] : array();
+	$post_views = isset( $result['posts'] ) ? $result['posts'] : array();
 	if ( ! is_array( $post_views ) ) {
 		return array();
 	}
 
 	$map = array();
 	foreach ( $post_views as $post_data ) {
-		if ( isset( $post_data['id'], $post_data['views'] ) ) {
-			$map[ (int) $post_data['id'] ] = (int) $post_data['views'];
-		}
-	}
-
-	return $map;
-}
-
-/**
- * Get per-kit download click counts from Jetpack Clicks report.
- *
- * @param string $range       One of '7d', '30d', '90d', 'all'.
- * @param array  $zip_url_map Map of zip_url (string) => array of post_ids (int[]).
- * @return array              Map of post_id (int) => click_count (int). Empty on failure.
- */
-function get_jetpack_download_clicks( $range, $zip_url_map ) {
-	if ( ! class_exists( '\Automattic\Jetpack\Stats\WPCOM_Stats' ) || empty( $zip_url_map ) ) {
-		return array();
-	}
-
-	$stats = new \Automattic\Jetpack\Stats\WPCOM_Stats();
-
-	if ( 'all' === $range ) {
-		$period = 'month';
-		$num    = 36;
-	} else {
-		$period = 'day';
-		$num    = intval( str_replace( 'd', '', $range ) );
-	}
-
-	$result = $stats->get_clicks(
-		array(
-			'period'    => $period,
-			'num'       => $num,
-			'date'      => gmdate( 'Y-m-d' ),
-			'summarize' => true,
-			'max'       => 1000,
-		)
-	);
-
-	if ( is_wp_error( $result ) || ! is_array( $result ) ) {
-		return array();
-	}
-
-	$clicks = isset( $result['summary']['clicks'] ) ? $result['summary']['clicks'] : array();
-	if ( ! is_array( $clicks ) ) {
-		return array();
-	}
-
-	// Jetpack groups clicks into a tree: a domain node carries a NULL url and
-	// the real per-URL clicks under `children`, while a lone click can appear
-	// as a flat leaf. Walk the tree and keep only leaves with a url + views.
-	$leaves = array();
-	$stack  = $clicks;
-	while ( $stack ) {
-		$node = array_pop( $stack );
-		if ( ! empty( $node['children'] ) && is_array( $node['children'] ) ) {
-			foreach ( $node['children'] as $child ) {
-				$stack[] = $child;
-			}
-		} elseif ( isset( $node['url'], $node['views'] ) ) {
-			$leaves[] = $node;
-		}
-	}
-
-	$map = array();
-	foreach ( $leaves as $leaf ) {
-		if ( ! isset( $zip_url_map[ $leaf['url'] ] ) ) {
-			continue;
-		}
-		foreach ( $zip_url_map[ $leaf['url'] ] as $post_id ) {
-			$map[ $post_id ] = ( isset( $map[ $post_id ] ) ? $map[ $post_id ] : 0 ) + (int) $leaf['views'];
+		if ( isset( $post_data['ID'], $post_data['views'] ) ) {
+			$map[ (int) $post_data['ID'] ] = (int) $post_data['views'];
 		}
 	}
 

--- a/wp-content/plugins/wporg-learn/inc/activity-kit-rest.php
+++ b/wp-content/plugins/wporg-learn/inc/activity-kit-rest.php
@@ -123,10 +123,16 @@ function handle_download( $request ) {
 	}
 
 	// Increment the download counter stored in post meta.
-	$current_count = (int) get_post_meta( $kit_post->ID, '_activity_download_count', true );
-	update_post_meta( $kit_post->ID, '_activity_download_count', $current_count + 1 );
+	// Use a compare-and-swap retry loop (update_post_meta's $prev_value arg) to avoid
+	// lost increments when two requests arrive simultaneously.
+	$retries = 0;
+	do {
+		$current_count = (int) get_post_meta( $kit_post->ID, '_activity_download_count', true );
+		$updated       = update_post_meta( $kit_post->ID, '_activity_download_count', $current_count + 1, $current_count );
+		$retries++;
+	} while ( ! $updated && $retries < 5 );
 
-	return new \WP_REST_Response( null, 302, array( 'Location' => $zip_url ) );
+	return new \WP_REST_Response( null, 302, array( 'Location' => esc_url_raw( $zip_url ) ) );
 }
 
 /**
@@ -175,17 +181,17 @@ function handle_stats( $request ) {
 			'updated' => get_the_modified_date( 'Y-m-d', $kit_post->ID ),
 		);
 
-		if ( $jetpack_unavailable ) {
-			$data['jetpack_unavailable'] = true;
-			$data['views']               = 0;
-			$data['downloads']           = 0;
-		} else {
-			if ( 'both' === $metric || 'views' === $metric ) {
+		// Views depend on Jetpack; downloads come from post meta regardless.
+		if ( 'both' === $metric || 'views' === $metric ) {
+			if ( $jetpack_unavailable ) {
+				$data['jetpack_unavailable'] = true;
+				$data['views']               = 0;
+			} else {
 				$data['views'] = $views_map[ $kit_post->ID ] ?? 0;
 			}
-			if ( 'both' === $metric || 'downloads' === $metric ) {
-				$data['downloads'] = (int) get_post_meta( $kit_post->ID, '_activity_download_count', true );
-			}
+		}
+		if ( 'both' === $metric || 'downloads' === $metric ) {
+			$data['downloads'] = (int) get_post_meta( $kit_post->ID, '_activity_download_count', true );
 		}
 
 		$results[] = $data;

--- a/wp-content/plugins/wporg-learn/inc/activity-kit-rest.php
+++ b/wp-content/plugins/wporg-learn/inc/activity-kit-rest.php
@@ -143,8 +143,10 @@ function handle_download( $request ) {
 				'_activity_download_count'
 			)
 		);
-		if ( ! $updated ) {
+		if ( 0 === $updated ) {
 			// No row yet — insert with an initial count of 1.
+			// $wpdb->query() returns false on DB error and 0 when no rows matched;
+			// strict comparison avoids falling into this branch on a real error.
 			add_post_meta( $kit_post->ID, '_activity_download_count', 1, true );
 		}
 		wp_cache_delete( $kit_post->ID, 'post_meta' );
@@ -184,7 +186,15 @@ function handle_stats( $request ) {
 
 	$jetpack_unavailable = ! class_exists( '\Automattic\Jetpack\Stats\WPCOM_Stats' );
 
-	$kit_ids   = wp_list_pluck( $kits, 'ID' );
+	// Narrow to only the requested kit when a slug filter is active, so that
+	// the Jetpack API is not queried for IDs whose data will never be returned.
+	$kit_ids = array();
+	foreach ( $kits as $kit_post ) {
+		if ( ! $kit || $kit_post->post_name === $kit ) {
+			$kit_ids[] = $kit_post->ID;
+		}
+	}
+
 	$views_map = array();
 
 	if ( ! $jetpack_unavailable && ( 'both' === $metric || 'views' === $metric ) ) {
@@ -255,9 +265,10 @@ function get_jetpack_post_views( $range, array $kit_ids ) {
 
 	/*
 	 * Map the UI range to one or more 30-day windows. Each window is defined by
-	 * how many days back its end-date is offset from today. The 'all' range is
-	 * capped at 90 days (3 × 30) — covering more would require an unreasonable
-	 * number of sequential API calls.
+	 * how many days back its end-date is offset from today. 'all' uses 6 windows
+	 * (≈ 6 months) rather than 3, giving a meaningful distinction from '90d'.
+	 * Extending further would multiply sequential API calls proportionally; 6 is
+	 * a reasonable ceiling for an admin-only dashboard with a small post count.
 	 */
 	switch ( $range ) {
 		case '7d':
@@ -275,8 +286,6 @@ function get_jetpack_post_views( $range, array $kit_ids ) {
 			);
 			break;
 		case '90d':
-		case 'all':
-		default:
 			$windows = array(
 				array(
 					'num' => 30, 'offset' => 0,
@@ -289,6 +298,40 @@ function get_jetpack_post_views( $range, array $kit_ids ) {
 				),
 			);
 			break;
+		case 'all':
+		default:
+			$windows = array(
+				array(
+					'num' => 30, 'offset' => 0,
+				),
+				array(
+					'num' => 30, 'offset' => 30,
+				),
+				array(
+					'num' => 30, 'offset' => 60,
+				),
+				array(
+					'num' => 30, 'offset' => 90,
+				),
+				array(
+					'num' => 30, 'offset' => 120,
+				),
+				array(
+					'num' => 30, 'offset' => 150,
+				),
+			);
+			break;
+	}
+
+	// Pre-compute window end-dates once so every chunk uses the same calendar
+	// day, even if a UTC midnight falls between chunk iterations.
+	$now           = time();
+	$dated_windows = array();
+	foreach ( $windows as $window ) {
+		$dated_windows[] = array(
+			'num'  => $window['num'],
+			'date' => gmdate( 'Y-m-d', $now - $window['offset'] * DAY_IN_SECONDS ),
+		);
 	}
 
 	$chunks = array_chunk( $kit_ids, 100 );
@@ -297,17 +340,22 @@ function get_jetpack_post_views( $range, array $kit_ids ) {
 	foreach ( $chunks as $chunk ) {
 		$post_ids_str = implode( ',', array_map( 'absint', $chunk ) );
 
-		foreach ( $windows as $window ) {
-			$date   = gmdate( 'Y-m-d', time() - $window['offset'] * DAY_IN_SECONDS );
+		foreach ( $dated_windows as $window ) {
 			$result = $stats->get_total_post_views(
 				array(
 					'post_ids' => $post_ids_str,
 					'num'      => $window['num'],
-					'date'     => $date,
+					'date'     => $window['date'],
 				)
 			);
 
-			if ( is_wp_error( $result ) || ! is_array( $result ) ) {
+			if ( is_wp_error( $result ) ) {
+				// Real API failure — return empty so the caller shows 0 for all
+				// kits (a visible failure signal) rather than a plausible-looking
+				// undercount that is harder to detect.
+				return array();
+			}
+			if ( ! is_array( $result ) ) {
 				continue;
 			}
 

--- a/wp-content/plugins/wporg-learn/inc/activity-kit-rest.php
+++ b/wp-content/plugins/wporg-learn/inc/activity-kit-rest.php
@@ -91,9 +91,10 @@ function stats_cache_expiration( $expiration ) {
 /**
  * Handle GET /activity-kits/v1/download/{id}
  *
- * Increments the kit's download counter (stored in post meta) and redirects
- * the browser to the actual ZIP file URL. Using a server-side redirect lets us
- * track same-domain downloads that Jetpack's outbound-click tracker misses.
+ * Increments the kit's download counter (stored in post meta) for requests that
+ * look like a person, and redirects the browser to the actual ZIP file URL.
+ * Using a server-side redirect lets us track same-domain downloads that
+ * Jetpack's outbound-click tracker misses.
  *
  * @param \WP_REST_Request $request The REST request.
  * @return \WP_REST_Response|\WP_Error 302 redirect on success, WP_Error on failure.
@@ -102,14 +103,12 @@ function handle_download( $request ) {
 	global $wpdb;
 
 	/*
-	 * Reject obvious crawler / link-unfurler User-Agents so that Slack previews,
-	 * email scanners, and browser prefetch rules do not increment the counter.
-	 * Empty User-Agent also suggests an automated tool rather than a real download.
+	 * Skip counting unfurlers, scanners and prefetches. Still redirect: the
+	 * heuristic has false positives, and those should cost an uncounted
+	 * download, not a failed one.
 	 */
 	$user_agent = sanitize_text_field( wp_unslash( isset( $_SERVER['HTTP_USER_AGENT'] ) ? $_SERVER['HTTP_USER_AGENT'] : '' ) );
-	if ( empty( $user_agent ) || preg_match( '/bot|crawl|slurp|spider|mediapartners|facebookexternalhit|linkedinbot|twitterbot|whatsapp|slack|discord|prefetch/i', $user_agent ) ) {
-		return new \WP_Error( 'activity_kit_bot', '', array( 'status' => 404 ) );
-	}
+	$is_bot     = empty( $user_agent ) || preg_match( '/bot|crawl|slurp|spider|mediapartners|facebookexternalhit|linkedinbot|twitterbot|whatsapp|slack|discord|prefetch/i', $user_agent );
 
 	$kit_id   = absint( $request->get_param( 'id' ) );
 	$kit_post = get_post( $kit_id );
@@ -130,28 +129,26 @@ function handle_download( $request ) {
 		return new \WP_Error( 'activity_kit_zip_url', __( 'Could not resolve the download URL.', 'wporg-learn' ), array( 'status' => 500 ) );
 	}
 
-	/*
-	 * Atomic increment via a direct UPDATE — avoids the read-then-write race where
-	 * two simultaneous downloads overwrite each other. update_post_meta()'s
-	 * $prev_value CAS skips the WHERE clause when $prev_value is 0 (so two
-	 * concurrent first-downloads both write 1), and a genuine CAS failure leaves
-	 * the object cache stale so retries keep issuing the same failing UPDATE.
-	 * A single UPDATE with no read is safe. The object cache is invalidated after
-	 * either path so subsequent get_post_meta() calls see the new value.
-	 */
-	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Atomic increment; cache invalidated immediately below.
-	$updated = $wpdb->query(
-		$wpdb->prepare(
-			"UPDATE {$wpdb->postmeta} SET meta_value = meta_value + 1 WHERE post_id = %d AND meta_key = %s",
-			$kit_post->ID,
-			'_activity_download_count'
-		)
-	);
-	if ( ! $updated ) {
-		// No row yet — insert with an initial count of 1.
-		add_post_meta( $kit_post->ID, '_activity_download_count', 1, true );
+	if ( ! $is_bot ) {
+		/*
+		 * Direct UPDATE, not update_post_meta(): its $prev_value CAS drops the WHERE
+		 * clause when the previous value is 0, so two concurrent first-downloads
+		 * would both write 1.
+		 */
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Atomic increment; cache invalidated immediately below.
+		$updated = $wpdb->query(
+			$wpdb->prepare(
+				"UPDATE {$wpdb->postmeta} SET meta_value = meta_value + 1 WHERE post_id = %d AND meta_key = %s",
+				$kit_post->ID,
+				'_activity_download_count'
+			)
+		);
+		if ( ! $updated ) {
+			// No row yet — insert with an initial count of 1.
+			add_post_meta( $kit_post->ID, '_activity_download_count', 1, true );
+		}
+		wp_cache_delete( $kit_post->ID, 'post_meta' );
 	}
-	wp_cache_delete( $kit_post->ID, 'post_meta' );
 
 	return new \WP_REST_Response(
 		null,

--- a/wp-content/plugins/wporg-learn/inc/activity-kit-rest.php
+++ b/wp-content/plugins/wporg-learn/inc/activity-kit-rest.php
@@ -91,8 +91,9 @@ function stats_cache_expiration( $expiration ) {
 /**
  * Handle GET /activity-kits/v1/download/{id}
  *
- * Increments the kit's download counter (stored in post meta) for requests that
- * look like a person, and redirects the browser to the actual ZIP file URL.
+ * Increments the kit's download counter (stored in one post meta row per UTC
+ * day) for requests that look like a person, and redirects the browser to the
+ * actual ZIP file URL.
  * Using a server-side redirect lets us track same-domain downloads that
  * Jetpack's outbound-click tracker misses.
  *
@@ -107,7 +108,7 @@ function handle_download( $request ) {
 	 * heuristic has false positives, and those should cost an uncounted
 	 * download, not a failed one.
 	 */
-	$user_agent = sanitize_text_field( wp_unslash( isset( $_SERVER['HTTP_USER_AGENT'] ) ? $_SERVER['HTTP_USER_AGENT'] : '' ) );
+	$user_agent = sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ?? '' ) );
 	$is_bot     = empty( $user_agent ) || preg_match( '/bot|crawl|slurp|spider|mediapartners|facebookexternalhit|linkedinbot|twitterbot|whatsapp|slack|discord|prefetch/i', $user_agent );
 
 	$kit_id   = absint( $request->get_param( 'id' ) );
@@ -131,36 +132,26 @@ function handle_download( $request ) {
 
 	if ( ! $is_bot ) {
 		/*
-		 * Direct UPDATE, not update_post_meta(): its $prev_value CAS drops the WHERE
-		 * clause when the previous value is 0, so two concurrent first-downloads
-		 * would both write 1.
+		 * Downloads are stored in one meta row per kit per UTC day so the stats
+		 * endpoint can sum them over the same day span as the Jetpack view
+		 * ranges (see get_download_counts()). Seed today's bucket ($unique=true
+		 * is a no-op once it exists), then increment with a direct UPDATE —
+		 * update_post_meta()'s $prev_value CAS drops its WHERE clause when the
+		 * previous value is 0, so two concurrent downloads would both write 1.
+		 * If two first-downloads of the day race the seed into duplicate rows,
+		 * every UPDATE increments both and reads take MAX per bucket, so no
+		 * download is lost.
 		 */
+		$meta_key = '_activity_downloads_' . gmdate( 'Ymd' );
+		add_post_meta( $kit_post->ID, $meta_key, 0, true );
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Atomic increment; cache invalidated immediately below.
-		$updated = $wpdb->query(
+		$wpdb->query(
 			$wpdb->prepare(
 				"UPDATE {$wpdb->postmeta} SET meta_value = meta_value + 1 WHERE post_id = %d AND meta_key = %s",
 				$kit_post->ID,
-				'_activity_download_count'
+				$meta_key
 			)
 		);
-		if ( 0 === $updated ) {
-			// No row yet (e.g. a kit published before the pre-seeding hook was
-			// added). Insert with an initial count of 1. If a concurrent
-			// first-download wins the INSERT race, add_post_meta() returns false
-			// ($unique=true blocks the duplicate); re-run the UPDATE so this
-			// download is still counted.
-			$inserted = add_post_meta( $kit_post->ID, '_activity_download_count', 1, true );
-			if ( ! $inserted ) {
-				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Atomic fallback after concurrent INSERT collision; cache invalidated immediately below.
-				$wpdb->query(
-					$wpdb->prepare(
-						"UPDATE {$wpdb->postmeta} SET meta_value = meta_value + 1 WHERE post_id = %d AND meta_key = %s",
-						$kit_post->ID,
-						'_activity_download_count'
-					)
-				);
-			}
-		}
 		wp_cache_delete( $kit_post->ID, 'post_meta' );
 	}
 
@@ -215,6 +206,12 @@ function handle_stats( $request ) {
 		remove_filter( 'jetpack_fetch_stats_cache_expiration', __NAMESPACE__ . '\stats_cache_expiration' );
 	}
 
+	$downloads_map = array();
+
+	if ( 'both' === $metric || 'downloads' === $metric ) {
+		$downloads_map = get_download_counts( $range, $kit_ids );
+	}
+
 	$results = array();
 
 	foreach ( $kits as $kit_post ) {
@@ -239,7 +236,7 @@ function handle_stats( $request ) {
 			}
 		}
 		if ( 'both' === $metric || 'downloads' === $metric ) {
-			$data['downloads'] = (int) get_post_meta( $kit_post->ID, '_activity_download_count', true );
+			$data['downloads'] = $downloads_map[ $kit_post->ID ] ?? 0;
 		}
 
 		$results[] = $data;
@@ -286,27 +283,32 @@ function get_jetpack_post_views( $range, array $kit_ids ) {
 		case '7d':
 			$windows = array(
 				array(
-					'num' => 7, 'offset' => 0,
+					'num'    => 7,
+					'offset' => 0,
 				),
 			);
 			break;
 		case '30d':
 			$windows = array(
 				array(
-					'num' => 30, 'offset' => 0,
+					'num'    => 30,
+					'offset' => 0,
 				),
 			);
 			break;
 		case '90d':
 			$windows = array(
 				array(
-					'num' => 30, 'offset' => 0,
+					'num'    => 30,
+					'offset' => 0,
 				),
 				array(
-					'num' => 30, 'offset' => 30,
+					'num'    => 30,
+					'offset' => 30,
 				),
 				array(
-					'num' => 30, 'offset' => 60,
+					'num'    => 30,
+					'offset' => 60,
 				),
 			);
 			break;
@@ -314,22 +316,28 @@ function get_jetpack_post_views( $range, array $kit_ids ) {
 		default:
 			$windows = array(
 				array(
-					'num' => 30, 'offset' => 0,
+					'num'    => 30,
+					'offset' => 0,
 				),
 				array(
-					'num' => 30, 'offset' => 30,
+					'num'    => 30,
+					'offset' => 30,
 				),
 				array(
-					'num' => 30, 'offset' => 60,
+					'num'    => 30,
+					'offset' => 60,
 				),
 				array(
-					'num' => 30, 'offset' => 90,
+					'num'    => 30,
+					'offset' => 90,
 				),
 				array(
-					'num' => 30, 'offset' => 120,
+					'num'    => 30,
+					'offset' => 120,
 				),
 				array(
-					'num' => 30, 'offset' => 150,
+					'num'    => 30,
+					'offset' => 150,
 				),
 			);
 			break;
@@ -361,19 +369,14 @@ function get_jetpack_post_views( $range, array $kit_ids ) {
 				)
 			);
 
-			if ( is_wp_error( $result ) ) {
-				// Real API failure — return empty so the caller shows 0 for all
-				// kits (a visible failure signal) rather than a plausible-looking
-				// undercount that is harder to detect.
+			// Any unusable response returns empty so all kits show 0 (a visible failure) rather than a plausible-looking undercount.
+			if ( is_wp_error( $result ) || ! is_array( $result ) ) {
 				return array();
-			}
-			if ( ! is_array( $result ) ) {
-				continue;
 			}
 
 			$post_views = isset( $result['posts'] ) ? $result['posts'] : array();
 			if ( ! is_array( $post_views ) ) {
-				continue;
+				return array();
 			}
 
 			foreach ( $post_views as $post_data ) {
@@ -384,6 +387,63 @@ function get_jetpack_post_views( $range, array $kit_ids ) {
 				}
 			}
 		}
+	}
+
+	return $map;
+}
+
+/**
+ * Get per-kit download counts from the daily download meta buckets.
+ *
+ * Downloads are stored as one meta row per kit per UTC day
+ * ('_activity_downloads_YYYYMMDD', see handle_download()), so they can be
+ * summed over the same day span as the Jetpack view windows and the download
+ * rate always divides two figures covering the identical period.
+ *
+ * MAX() per bucket (instead of SUM) makes duplicate rows from a concurrent
+ * first-download race harmless: the atomic UPDATE in handle_download()
+ * increments every duplicate equally, so each row holds the full count for
+ * its day.
+ *
+ * @param string $range   One of '7d', '30d', '90d', 'all'.
+ * @param int[]  $kit_ids Post IDs of the activity kits to fetch downloads for.
+ * @return array          Map of post_id (int) => download_count (int).
+ */
+function get_download_counts( $range, array $kit_ids ) {
+	global $wpdb;
+
+	if ( empty( $kit_ids ) ) {
+		return array();
+	}
+
+	// Day spans matching the view windows in get_jetpack_post_views().
+	$range_days = array(
+		'7d'  => 7,
+		'30d' => 30,
+		'90d' => 90,
+		'all' => 180,
+	);
+	$days       = isset( $range_days[ $range ] ) ? $range_days[ $range ] : 180;
+
+	$now       = time();
+	$first_key = '_activity_downloads_' . gmdate( 'Ymd', $now - ( $days - 1 ) * DAY_IN_SECONDS );
+	$last_key  = '_activity_downloads_' . gmdate( 'Ymd', $now );
+
+	$id_placeholders = implode( ',', array_fill( 0, count( $kit_ids ), '%d' ) );
+
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- The meta API has no ranged multi-key read.
+	$rows = $wpdb->get_results(
+		$wpdb->prepare(
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $id_placeholders is a list of %d placeholders built above from count().
+			"SELECT post_id, meta_key, MAX( CAST( meta_value AS UNSIGNED ) ) AS downloads FROM {$wpdb->postmeta} WHERE post_id IN ( {$id_placeholders} ) AND meta_key BETWEEN %s AND %s GROUP BY post_id, meta_key",
+			array_merge( $kit_ids, array( $first_key, $last_key ) )
+		)
+	);
+
+	$map = array();
+	foreach ( $rows as $row ) {
+		$id         = (int) $row->post_id;
+		$map[ $id ] = ( isset( $map[ $id ] ) ? $map[ $id ] : 0 ) + (int) $row->downloads;
 	}
 
 	return $map;

--- a/wp-content/plugins/wporg-learn/inc/post-meta.php
+++ b/wp-content/plugins/wporg-learn/inc/post-meta.php
@@ -1052,7 +1052,7 @@ function register_activity_kit_meta() {
 		'activity_kit',
 		'_activity_download_count',
 		array(
-			'description'       => __( 'Number of times this activity kit ZIP has been downloaded via the tracked download endpoint.', 'wporg-learn' ),
+			'description'       => 'Number of times this activity kit ZIP has been downloaded via the tracked download endpoint.',
 			'type'              => 'integer',
 			'single'            => true,
 			'default'           => 0,

--- a/wp-content/plugins/wporg-learn/inc/post-meta.php
+++ b/wp-content/plugins/wporg-learn/inc/post-meta.php
@@ -25,7 +25,6 @@ add_action( 'save_post_meeting', __NAMESPACE__ . '\save_meeting_metabox_fields' 
 add_action( 'admin_footer', __NAMESPACE__ . '\render_locales_list' );
 add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_editor_assets' );
 add_action( 'wp_insert_post', __NAMESPACE__ . '\set_default_lesson_preview', 10, 3 );
-add_action( 'publish_activity_kit', __NAMESPACE__ . '\initialize_activity_download_count' );
 
 /**
  * Register all post meta keys.
@@ -1079,36 +1078,4 @@ function register_activity_kit_meta() {
 			'auth_callback'     => $auth_callback,
 		)
 	);
-
-	register_post_meta(
-		'activity_kit',
-		'_activity_download_count',
-		array(
-			'description'       => 'Number of times this activity kit ZIP has been downloaded via the tracked download endpoint.',
-			'type'              => 'integer',
-			'single'            => true,
-			'default'           => 0,
-			'sanitize_callback' => 'absint',
-			'show_in_rest'      => false,
-			'auth_callback'     => $auth_callback,
-		)
-	);
-}
-
-/**
- * Pre-create the _activity_download_count meta row when a kit is first published.
- *
- * The handle_download() callback uses an atomic UPDATE (meta_value = meta_value + 1) to avoid
- * the lost-update race that update_post_meta()'s CAS pattern has. But UPDATE
- * requires the row to already exist — without it, two concurrent first-downloads
- * can both see 0 rows matched, both fall through to add_post_meta(), and both
- * INSERT, creating a duplicate meta row. Pre-creating the row at publish time
- * ensures every download hits the UPDATE path and the race never occurs.
- *
- * @param int $post_id ID of the newly-published activity kit.
- */
-function initialize_activity_download_count( $post_id ) {
-	// add_post_meta() with $unique=true is a no-op if the row already exists,
-	// so re-publishing or repeated saves cannot reset or duplicate the counter.
-	add_post_meta( $post_id, '_activity_download_count', 0, true );
 }

--- a/wp-content/plugins/wporg-learn/inc/post-meta.php
+++ b/wp-content/plugins/wporg-learn/inc/post-meta.php
@@ -25,6 +25,7 @@ add_action( 'save_post_meeting', __NAMESPACE__ . '\save_meeting_metabox_fields' 
 add_action( 'admin_footer', __NAMESPACE__ . '\render_locales_list' );
 add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_editor_assets' );
 add_action( 'wp_insert_post', __NAMESPACE__ . '\set_default_lesson_preview', 10, 3 );
+add_action( 'publish_activity_kit', __NAMESPACE__ . '\initialize_activity_download_count' );
 
 /**
  * Register all post meta keys.
@@ -1060,4 +1061,22 @@ function register_activity_kit_meta() {
 			'auth_callback'     => $auth_callback,
 		)
 	);
+}
+
+/**
+ * Pre-create the _activity_download_count meta row when a kit is first published.
+ *
+ * The handle_download() callback uses an atomic UPDATE (meta_value = meta_value + 1) to avoid
+ * the lost-update race that update_post_meta()'s CAS pattern has. But UPDATE
+ * requires the row to already exist — without it, two concurrent first-downloads
+ * can both see 0 rows matched, both fall through to add_post_meta(), and both
+ * INSERT, creating a duplicate meta row. Pre-creating the row at publish time
+ * ensures every download hits the UPDATE path and the race never occurs.
+ *
+ * @param int $post_id ID of the newly-published activity kit.
+ */
+function initialize_activity_download_count( $post_id ) {
+	// add_post_meta() with $unique=true is a no-op if the row already exists,
+	// so re-publishing or repeated saves cannot reset or duplicate the counter.
+	add_post_meta( $post_id, '_activity_download_count', 0, true );
 }

--- a/wp-content/plugins/wporg-learn/inc/post-meta.php
+++ b/wp-content/plugins/wporg-learn/inc/post-meta.php
@@ -1057,6 +1057,7 @@ function register_activity_kit_meta() {
 			'default'           => 0,
 			'sanitize_callback' => 'absint',
 			'show_in_rest'      => false,
+			'auth_callback'     => $auth_callback,
 		)
 	);
 }

--- a/wp-content/plugins/wporg-learn/inc/post-meta.php
+++ b/wp-content/plugins/wporg-learn/inc/post-meta.php
@@ -1046,4 +1046,17 @@ function register_activity_kit_meta() {
 			'auth_callback'     => $auth_callback,
 		)
 	);
+
+	register_post_meta(
+		'activity_kit',
+		'_activity_download_count',
+		array(
+			'description'       => __( 'Number of times this activity kit ZIP has been downloaded via the tracked download endpoint.', 'wporg-learn' ),
+			'type'              => 'integer',
+			'single'            => true,
+			'default'           => 0,
+			'sanitize_callback' => 'absint',
+			'show_in_rest'      => false,
+		)
+	);
 }

--- a/wp-content/plugins/wporg-learn/js/activity-kit-stats/index.js
+++ b/wp-content/plugins/wporg-learn/js/activity-kit-stats/index.js
@@ -123,7 +123,6 @@ if ( filterKit && tableBody && chartCanvas ) {
 		const isSingle = !! activeKit;
 		const totalV = data.reduce( ( sum, row ) => sum + ( row.views ?? 0 ), 0 );
 		const totalD = data.reduce( ( sum, row ) => sum + ( row.downloads ?? 0 ), 0 );
-		// Downloads and views both cover the selected range, so the rate is valid for every range.
 		const rate = totalV > 0 ? ( ( totalD / totalV ) * 100 ).toFixed( 1 ) + '%' : '—';
 
 		if ( summaryViews ) {

--- a/wp-content/plugins/wporg-learn/js/activity-kit-stats/index.js
+++ b/wp-content/plugins/wporg-learn/js/activity-kit-stats/index.js
@@ -54,6 +54,11 @@ if ( filterKit && tableBody && chartCanvas ) {
 		return ( num ?? 0 ).toLocaleString();
 	}
 
+	// Formats downloads/views as a percentage; '—' when there are no views to divide by.
+	function formatRate( views, downloads ) {
+		return views > 0 ? ( ( downloads / views ) * 100 ).toFixed( 1 ) + '%' : '—';
+	}
+
 	function formatDate( dateStr ) {
 		if ( ! dateStr ) {
 			return '—';
@@ -123,7 +128,7 @@ if ( filterKit && tableBody && chartCanvas ) {
 		const isSingle = !! activeKit;
 		const totalV = data.reduce( ( sum, row ) => sum + ( row.views ?? 0 ), 0 );
 		const totalD = data.reduce( ( sum, row ) => sum + ( row.downloads ?? 0 ), 0 );
-		const rate = totalV > 0 ? ( ( totalD / totalV ) * 100 ).toFixed( 1 ) + '%' : '—';
+		const rate = formatRate( totalV, totalD );
 
 		if ( summaryViews ) {
 			summaryViews.textContent = fmt( totalV );
@@ -299,7 +304,7 @@ if ( filterKit && tableBody && chartCanvas ) {
 		sorted.forEach( ( row ) => {
 			const views = row.views ?? 0;
 			const downloads = row.downloads ?? 0;
-			const rate = views > 0 ? ( ( downloads / views ) * 100 ).toFixed( 1 ) + '%' : '—';
+			const rate = formatRate( views, downloads );
 			const isSelected = row.slug === activeKit;
 			const tableRow = document.createElement( 'tr' );
 			if ( isSelected ) {
@@ -476,7 +481,7 @@ if ( filterKit && tableBody && chartCanvas ) {
 		data.forEach( ( row ) => {
 			const views = row.views ?? 0;
 			const downloads = row.downloads ?? 0;
-			const rate = views > 0 ? ( ( downloads / views ) * 100 ).toFixed( 1 ) + '%' : 'N/A';
+			const rate = formatRate( views, downloads );
 			rows.push( [ row.title, views, downloads, rate, row.updated || '' ] );
 		} );
 		const csv = rows.map( ( row ) => row.map( csvCell ).join( ',' ) ).join( '\n' );

--- a/wp-content/plugins/wporg-learn/js/activity-kit-stats/index.js
+++ b/wp-content/plugins/wporg-learn/js/activity-kit-stats/index.js
@@ -123,9 +123,8 @@ if ( filterKit && tableBody && chartCanvas ) {
 		const isSingle = !! activeKit;
 		const totalV = data.reduce( ( sum, row ) => sum + ( row.views ?? 0 ), 0 );
 		const totalD = data.reduce( ( sum, row ) => sum + ( row.downloads ?? 0 ), 0 );
-		// Downloads are an all-time cumulative counter; rate is only meaningful
-		// when views cover the same all-time window.
-		const rate = activeRange === 'all' && totalV > 0 ? ( ( totalD / totalV ) * 100 ).toFixed( 1 ) + '%' : '—';
+		// Downloads and views both cover the selected range, so the rate is valid for every range.
+		const rate = totalV > 0 ? ( ( totalD / totalV ) * 100 ).toFixed( 1 ) + '%' : '—';
 
 		if ( summaryViews ) {
 			summaryViews.textContent = fmt( totalV );
@@ -149,9 +148,8 @@ if ( filterKit && tableBody && chartCanvas ) {
 		if ( boxDownloads ) {
 			boxDownloads.style.display = activeMetric === 'views' ? 'none' : '';
 		}
-		// Rate is only valid when views cover the same window as the all-time download counter.
 		if ( boxRate ) {
-			boxRate.style.display = isSingle && activeRange === 'all' ? '' : 'none';
+			boxRate.style.display = isSingle ? '' : 'none';
 		}
 	}
 
@@ -302,8 +300,7 @@ if ( filterKit && tableBody && chartCanvas ) {
 		sorted.forEach( ( row ) => {
 			const views = row.views ?? 0;
 			const downloads = row.downloads ?? 0;
-			// Suppress rate when views are range-scoped but downloads are all-time.
-			const rate = activeRange === 'all' && views > 0 ? ( ( downloads / views ) * 100 ).toFixed( 1 ) + '%' : '—';
+			const rate = views > 0 ? ( ( downloads / views ) * 100 ).toFixed( 1 ) + '%' : '—';
 			const isSelected = row.slug === activeKit;
 			const tableRow = document.createElement( 'tr' );
 			if ( isSelected ) {
@@ -389,22 +386,6 @@ if ( filterKit && tableBody && chartCanvas ) {
 		}
 		if ( thDownloads ) {
 			thDownloads.classList.toggle( 'ak-hidden-col', activeMetric === 'views' );
-			// Label the column so admins know downloads are always all-time when a
-			// range-scoped view window is selected.
-			const arrow = thDownloads.querySelector( '.ak-sort-arrow' );
-			thDownloads.textContent = activeRange === 'all' ? 'Downloads' : 'Downloads (all time)';
-			if ( arrow ) {
-				thDownloads.appendChild( arrow );
-			}
-		}
-		// Mirror the same label on the summary box.
-		if ( summaryDownloads ) {
-			const dlLabel = summaryDownloads.closest( '.ak-summary-box' )
-				? summaryDownloads.closest( '.ak-summary-box' ).querySelector( '.ak-stat-label' )
-				: null;
-			if ( dlLabel ) {
-				dlLabel.textContent = activeRange === 'all' ? 'Total Downloads' : 'Total Downloads (all time)';
-			}
 		}
 
 		if ( backLinkBar ) {
@@ -492,15 +473,11 @@ if ( filterKit && tableBody && chartCanvas ) {
 
 	function exportCSV() {
 		const data = activeKit ? allData.filter( ( row ) => row.slug === activeKit ) : allData;
-		// Downloads column header clarifies scope when views are range-filtered.
-		const dlHeader = activeRange === 'all' ? 'Downloads' : 'Downloads (all time)';
-		const rows = [ [ 'Kit Name', 'Views', dlHeader, 'Download Rate', 'Last Updated' ] ];
+		const rows = [ [ 'Kit Name', 'Views', 'Downloads', 'Download Rate', 'Last Updated' ] ];
 		data.forEach( ( row ) => {
 			const views = row.views ?? 0;
 			const downloads = row.downloads ?? 0;
-			// Rate is only meaningful when views and downloads cover the same window.
-			const rate =
-				activeRange === 'all' && views > 0 ? ( ( downloads / views ) * 100 ).toFixed( 1 ) + '%' : 'N/A';
+			const rate = views > 0 ? ( ( downloads / views ) * 100 ).toFixed( 1 ) + '%' : 'N/A';
 			rows.push( [ row.title, views, downloads, rate, row.updated || '' ] );
 		} );
 		const csv = rows.map( ( row ) => row.map( csvCell ).join( ',' ) ).join( '\n' );

--- a/wp-content/plugins/wporg-learn/js/activity-kit-stats/index.js
+++ b/wp-content/plugins/wporg-learn/js/activity-kit-stats/index.js
@@ -121,20 +121,11 @@ if ( filterKit && tableBody && chartCanvas ) {
 	// ── Summary ──
 	function updateSummary( data ) {
 		const isSingle = !! activeKit;
-		const totalV = data.reduce(
-			( sum, row ) => sum + ( row.views ?? 0 ),
-			0
-		);
-		const totalD = data.reduce(
-			( sum, row ) => sum + ( row.downloads ?? 0 ),
-			0
-		);
+		const totalV = data.reduce( ( sum, row ) => sum + ( row.views ?? 0 ), 0 );
+		const totalD = data.reduce( ( sum, row ) => sum + ( row.downloads ?? 0 ), 0 );
 		// Downloads are an all-time cumulative counter; rate is only meaningful
 		// when views cover the same all-time window.
-		const rate =
-			activeRange === 'all' && totalV > 0
-				? ( ( totalD / totalV ) * 100 ).toFixed( 1 ) + '%'
-				: '—';
+		const rate = activeRange === 'all' && totalV > 0 ? ( ( totalD / totalV ) * 100 ).toFixed( 1 ) + '%' : '—';
 
 		if ( summaryViews ) {
 			summaryViews.textContent = fmt( totalV );
@@ -160,8 +151,7 @@ if ( filterKit && tableBody && chartCanvas ) {
 		}
 		// Rate is only valid when views cover the same window as the all-time download counter.
 		if ( boxRate ) {
-			boxRate.style.display =
-				isSingle && activeRange === 'all' ? '' : 'none';
+			boxRate.style.display = isSingle && activeRange === 'all' ? '' : 'none';
 		}
 	}
 
@@ -179,10 +169,7 @@ if ( filterKit && tableBody && chartCanvas ) {
 					tooltip: {
 						callbacks: {
 							label: ( context ) =>
-								' ' +
-								context.dataset.label +
-								': ' +
-								context.parsed.y.toLocaleString(),
+								' ' + context.dataset.label + ': ' + context.parsed.y.toLocaleString(),
 						},
 					},
 				},
@@ -216,9 +203,7 @@ if ( filterKit && tableBody && chartCanvas ) {
 
 		const total = data.length;
 		const paged = total > CHART_PAGE;
-		const sliced = paged
-			? data.slice( chartOffset, chartOffset + CHART_PAGE )
-			: data;
+		const sliced = paged ? data.slice( chartOffset, chartOffset + CHART_PAGE ) : data;
 
 		// Slider visibility and state.
 		if ( chartSliderWrap ) {
@@ -231,13 +216,10 @@ if ( filterKit && tableBody && chartCanvas ) {
 		}
 		if ( paged && chartSliderLabel ) {
 			const end = Math.min( chartOffset + CHART_PAGE, total );
-			chartSliderLabel.textContent =
-				chartOffset + 1 + '–' + end + ' of ' + total;
+			chartSliderLabel.textContent = chartOffset + 1 + '–' + end + ' of ' + total;
 		}
 
-		const labels = sliced.map( ( row ) =>
-			row.title.length > 20 ? row.title.slice( 0, 18 ) + '…' : row.title
-		);
+		const labels = sliced.map( ( row ) => ( row.title.length > 20 ? row.title.slice( 0, 18 ) + '…' : row.title ) );
 		const datasets = [];
 
 		if ( activeMetric !== 'downloads' ) {
@@ -303,10 +285,7 @@ if ( filterKit && tableBody && chartCanvas ) {
 			} else if ( sortCol === 'downloads' ) {
 				valueA = a.downloads ?? 0;
 			} else {
-				valueA =
-					( a.views ?? 0 ) > 0
-						? ( a.downloads ?? 0 ) / ( a.views ?? 0 )
-						: 0;
+				valueA = ( a.views ?? 0 ) > 0 ? ( a.downloads ?? 0 ) / ( a.views ?? 0 ) : 0;
 			}
 			let valueB;
 			if ( sortCol === 'views' ) {
@@ -314,10 +293,7 @@ if ( filterKit && tableBody && chartCanvas ) {
 			} else if ( sortCol === 'downloads' ) {
 				valueB = b.downloads ?? 0;
 			} else {
-				valueB =
-					( b.views ?? 0 ) > 0
-						? ( b.downloads ?? 0 ) / ( b.views ?? 0 )
-						: 0;
+				valueB = ( b.views ?? 0 ) > 0 ? ( b.downloads ?? 0 ) / ( b.views ?? 0 ) : 0;
 			}
 			return sortDir === 'asc' ? valueA - valueB : valueB - valueA;
 		} );
@@ -327,22 +303,15 @@ if ( filterKit && tableBody && chartCanvas ) {
 			const views = row.views ?? 0;
 			const downloads = row.downloads ?? 0;
 			// Suppress rate when views are range-scoped but downloads are all-time.
-			const rate =
-				activeRange === 'all' && views > 0
-					? ( ( downloads / views ) * 100 ).toFixed( 1 ) + '%'
-					: '—';
+			const rate = activeRange === 'all' && views > 0 ? ( ( downloads / views ) * 100 ).toFixed( 1 ) + '%' : '—';
 			const isSelected = row.slug === activeKit;
 			const tableRow = document.createElement( 'tr' );
 			if ( isSelected ) {
 				tableRow.classList.add( 'is-selected' );
 			}
 
-			const viewsClass =
-				'ak-col-number' +
-				( activeMetric === 'downloads' ? ' ak-hidden-col' : '' );
-			const dlClass =
-				'ak-col-number' +
-				( activeMetric === 'views' ? ' ak-hidden-col' : '' );
+			const viewsClass = 'ak-col-number' + ( activeMetric === 'downloads' ? ' ak-hidden-col' : '' );
+			const dlClass = 'ak-col-number' + ( activeMetric === 'views' ? ' ak-hidden-col' : '' );
 
 			const tdTitle = document.createElement( 'td' );
 			const link = document.createElement( 'a' );
@@ -381,64 +350,49 @@ if ( filterKit && tableBody && chartCanvas ) {
 		} );
 
 		// Update sort arrows.
-		document
-			.querySelectorAll( '#ak-stats-table thead th' )
-			.forEach( ( tableHeader ) => {
-				const col = tableHeader.dataset.col;
-				const arrow = tableHeader.querySelector( '.ak-sort-arrow' );
-				tableHeader.classList.remove( 'is-sorted' );
-				if ( arrow ) {
-					arrow.textContent = '';
-				}
-				if ( col === sortCol && arrow ) {
-					tableHeader.classList.add( 'is-sorted' );
-					arrow.textContent = sortDir === 'asc' ? ' ↑' : ' ↓';
-				}
-			} );
+		document.querySelectorAll( '#ak-stats-table thead th' ).forEach( ( tableHeader ) => {
+			const col = tableHeader.dataset.col;
+			const arrow = tableHeader.querySelector( '.ak-sort-arrow' );
+			tableHeader.classList.remove( 'is-sorted' );
+			if ( arrow ) {
+				arrow.textContent = '';
+			}
+			if ( col === sortCol && arrow ) {
+				tableHeader.classList.add( 'is-sorted' );
+				arrow.textContent = sortDir === 'asc' ? ' ↑' : ' ↓';
+			}
+		} );
 	}
 
 	// ── UI state ──
 	function updateUI() {
 		const isSingle = !! activeKit;
-		const kitObj = isSingle
-			? allData.find( ( row ) => row.slug === activeKit )
-			: null;
+		const kitObj = isSingle ? allData.find( ( row ) => row.slug === activeKit ) : null;
 
 		if ( chartTitle ) {
 			chartTitle.textContent =
-				metricLabel[ activeMetric ] +
-				' — ' +
-				( isSingle && kitObj ? kitObj.title : 'All Kits' );
+				metricLabel[ activeMetric ] + ' — ' + ( isSingle && kitObj ? kitObj.title : 'All Kits' );
 		}
 		if ( chartSubtitle ) {
 			chartSubtitle.textContent = rangeLabel();
 		}
 
 		if ( legendViews ) {
-			legendViews.style.display =
-				activeMetric === 'downloads' ? 'none' : '';
+			legendViews.style.display = activeMetric === 'downloads' ? 'none' : '';
 		}
 		if ( legendDownloads ) {
-			legendDownloads.style.display =
-				activeMetric === 'views' ? 'none' : '';
+			legendDownloads.style.display = activeMetric === 'views' ? 'none' : '';
 		}
 
 		if ( thViews ) {
-			thViews.classList.toggle(
-				'ak-hidden-col',
-				activeMetric === 'downloads'
-			);
+			thViews.classList.toggle( 'ak-hidden-col', activeMetric === 'downloads' );
 		}
 		if ( thDownloads ) {
-			thDownloads.classList.toggle(
-				'ak-hidden-col',
-				activeMetric === 'views'
-			);
+			thDownloads.classList.toggle( 'ak-hidden-col', activeMetric === 'views' );
 			// Label the column so admins know downloads are always all-time when a
 			// range-scoped view window is selected.
 			const arrow = thDownloads.querySelector( '.ak-sort-arrow' );
-			thDownloads.textContent =
-				activeRange === 'all' ? 'Downloads' : 'Downloads (all time)';
+			thDownloads.textContent = activeRange === 'all' ? 'Downloads' : 'Downloads (all time)';
 			if ( arrow ) {
 				thDownloads.appendChild( arrow );
 			}
@@ -446,15 +400,10 @@ if ( filterKit && tableBody && chartCanvas ) {
 		// Mirror the same label on the summary box.
 		if ( summaryDownloads ) {
 			const dlLabel = summaryDownloads.closest( '.ak-summary-box' )
-				? summaryDownloads
-						.closest( '.ak-summary-box' )
-						.querySelector( '.ak-stat-label' )
+				? summaryDownloads.closest( '.ak-summary-box' ).querySelector( '.ak-stat-label' )
 				: null;
 			if ( dlLabel ) {
-				dlLabel.textContent =
-					activeRange === 'all'
-						? 'Total Downloads'
-						: 'Total Downloads (all time)';
+				dlLabel.textContent = activeRange === 'all' ? 'Total Downloads' : 'Total Downloads (all time)';
 			}
 		}
 
@@ -469,9 +418,7 @@ if ( filterKit && tableBody && chartCanvas ) {
 		}
 
 		if ( tableSubtitle ) {
-			tableSubtitle.textContent = isSingle
-				? 'Showing single kit'
-				: "Click a row to see a single kit's stats";
+			tableSubtitle.textContent = isSingle ? 'Showing single kit' : "Click a row to see a single kit's stats";
 		}
 	}
 
@@ -490,32 +437,21 @@ if ( filterKit && tableBody && chartCanvas ) {
 
 		try {
 			allData = await fetchStats();
-			const data = activeKit
-				? allData.filter( ( row ) => row.slug === activeKit )
-				: allData;
+			const data = activeKit ? allData.filter( ( row ) => row.slug === activeKit ) : allData;
 			updateSummary( data );
 			updateUI();
 			renderChart( data );
 			renderTable( data );
 		} catch ( error ) {
-			tableBody.replaceChildren(
-				msgRow( 'Error loading stats: ' + error.message )
-			);
+			tableBody.replaceChildren( msgRow( 'Error loading stats: ' + error.message ) );
 		}
 	}
 
 	// ── Setters ──
 	function setMetric( metric ) {
 		activeMetric = metric;
-		metricBtns.forEach( ( button ) =>
-			button.classList.toggle(
-				'is-active',
-				button.dataset.akMetric === metric
-			)
-		);
-		const data = activeKit
-			? allData.filter( ( row ) => row.slug === activeKit )
-			: allData;
+		metricBtns.forEach( ( button ) => button.classList.toggle( 'is-active', button.dataset.akMetric === metric ) );
+		const data = activeKit ? allData.filter( ( row ) => row.slug === activeKit ) : allData;
 		updateSummary( data );
 		updateUI();
 		renderChart( data );
@@ -524,12 +460,7 @@ if ( filterKit && tableBody && chartCanvas ) {
 
 	function setRange( range ) {
 		activeRange = range;
-		rangeBtns.forEach( ( button ) =>
-			button.classList.toggle(
-				'is-active',
-				button.dataset.akRange === range
-			)
-		);
+		rangeBtns.forEach( ( button ) => button.classList.toggle( 'is-active', button.dataset.akRange === range ) );
 		render();
 	}
 
@@ -560,34 +491,19 @@ if ( filterKit && tableBody && chartCanvas ) {
 	}
 
 	function exportCSV() {
-		const data = activeKit
-			? allData.filter( ( row ) => row.slug === activeKit )
-			: allData;
+		const data = activeKit ? allData.filter( ( row ) => row.slug === activeKit ) : allData;
 		// Downloads column header clarifies scope when views are range-filtered.
-		const dlHeader =
-			activeRange === 'all' ? 'Downloads' : 'Downloads (all time)';
-		const rows = [
-			[ 'Kit Name', 'Views', dlHeader, 'Download Rate', 'Last Updated' ],
-		];
+		const dlHeader = activeRange === 'all' ? 'Downloads' : 'Downloads (all time)';
+		const rows = [ [ 'Kit Name', 'Views', dlHeader, 'Download Rate', 'Last Updated' ] ];
 		data.forEach( ( row ) => {
 			const views = row.views ?? 0;
 			const downloads = row.downloads ?? 0;
 			// Rate is only meaningful when views and downloads cover the same window.
 			const rate =
-				activeRange === 'all' && views > 0
-					? ( ( downloads / views ) * 100 ).toFixed( 1 ) + '%'
-					: 'N/A';
-			rows.push( [
-				row.title,
-				views,
-				downloads,
-				rate,
-				row.updated || '',
-			] );
+				activeRange === 'all' && views > 0 ? ( ( downloads / views ) * 100 ).toFixed( 1 ) + '%' : 'N/A';
+			rows.push( [ row.title, views, downloads, rate, row.updated || '' ] );
 		} );
-		const csv = rows
-			.map( ( row ) => row.map( csvCell ).join( ',' ) )
-			.join( '\n' );
+		const csv = rows.map( ( row ) => row.map( csvCell ).join( ',' ) ).join( '\n' );
 		const blob = new Blob( [ csv ], { type: 'text/csv' } );
 		const url = URL.createObjectURL( blob );
 		const a = document.createElement( 'a' );
@@ -599,9 +515,7 @@ if ( filterKit && tableBody && chartCanvas ) {
 
 	// ── Event listeners ──
 	metricBtns.forEach( ( btn ) => {
-		btn.addEventListener( 'click', () =>
-			setMetric( btn.dataset.akMetric )
-		);
+		btn.addEventListener( 'click', () => setMetric( btn.dataset.akMetric ) );
 	} );
 
 	rangeBtns.forEach( ( btn ) => {
@@ -617,9 +531,7 @@ if ( filterKit && tableBody && chartCanvas ) {
 	if ( chartSlider ) {
 		chartSlider.addEventListener( 'input', () => {
 			chartOffset = parseInt( chartSlider.value, 10 );
-			const data = activeKit
-				? allData.filter( ( row ) => row.slug === activeKit )
-				: allData;
+			const data = activeKit ? allData.filter( ( row ) => row.slug === activeKit ) : allData;
 			renderChart( data );
 		} );
 	}
@@ -646,27 +558,22 @@ if ( filterKit && tableBody && chartCanvas ) {
 	}
 
 	// Sortable column headers.
-	document
-		.querySelectorAll( '#ak-stats-table thead th' )
-		.forEach( ( tableHeader ) => {
-			tableHeader.addEventListener( 'click', () => {
-				const col = tableHeader.dataset.col;
-				if ( ! col ) {
-					return;
-				}
-				if ( sortCol === col ) {
-					sortDir = sortDir === 'asc' ? 'desc' : 'asc';
-				} else {
-					sortCol = col;
-					sortDir =
-						tableHeader.dataset.type === 'number' ? 'desc' : 'asc';
-				}
-				const data = activeKit
-					? allData.filter( ( row ) => row.slug === activeKit )
-					: allData;
-				renderTable( data );
-			} );
+	document.querySelectorAll( '#ak-stats-table thead th' ).forEach( ( tableHeader ) => {
+		tableHeader.addEventListener( 'click', () => {
+			const col = tableHeader.dataset.col;
+			if ( ! col ) {
+				return;
+			}
+			if ( sortCol === col ) {
+				sortDir = sortDir === 'asc' ? 'desc' : 'asc';
+			} else {
+				sortCol = col;
+				sortDir = tableHeader.dataset.type === 'number' ? 'desc' : 'asc';
+			}
+			const data = activeKit ? allData.filter( ( row ) => row.slug === activeKit ) : allData;
+			renderTable( data );
 		} );
+	} );
 
 	// ── Init ──
 	initChart();

--- a/wp-content/plugins/wporg-learn/js/activity-kit-stats/index.js
+++ b/wp-content/plugins/wporg-learn/js/activity-kit-stats/index.js
@@ -122,7 +122,7 @@ if ( filterKit && tableBody && chartCanvas ) {
 		const totalD = data.reduce( ( sum, row ) => sum + ( row.downloads ?? 0 ), 0 );
 		// Downloads are an all-time cumulative counter; rate is only meaningful
 		// when views cover the same all-time window.
-		const rate = ( activeRange === 'all' && totalV > 0 ) ? ( ( totalD / totalV ) * 100 ).toFixed( 1 ) + '%' : '—';
+		const rate = activeRange === 'all' && totalV > 0 ? ( ( totalD / totalV ) * 100 ).toFixed( 1 ) + '%' : '—';
 
 		if ( summaryViews ) {
 			summaryViews.textContent = fmt( totalV );
@@ -148,7 +148,7 @@ if ( filterKit && tableBody && chartCanvas ) {
 		}
 		// Rate is only valid when views cover the same window as the all-time download counter.
 		if ( boxRate ) {
-			boxRate.style.display = ( isSingle && activeRange === 'all' ) ? '' : 'none';
+			boxRate.style.display = isSingle && activeRange === 'all' ? '' : 'none';
 		}
 	}
 
@@ -300,7 +300,7 @@ if ( filterKit && tableBody && chartCanvas ) {
 			const views = row.views ?? 0;
 			const downloads = row.downloads ?? 0;
 			// Suppress rate when views are range-scoped but downloads are all-time.
-			const rate = ( activeRange === 'all' && views > 0 ) ? ( ( downloads / views ) * 100 ).toFixed( 1 ) + '%' : '—';
+			const rate = activeRange === 'all' && views > 0 ? ( ( downloads / views ) * 100 ).toFixed( 1 ) + '%' : '—';
 			const isSelected = row.slug === activeKit;
 			const tableRow = document.createElement( 'tr' );
 			if ( isSelected ) {
@@ -496,7 +496,8 @@ if ( filterKit && tableBody && chartCanvas ) {
 			const views = row.views ?? 0;
 			const downloads = row.downloads ?? 0;
 			// Rate is only meaningful when views and downloads cover the same window.
-			const rate = ( activeRange === 'all' && views > 0 ) ? ( ( downloads / views ) * 100 ).toFixed( 1 ) + '%' : 'N/A';
+			const rate =
+				activeRange === 'all' && views > 0 ? ( ( downloads / views ) * 100 ).toFixed( 1 ) + '%' : 'N/A';
 			rows.push( [ row.title, views, downloads, rate, row.updated || '' ] );
 		} );
 		const csv = rows.map( ( row ) => row.map( csvCell ).join( ',' ) ).join( '\n' );

--- a/wp-content/plugins/wporg-learn/js/activity-kit-stats/index.js
+++ b/wp-content/plugins/wporg-learn/js/activity-kit-stats/index.js
@@ -71,9 +71,11 @@ if ( filterKit && tableBody && chartCanvas ) {
 			'7d': 'Last 7 days',
 			'30d': 'Last 30 days',
 			'90d': 'Last 90 days',
-			all: 'All time',
+			// 'All time' is capped at 90 days by the WPCOM /stats/views/posts API
+			// (30-day max per call; see get_jetpack_post_views() in activity-kit-rest.php).
+			all: 'All time (max 90 days)',
 		};
-		return labels[ activeRange ] || 'All time';
+		return labels[ activeRange ] || 'All time (max 90 days)';
 	}
 
 	const metricLabel = {
@@ -118,7 +120,9 @@ if ( filterKit && tableBody && chartCanvas ) {
 		const isSingle = !! activeKit;
 		const totalV = data.reduce( ( sum, row ) => sum + ( row.views ?? 0 ), 0 );
 		const totalD = data.reduce( ( sum, row ) => sum + ( row.downloads ?? 0 ), 0 );
-		const rate = totalV > 0 ? ( ( totalD / totalV ) * 100 ).toFixed( 1 ) + '%' : '—';
+		// Downloads are an all-time cumulative counter; rate is only meaningful
+		// when views cover the same all-time window.
+		const rate = ( activeRange === 'all' && totalV > 0 ) ? ( ( totalD / totalV ) * 100 ).toFixed( 1 ) + '%' : '—';
 
 		if ( summaryViews ) {
 			summaryViews.textContent = fmt( totalV );
@@ -142,8 +146,9 @@ if ( filterKit && tableBody && chartCanvas ) {
 		if ( boxDownloads ) {
 			boxDownloads.style.display = activeMetric === 'views' ? 'none' : '';
 		}
+		// Rate is only valid when views cover the same window as the all-time download counter.
 		if ( boxRate ) {
-			boxRate.style.display = isSingle ? '' : 'none';
+			boxRate.style.display = ( isSingle && activeRange === 'all' ) ? '' : 'none';
 		}
 	}
 
@@ -294,7 +299,8 @@ if ( filterKit && tableBody && chartCanvas ) {
 		sorted.forEach( ( row ) => {
 			const views = row.views ?? 0;
 			const downloads = row.downloads ?? 0;
-			const rate = views > 0 ? ( ( downloads / views ) * 100 ).toFixed( 1 ) + '%' : '—';
+			// Suppress rate when views are range-scoped but downloads are all-time.
+			const rate = ( activeRange === 'all' && views > 0 ) ? ( ( downloads / views ) * 100 ).toFixed( 1 ) + '%' : '—';
 			const isSelected = row.slug === activeKit;
 			const tableRow = document.createElement( 'tr' );
 			if ( isSelected ) {
@@ -380,6 +386,22 @@ if ( filterKit && tableBody && chartCanvas ) {
 		}
 		if ( thDownloads ) {
 			thDownloads.classList.toggle( 'ak-hidden-col', activeMetric === 'views' );
+			// Label the column so admins know downloads are always all-time when a
+			// range-scoped view window is selected.
+			const arrow = thDownloads.querySelector( '.ak-sort-arrow' );
+			thDownloads.textContent = activeRange === 'all' ? 'Downloads' : 'Downloads (all time)';
+			if ( arrow ) {
+				thDownloads.appendChild( arrow );
+			}
+		}
+		// Mirror the same label on the summary box.
+		if ( summaryDownloads ) {
+			const dlLabel = summaryDownloads.closest( '.ak-summary-box' )
+				? summaryDownloads.closest( '.ak-summary-box' ).querySelector( '.ak-stat-label' )
+				: null;
+			if ( dlLabel ) {
+				dlLabel.textContent = activeRange === 'all' ? 'Total Downloads' : 'Total Downloads (all time)';
+			}
 		}
 
 		if ( backLinkBar ) {
@@ -467,11 +489,14 @@ if ( filterKit && tableBody && chartCanvas ) {
 
 	function exportCSV() {
 		const data = activeKit ? allData.filter( ( row ) => row.slug === activeKit ) : allData;
-		const rows = [ [ 'Kit Name', 'Views', 'Downloads', 'Download Rate', 'Last Updated' ] ];
+		// Downloads column header clarifies scope when views are range-filtered.
+		const dlHeader = activeRange === 'all' ? 'Downloads' : 'Downloads (all time)';
+		const rows = [ [ 'Kit Name', 'Views', dlHeader, 'Download Rate', 'Last Updated' ] ];
 		data.forEach( ( row ) => {
 			const views = row.views ?? 0;
 			const downloads = row.downloads ?? 0;
-			const rate = views > 0 ? ( ( downloads / views ) * 100 ).toFixed( 1 ) + '%' : '0%';
+			// Rate is only meaningful when views and downloads cover the same window.
+			const rate = ( activeRange === 'all' && views > 0 ) ? ( ( downloads / views ) * 100 ).toFixed( 1 ) + '%' : 'N/A';
 			rows.push( [ row.title, views, downloads, rate, row.updated || '' ] );
 		} );
 		const csv = rows.map( ( row ) => row.map( csvCell ).join( ',' ) ).join( '\n' );

--- a/wp-content/plugins/wporg-learn/views/block-activity-kit-card.php
+++ b/wp-content/plugins/wporg-learn/views/block-activity-kit-card.php
@@ -25,7 +25,7 @@ $zip_id   = (int) get_post_meta( $kit_post_id, '_activity_zip_id', true );
 $zip_url  = $zip_id ? wp_get_attachment_url( $zip_id ) : '';
 
 // Route through the counting endpoint so card downloads are tracked too.
-$download_url = $zip_url ? rest_url( 'activity-kits/v1/download/' . $kit_post_id ) : '';
+$download_url = $zip_url ? \WPOrg_Learn\Activity_Kit_REST\get_download_url( $kit_post_id ) : '';
 
 $level_terms = wp_get_post_terms( $kit_post_id, 'level', array( 'fields' => 'names' ) );
 $level_name  = ! is_wp_error( $level_terms ) && ! empty( $level_terms ) ? $level_terms[0] : '';

--- a/wp-content/plugins/wporg-learn/views/block-activity-kit-card.php
+++ b/wp-content/plugins/wporg-learn/views/block-activity-kit-card.php
@@ -24,6 +24,9 @@ $duration = get_post_meta( $kit_post_id, '_activity_duration', true );
 $zip_id   = (int) get_post_meta( $kit_post_id, '_activity_zip_id', true );
 $zip_url  = $zip_id ? wp_get_attachment_url( $zip_id ) : '';
 
+// Route through the counting endpoint so card downloads are tracked too.
+$download_url = $zip_url ? rest_url( 'activity-kits/v1/download/' . $kit_post_id ) : '';
+
 $level_terms = wp_get_post_terms( $kit_post_id, 'level', array( 'fields' => 'names' ) );
 $level_name  = ! is_wp_error( $level_terms ) && ! empty( $level_terms ) ? $level_terms[0] : '';
 
@@ -86,11 +89,9 @@ if ( has_post_thumbnail( $kit_post_id ) ) {
 				href="<?php echo esc_url( $permalink ); ?>">
 				<?php esc_html_e( 'View', 'wporg-learn' ); ?>
 			</a>
-			<?php if ( $zip_url ) : ?>
+			<?php if ( $download_url ) : ?>
 				<a class="wporg-activity-kit-card__download-btn button button-primary"
-					href="<?php echo esc_url( $zip_url ); ?>"
-					data-post-id="<?php echo absint( $kit_post_id ); ?>"
-					data-track-download="1">
+					href="<?php echo esc_url( $download_url ); ?>">
 					<?php esc_html_e( 'Download ↓', 'wporg-learn' ); ?>
 				</a>
 			<?php endif; ?>

--- a/wp-content/themes/pub/wporg-learn-2024/inc/block-hooks.php
+++ b/wp-content/themes/pub/wporg-learn-2024/inc/block-hooks.php
@@ -203,6 +203,9 @@ function replace_card_with_activity_kit_card( $block_content, $parsed_block ) {
 	$zip_id      = (int) get_post_meta( $kit_post_id, '_activity_zip_id', true );
 	$zip_url     = $zip_id ? wp_get_attachment_url( $zip_id ) : '';
 
+	// Route through the counting endpoint so card downloads are tracked too.
+	$download_url = $zip_url ? rest_url( 'activity-kits/v1/download/' . $kit_post_id ) : '';
+
 	$level_terms = wp_get_post_terms( $kit_post_id, 'level', array( 'fields' => 'names' ) );
 	$level_name  = ! is_wp_error( $level_terms ) && ! empty( $level_terms ) ? $level_terms[0] : '';
 
@@ -267,11 +270,9 @@ function replace_card_with_activity_kit_card( $block_content, $parsed_block ) {
 					href="<?php echo esc_url( $permalink ); ?>">
 					<?php esc_html_e( 'View', 'wporg-learn' ); ?>
 				</a>
-				<?php if ( $zip_url ) : ?>
+				<?php if ( $download_url ) : ?>
 					<a class="wporg-activity-kit-card__download-btn"
-						href="<?php echo esc_url( $zip_url ); ?>"
-						data-post-id="<?php echo absint( $kit_post_id ); ?>"
-						data-track-download="1">
+						href="<?php echo esc_url( $download_url ); ?>">
 						<?php esc_html_e( 'Download ↓', 'wporg-learn' ); ?>
 					</a>
 				<?php endif; ?>

--- a/wp-content/themes/pub/wporg-learn-2024/inc/block-hooks.php
+++ b/wp-content/themes/pub/wporg-learn-2024/inc/block-hooks.php
@@ -204,7 +204,7 @@ function replace_card_with_activity_kit_card( $block_content, $parsed_block ) {
 	$zip_url     = $zip_id ? wp_get_attachment_url( $zip_id ) : '';
 
 	// Route through the counting endpoint so card downloads are tracked too.
-	$download_url = $zip_url ? rest_url( 'activity-kits/v1/download/' . $kit_post_id ) : '';
+	$download_url = $zip_url ? \WPOrg_Learn\Activity_Kit_REST\get_download_url( $kit_post_id ) : '';
 
 	$level_terms = wp_get_post_terms( $kit_post_id, 'level', array( 'fields' => 'names' ) );
 	$level_name  = ! is_wp_error( $level_terms ) && ! empty( $level_terms ) ? $level_terms[0] : '';

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/single-activity-kit-content.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/single-activity-kit-content.php
@@ -7,10 +7,12 @@
  * @package WPOrg_Learn
  */
 
-$kit_id   = get_the_ID();
-$duration = get_post_meta( $kit_id, '_activity_duration', true );
-$zip_id   = (int) get_post_meta( $kit_id, '_activity_zip_id', true );
-$zip_url  = $zip_id ? wp_get_attachment_url( $zip_id ) : '';
+$kit_id       = get_the_ID();
+$duration     = get_post_meta( $kit_id, '_activity_duration', true );
+$zip_id       = (int) get_post_meta( $kit_id, '_activity_zip_id', true );
+$zip_url      = $zip_id ? wp_get_attachment_url( $zip_id ) : '';
+// Use the server-side download endpoint so every click increments the post meta counter.
+$download_url = $zip_id ? rest_url( 'activity-kits/v1/download/' . get_post_field( 'post_name', $kit_id ) ) : '';
 
 $guide_pdf_id  = (int) get_post_meta( $kit_id, '_activity_guide_pdf_id', true );
 $slides_pdf_id = (int) get_post_meta( $kit_id, '_activity_slides_pdf_id', true );
@@ -100,11 +102,9 @@ $icon_desk_lg  = '<svg width="20" height="20" viewBox="-2 -2 24 24" fill="curren
 		<?php echo $icon_back; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Static SVG markup. ?>
 		<?php esc_html_e( 'Back to Activity Library', 'wporg-learn' ); ?>
 	</a>
-	<?php if ( $zip_url ) : ?>
+	<?php if ( $download_url ) : ?>
 		<a class="wporg-activity-kit-action-row__download wp-block-button__link"
-			href="<?php echo esc_url( $zip_url ); ?>"
-			data-post-id="<?php echo absint( $kit_id ); ?>"
-			data-track-download="1">
+			href="<?php echo esc_url( $download_url ); ?>">
 			<?php echo $icon_download; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Static SVG markup. ?>
 			<?php esc_html_e( 'Download kit', 'wporg-learn' ); ?>
 		</a>
@@ -306,22 +306,13 @@ if ( $feedback_url ) :
 </div>
 <?php endif; ?>
 
-<?php
-$wpcom_blog_id = '';
-if ( class_exists( '\Jetpack_Options' ) ) {
-	$wpcom_blog_id = (string) \Jetpack_Options::get_option( 'id', '' );
-}
-?>
-
 <!-- Download this kit -->
-<?php if ( $zip_url ) : ?>
+<?php if ( $download_url ) : ?>
 <div class="wporg-activity-kit-download-box">
 	<h2><?php esc_html_e( 'Download this kit', 'wporg-learn' ); ?></h2>
 	<p><?php echo esc_html( $download_desc ); ?></p>
 	<a class="wporg-activity-kit-download-box__btn"
-		href="<?php echo esc_url( $zip_url ); ?>"
-		data-post-id="<?php echo absint( $kit_id ); ?>"
-		data-track-download="1">
+		href="<?php echo esc_url( $download_url ); ?>">
 		<?php echo $icon_download; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Static SVG markup. ?>
 		<?php esc_html_e( 'Download kit', 'wporg-learn' ); ?>
 	</a>
@@ -333,24 +324,4 @@ if ( class_exists( '\Jetpack_Options' ) ) {
 		<?php endif; ?>
 	</p>
 </div>
-
-<script>
-( function () {
-	var blogId = '<?php echo esc_js( $wpcom_blog_id ); ?>';
-	if ( ! blogId || ! window._stq ) {
-		return;
-	}
-	document.querySelectorAll( '[data-track-download="1"]' ).forEach( function ( btn ) {
-		btn.addEventListener( 'click', function () {
-			window._stq.push( [ 'click', {
-				s: '2',
-				u: btn.href,
-				r: '0',
-				b: blogId,
-				p: btn.dataset.postId || '0',
-			} ] );
-		} );
-	} );
-} )();
-</script>
 <?php endif; ?>

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/single-activity-kit-content.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/single-activity-kit-content.php
@@ -11,7 +11,7 @@ $kit_id       = get_the_ID();
 $duration     = get_post_meta( $kit_id, '_activity_duration', true );
 $zip_id       = (int) get_post_meta( $kit_id, '_activity_zip_id', true );
 // Link at the counting endpoint, not the file; route on ID since slugs may not URL-encode cleanly.
-$download_url = ( $zip_id && wp_get_attachment_url( $zip_id ) ) ? rest_url( 'activity-kits/v1/download/' . $kit_id ) : '';
+$download_url = ( $zip_id && wp_get_attachment_url( $zip_id ) ) ? \WPOrg_Learn\Activity_Kit_REST\get_download_url( $kit_id ) : '';
 
 $guide_pdf_id  = (int) get_post_meta( $kit_id, '_activity_guide_pdf_id', true );
 $slides_pdf_id = (int) get_post_meta( $kit_id, '_activity_slides_pdf_id', true );

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/single-activity-kit-content.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/single-activity-kit-content.php
@@ -10,9 +10,8 @@
 $kit_id       = get_the_ID();
 $duration     = get_post_meta( $kit_id, '_activity_duration', true );
 $zip_id       = (int) get_post_meta( $kit_id, '_activity_zip_id', true );
-// Use the server-side download endpoint so every click increments the post meta counter.
-// Route on post ID (integer) to avoid slug-encoding issues with non-ASCII and underscore slugs.
-$download_url = $zip_id ? rest_url( 'activity-kits/v1/download/' . $kit_id ) : '';
+// Link at the counting endpoint, not the file; route on ID since slugs may not URL-encode cleanly.
+$download_url = ( $zip_id && wp_get_attachment_url( $zip_id ) ) ? rest_url( 'activity-kits/v1/download/' . $kit_id ) : '';
 
 $guide_pdf_id  = (int) get_post_meta( $kit_id, '_activity_guide_pdf_id', true );
 $slides_pdf_id = (int) get_post_meta( $kit_id, '_activity_slides_pdf_id', true );

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/single-activity-kit-content.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/single-activity-kit-content.php
@@ -11,7 +11,8 @@ $kit_id       = get_the_ID();
 $duration     = get_post_meta( $kit_id, '_activity_duration', true );
 $zip_id       = (int) get_post_meta( $kit_id, '_activity_zip_id', true );
 // Use the server-side download endpoint so every click increments the post meta counter.
-$download_url = $zip_id ? rest_url( 'activity-kits/v1/download/' . get_post_field( 'post_name', $kit_id ) ) : '';
+// Route on post ID (integer) to avoid slug-encoding issues with non-ASCII and underscore slugs.
+$download_url = $zip_id ? rest_url( 'activity-kits/v1/download/' . $kit_id ) : '';
 
 $guide_pdf_id  = (int) get_post_meta( $kit_id, '_activity_guide_pdf_id', true );
 $slides_pdf_id = (int) get_post_meta( $kit_id, '_activity_slides_pdf_id', true );

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/single-activity-kit-content.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/single-activity-kit-content.php
@@ -10,7 +10,6 @@
 $kit_id       = get_the_ID();
 $duration     = get_post_meta( $kit_id, '_activity_duration', true );
 $zip_id       = (int) get_post_meta( $kit_id, '_activity_zip_id', true );
-$zip_url      = $zip_id ? wp_get_attachment_url( $zip_id ) : '';
 // Use the server-side download endpoint so every click increments the post meta counter.
 $download_url = $zip_id ? rest_url( 'activity-kits/v1/download/' . get_post_field( 'post_name', $kit_id ) ) : '';
 


### PR DESCRIPTION
## Problem

`get_clicks()` in Jetpack Stats only tracks **outbound** (external-domain) clicks. Since the activity kit ZIP files are hosted on `learn.wordpress.org` (same domain), they are never captured — download counts always showed 0.

## Solution

Replace the Jetpack click approach with a thin REST redirect endpoint that increments a post meta counter before forwarding the browser to the actual file.

```
GET /wp-json/activity-kits/v1/download/{slug}
→ 302 Location: https://learn.wordpress.org/.../activity-kit.zip
```

This works regardless of file host domain, requires no JS, and persists across page loads.

## Changes

### `inc/activity-kit-rest.php`
- **New route** `GET activity-kits/v1/download/{slug}` (public, no auth required)
  - Resolves the kit by slug, fetches the ZIP attachment URL
  - Increments `_activity_download_count` post meta
  - Returns `WP_REST_Response( null, 302, [ 'Location' => $zip_url ] )`
- **Fix view stats** — switch from `get_top_posts()` to `get_total_post_views()` so recently published kits with low traffic aren't omitted from results (same fix as #3591, included here since this branch is off trunk)
- **Remove** `get_jetpack_download_clicks()` — now dead code
- **Stats endpoint** reads downloads from `_activity_download_count` post meta directly, removing the Jetpack clicks dependency entirely

### `inc/post-meta.php`
- Register `_activity_download_count` meta (integer, default 0, `show_in_rest => false` — admin-read-only via REST stats endpoint)

### `patterns/single-activity-kit-content.php`
- Both download buttons now point at the `/download/{slug}` endpoint
- Removed the `window._stq` JS tracking block — it was tracking clicks to internal REST URLs (meaningless), and server-side counting replaces it entirely

## Testing

1. Load any published activity kit page
2. Click **Download kit** — you should be redirected to the ZIP file
3. Visit the [Stats page](https://learn.wordpress.org/wp-admin/edit.php?post_type=activity_kit&page=activity-kit-stats) — the download count for that kit should increment

> 🤖 Written with [Claude Code](https://claude.ai/claude-code)