### PR TITLE
Theme: Update Activity Library page description to mention guide and slides

### DIFF
--- a/wp-content/themes/pub/wporg-learn-2024/patterns/archive-activity-kits-content.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/archive-activity-kits-content.php
@@ -15,7 +15,7 @@
 	<!-- /wp:heading -->
 
 	<!-- wp:paragraph -->
-	<p><?php esc_html_e( 'Download ready-to-use WordPress activity kits designed for educators, meetup organizers, and community facilitators. Each kit includes everything you need to run a hands-on WordPress learning session.', 'wporg-learn' ); ?></p>
+	<p><?php esc_html_e( 'Download ready-to-use WordPress activity kits designed for educators, meetup organizers, and community facilitators. Each kit includes a facilitation guide and presentation slides, everything you need to run a hands-on WordPress learning session.', 'wporg-learn' ); ?></p>
 	<!-- /wp:paragraph -->
 
 </div>


### PR DESCRIPTION
## Description

Updates the introductory paragraph on the Activity Library page to explicitly call out what each kit contains.

### Before
> Each kit includes everything you need to run a hands-on WordPress learning session.

### After
> Each kit includes a facilitation guide and presentation slides, everything you need to run a hands-on WordPress learning session.

### File changed
`wp-content/themes/pub/wporg-learn-2024/patterns/archive-activity-kits-content.php`

🤖 Generated with [Claude Code](https://claude.com/claude-code)