### PR TITLE
Activity Kit Stats: unique downloaders, download rate fix, last downloaded/viewed columns

### DIFF
--- a/wp-content/plugins/wporg-learn/inc/activity-kit-downloads-db.php
+++ b/wp-content/plugins/wporg-learn/inc/activity-kit-downloads-db.php
@@ -1,0 +1,213 @@
+<?php
+/**
+ * Unique-downloader tracking for activity kits.
+ *
+ * Jetpack Stats has no per-post unique-visitor data (only site-wide aggregates), and a
+ * per-page-view tracking table isn't viable here — a similar "record on every page load"
+ * endpoint was previously rejected for this project on infra/caching grounds, not privacy
+ * grounds. Downloads are a different story: they're already tracked server-side, on every
+ * download (a comparatively rare event), via the daily postmeta buckets in
+ * activity-kit-rest.php. This file adds one more fact to that same low-frequency write: a
+ * de-duplicated (kit, visitor, day) record, so a distinct-downloader count can be read back
+ * without needing per-post visitor data from Jetpack.
+ *
+ * @package WPOrg_Learn
+ */
+
+namespace WPOrg_Learn\Activity_Kit_Downloads_DB;
+
+defined( 'WPINC' ) || die();
+
+const DB_VERSION        = '1.0';
+const DB_VERSION_OPTION = 'activity_kit_downloads_db_version';
+const SECRET_OPTION     = 'activity_kit_downloads_secret';
+
+/**
+ * Actions and filters.
+ */
+add_action( 'init', __NAMESPACE__ . '\maybe_upgrade_schema' );
+
+/**
+ * Get the unique-downloads table's full name, including the site's table prefix.
+ *
+ * @return string
+ */
+function get_table_name() {
+	global $wpdb;
+	return "{$wpdb->prefix}activity_kit_downloads";
+}
+
+/**
+ * Create or upgrade the unique-downloads table, if the stored schema version is behind.
+ *
+ * Hooked to init (not admin_init) so the table exists before the very first public,
+ * unauthenticated download request tries to write to it — on a fresh install, an
+ * admin_init-only hook would leave a real front-end visitor's download silently
+ * uncounted (no error, just a write against a table that doesn't exist yet) if they
+ * arrive before any admin has ever loaded a wp-admin page.
+ *
+ * Calling dbDelta() itself is cheap to skip (only the get_option() check runs on every
+ * request — already covered by the same alloptions cache WordPress loads regardless),
+ * but the CREATE/ALTER it would run on a real change is not, hence the version gate. On
+ * WordPress.org's own infrastructure this may need the table provisioned separately
+ * rather than relying on dbDelta() in production — see the PR description.
+ */
+function maybe_upgrade_schema() {
+	if ( get_option( DB_VERSION_OPTION ) === DB_VERSION ) {
+		return;
+	}
+
+	global $wpdb;
+
+	require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+
+	$table_name      = get_table_name();
+	$charset_collate = $wpdb->get_charset_collate();
+
+	/*
+	 * kit_id, day, visitor_hash (not visitor-first) so the unique index's leading
+	 * columns also serve the "WHERE kit_id IN (...) AND day BETWEEN ..." read query
+	 * in get_unique_downloader_counts(), not just the write-side de-duplication.
+	 */
+	$sql = "CREATE TABLE {$table_name} (
+		id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+		kit_id BIGINT UNSIGNED NOT NULL,
+		visitor_hash CHAR(64) NOT NULL,
+		day DATE NOT NULL,
+		PRIMARY KEY (id),
+		UNIQUE KEY kit_day_visitor (kit_id, day, visitor_hash),
+		KEY day (day)
+	) {$charset_collate};";
+
+	dbDelta( $sql );
+
+	update_option( DB_VERSION_OPTION, DB_VERSION );
+}
+
+/**
+ * Get the site's secret for hashing visitor identifiers, generating one on first use.
+ *
+ * Never exposed outside this file. Not autoloaded, since it's read only when a
+ * download happens, not on every page load.
+ *
+ * @return string
+ */
+function get_site_secret() {
+	$secret = get_option( SECRET_OPTION );
+
+	if ( ! $secret ) {
+		$secret = wp_generate_password( 64, true, true );
+		add_option( SECRET_OPTION, $secret, '', false );
+	}
+
+	return $secret;
+}
+
+/**
+ * Get a salt scoped to one UTC day.
+ *
+ * This is an HMAC of the day string, not a value stored and rotated on a schedule —
+ * there's nothing to fail to rotate. Because HMAC is a pseudorandom function, knowing
+ * one day's salt reveals nothing about any other day's salt without also knowing the
+ * site secret, which never leaves this function. That's what makes visitor hashes
+ * un-correlatable across two different days: the same visitor downloading the same kit
+ * on two different days gets two unrelated hashes, so no persistent per-visitor
+ * identifier is ever stored or derivable.
+ *
+ * @param string|null $day Date in 'Ymd' format. Defaults to today (UTC).
+ * @return string
+ */
+function get_daily_salt( $day = null ) {
+	$day = $day ?? gmdate( 'Ymd' );
+	return hash_hmac( 'sha256', $day, get_site_secret() );
+}
+
+/**
+ * Get a one-way hash identifying a visitor for one kit on one day.
+ *
+ * No raw IP address is ever stored — only this hash. Combined with the daily salt,
+ * the same visitor produces an unrelated hash on a different day (see get_daily_salt()).
+ *
+ * @param int         $kit_id     Post ID of the activity kit.
+ * @param string      $ip         Visitor's IP address.
+ * @param string      $user_agent Visitor's User-Agent string.
+ * @param string|null $day        Date in 'Ymd' format. Defaults to today (UTC).
+ * @return string
+ */
+function get_visitor_hash( $kit_id, $ip, $user_agent, $day = null ) {
+	return hash( 'sha256', get_daily_salt( $day ) . '|' . $ip . '|' . $user_agent . '|' . $kit_id );
+}
+
+/**
+ * Record one download for a (kit, visitor, day) combination.
+ *
+ * A no-op if this exact combination was already recorded today, by design — this is
+ * what makes the count that reads it back a distinct-downloader count rather than a
+ * raw download count (that's still tracked separately, unchanged, via the daily
+ * postmeta buckets in activity-kit-rest.php).
+ *
+ * @param int    $kit_id     Post ID of the activity kit.
+ * @param string $ip         Visitor's IP address.
+ * @param string $user_agent Visitor's User-Agent string.
+ */
+function record_download( $kit_id, $ip, $user_agent ) {
+	global $wpdb;
+
+	$visitor_hash = get_visitor_hash( $kit_id, $ip, $user_agent );
+	$table_name   = get_table_name();
+
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- No wpdb API for INSERT IGNORE; a duplicate is an expected, harmless no-op.
+	$result = $wpdb->query(
+		$wpdb->prepare(
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $table_name is built from $wpdb->prefix, not user input.
+			"INSERT IGNORE INTO {$table_name} ( kit_id, visitor_hash, day ) VALUES ( %d, %s, %s )",
+			$kit_id,
+			$visitor_hash,
+			gmdate( 'Y-m-d' )
+		)
+	);
+
+	// A missing table (e.g. schema not yet created on this environment) fails the
+	// query silently otherwise — surface it so a broken deploy is visible somewhere.
+	if ( false === $result && $wpdb->last_error ) {
+		error_log( 'wporg-learn: activity kit download tracking failed: ' . $wpdb->last_error ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Best-effort visibility for a silent write failure; no logging framework exists in this plugin to use instead.
+	}
+}
+
+/**
+ * Get per-kit unique-downloader counts for a given time range.
+ *
+ * @param string $range   One of '7d', '30d', '90d', 'all'.
+ * @param int[]  $kit_ids Post IDs of the activity kits to fetch counts for.
+ * @return array          Map of post_id (int) => unique_downloader_count (int).
+ */
+function get_unique_downloader_counts( $range, array $kit_ids ) {
+	global $wpdb;
+
+	if ( empty( $kit_ids ) ) {
+		return array();
+	}
+
+	$bounds     = \WPOrg_Learn\Activity_Kit_REST\get_range_timestamps( $range );
+	$first_day  = gmdate( 'Y-m-d', $bounds['first'] );
+	$last_day   = gmdate( 'Y-m-d', $bounds['last'] );
+	$table_name = get_table_name();
+
+	$id_placeholders = implode( ',', array_fill( 0, count( $kit_ids ), '%d' ) );
+
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- No wpdb API for COUNT(DISTINCT ...) over a custom table.
+	$rows = $wpdb->get_results(
+		$wpdb->prepare(
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $id_placeholders is a list of %d placeholders built above from count().
+			"SELECT kit_id, COUNT( DISTINCT visitor_hash ) AS unique_downloaders FROM {$table_name} WHERE kit_id IN ( {$id_placeholders} ) AND day BETWEEN %s AND %s GROUP BY kit_id",
+			array_merge( $kit_ids, array( $first_day, $last_day ) )
+		)
+	);
+
+	$map = array();
+	foreach ( $rows as $row ) {
+		$map[ (int) $row->kit_id ] = (int) $row->unique_downloaders;
+	}
+
+	return $map;
+}

--- a/wp-content/plugins/wporg-learn/inc/activity-kit-downloads-db.php
+++ b/wp-content/plugins/wporg-learn/inc/activity-kit-downloads-db.php
@@ -81,7 +81,17 @@ function maybe_upgrade_schema() {
 
 	dbDelta( $sql );
 
-	update_option( DB_VERSION_OPTION, DB_VERSION );
+	/*
+	 * Only record the upgrade as done once the table is confirmed to exist — dbDelta()
+	 * doesn't reliably signal failure, and marking the version as current after a failed
+	 * CREATE (a permissions issue, a syntax problem introduced by a future edit, etc.)
+	 * would stop every later request from retrying, leaving download tracking silently
+	 * and permanently broken on that environment.
+	 */
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- One-off existence check right after a schema change; not a data query.
+	if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) ) === $table_name ) {
+		update_option( DB_VERSION_OPTION, DB_VERSION );
+	}
 }
 
 /**
@@ -96,8 +106,18 @@ function get_site_secret() {
 	$secret = get_option( SECRET_OPTION );
 
 	if ( ! $secret ) {
-		$secret = wp_generate_password( 64, true, true );
-		add_option( SECRET_OPTION, $secret, '', false );
+		$generated = wp_generate_password( 64, true, true );
+
+		/*
+		 * add_option() is a no-op if another concurrent request already won this race
+		 * and inserted the option first — re-read rather than trusting $generated, so
+		 * every request ends up hashing against the one secret that actually persisted.
+		 */
+		if ( add_option( SECRET_OPTION, $generated, '', false ) ) {
+			$secret = $generated;
+		} else {
+			$secret = get_option( SECRET_OPTION );
+		}
 	}
 
 	return $secret;

--- a/wp-content/plugins/wporg-learn/inc/activity-kit-rest.php
+++ b/wp-content/plugins/wporg-learn/inc/activity-kit-rest.php
@@ -482,7 +482,12 @@ function get_last_downloaded_date( $kit_id ) {
 		return null;
 	}
 
-	return gmdate( 'Y-m-d', strtotime( $timestamp ) );
+	/*
+	 * $timestamp is stored as GMT (current_time( 'mysql', true )) but carries no timezone
+	 * of its own — strtotime() would otherwise interpret it in PHP's default timezone,
+	 * which can shift the resulting day near midnight. The explicit +0000 forces UTC.
+	 */
+	return gmdate( 'Y-m-d', strtotime( $timestamp . ' +0000' ) );
 }
 
 /**

--- a/wp-content/plugins/wporg-learn/inc/activity-kit-rest.php
+++ b/wp-content/plugins/wporg-learn/inc/activity-kit-rest.php
@@ -101,9 +101,11 @@ function stats_cache_expiration( $expiration ) {
 /**
  * Handle GET /activity-kits/v1/download/{id}
  *
- * Increments the kit's download counter (stored in one post meta row per UTC
- * day) for requests that look like a person, and redirects the browser to the
- * actual ZIP file URL.
+ * For requests that look like a person: increments the kit's download counter
+ * (stored in one post meta row per UTC day), records a de-duplicated
+ * (kit, visitor, day) row for the unique-downloader count (see
+ * activity-kit-downloads-db.php), and updates the kit's last-downloaded
+ * timestamp. Then redirects the browser to the actual ZIP file URL.
  * Using a server-side redirect lets us track same-domain downloads that
  * Jetpack's outbound-click tracker misses.
  *
@@ -161,6 +163,21 @@ function handle_download( $request ) {
 			)
 		);
 		wp_cache_delete( $kit_post->ID, 'post_meta' );
+
+		/*
+		 * REMOTE_ADDR is used as-is, with no X-Forwarded-For/CF-Connecting-IP fallback.
+		 * If WordPress.org's edge doesn't already rewrite REMOTE_ADDR to the real client
+		 * IP for this site, every visitor would share one IP here, and uniqueness would
+		 * collapse to distinguishing visitors by User-Agent alone — undercounting
+		 * unique_downloaders. This is only used for an anonymized analytics hash (never
+		 * stored or trusted for access control), so a forwarded-header fallback would be
+		 * safe to add against spoofing, but blindly trusting an unvalidated header without
+		 * confirming this site's actual proxy setup first could make counting worse, not
+		 * better. Confirm with WordPress.org infra before changing this.
+		 */
+		$ip = sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ?? '' ) );
+		\WPOrg_Learn\Activity_Kit_Downloads_DB\record_download( $kit_post->ID, $ip, $user_agent );
+		update_post_meta( $kit_post->ID, '_activity_last_downloaded', current_time( 'mysql', true ) );
 	}
 
 	return new \WP_REST_Response(
@@ -206,18 +223,29 @@ function handle_stats( $request ) {
 		}
 	}
 
-	$views_map = array();
+	/*
+	 * Last-viewed is approximated from Jetpack's own per-post view history, so it shares
+	 * $views_map's Jetpack-availability guard, not just the metric filter.
+	 */
+	$should_fetch_views = ! $jetpack_unavailable && ( 'both' === $metric || 'views' === $metric );
 
-	if ( ! $jetpack_unavailable && ( 'both' === $metric || 'views' === $metric ) ) {
+	$views_map       = array();
+	$last_viewed_map = array();
+
+	if ( $should_fetch_views ) {
 		add_filter( 'jetpack_fetch_stats_cache_expiration', __NAMESPACE__ . '\stats_cache_expiration' );
 		$views_map = get_jetpack_post_views( $range, $kit_ids );
 		remove_filter( 'jetpack_fetch_stats_cache_expiration', __NAMESPACE__ . '\stats_cache_expiration' );
+
+		$last_viewed_map = get_last_viewed_dates( $kit_ids );
 	}
 
-	$downloads_map = array();
+	$downloads_map          = array();
+	$unique_downloaders_map = array();
 
 	if ( 'both' === $metric || 'downloads' === $metric ) {
-		$downloads_map = get_download_counts( $range, $kit_ids );
+		$downloads_map          = get_download_counts( $range, $kit_ids );
+		$unique_downloaders_map = \WPOrg_Learn\Activity_Kit_Downloads_DB\get_unique_downloader_counts( $range, $kit_ids );
 	}
 
 	$results = array();
@@ -234,17 +262,20 @@ function handle_stats( $request ) {
 			'updated' => get_the_modified_date( 'Y-m-d', $kit_post->ID ),
 		);
 
-		// Views depend on Jetpack; downloads come from post meta regardless.
+		// Views depend on Jetpack; downloads come from post meta/the downloads table regardless.
 		if ( 'both' === $metric || 'views' === $metric ) {
 			if ( $jetpack_unavailable ) {
 				$data['jetpack_unavailable'] = true;
 				$data['views']               = 0;
 			} else {
-				$data['views'] = $views_map[ $kit_post->ID ] ?? 0;
+				$data['views']       = $views_map[ $kit_post->ID ] ?? 0;
+				$data['last_viewed'] = $last_viewed_map[ $kit_post->ID ] ?? null;
 			}
 		}
 		if ( 'both' === $metric || 'downloads' === $metric ) {
-			$data['downloads'] = $downloads_map[ $kit_post->ID ] ?? 0;
+			$data['downloads']          = $downloads_map[ $kit_post->ID ] ?? 0;
+			$data['unique_downloaders'] = $unique_downloaders_map[ $kit_post->ID ] ?? 0;
+			$data['last_downloaded']    = get_last_downloaded_date( $kit_post->ID );
 		}
 
 		$results[] = $data;
@@ -273,6 +304,27 @@ function get_range_days( $range ) {
 		default:
 			return 180;
 	}
+}
+
+/**
+ * Get the Unix timestamp boundaries a stats range covers.
+ *
+ * Shared by get_download_counts() and Activity_Kit_Downloads_DB\get_unique_downloader_counts()
+ * (each formats these into whatever date/meta-key string shape it needs) so the two
+ * counts — and any other range-scoped query added later — can't silently drift onto
+ * different day spans if this boundary math ever changes.
+ *
+ * @param string $range One of '7d', '30d', '90d', 'all'.
+ * @return array{first: int, last: int} Unix timestamps for the first and last day.
+ */
+function get_range_timestamps( $range ) {
+	$days = get_range_days( $range );
+	$now  = time();
+
+	return array(
+		'first' => $now - ( $days - 1 ) * DAY_IN_SECONDS,
+		'last'  => $now,
+	);
 }
 
 /**
@@ -389,10 +441,9 @@ function get_download_counts( $range, array $kit_ids ) {
 		return array();
 	}
 
-	$days      = get_range_days( $range );
-	$now       = time();
-	$first_key = '_activity_downloads_' . gmdate( 'Ymd', $now - ( $days - 1 ) * DAY_IN_SECONDS );
-	$last_key  = '_activity_downloads_' . gmdate( 'Ymd', $now );
+	$bounds    = get_range_timestamps( $range );
+	$first_key = '_activity_downloads_' . gmdate( 'Ymd', $bounds['first'] );
+	$last_key  = '_activity_downloads_' . gmdate( 'Ymd', $bounds['last'] );
 
 	$id_placeholders = implode( ',', array_fill( 0, count( $kit_ids ), '%d' ) );
 
@@ -412,4 +463,114 @@ function get_download_counts( $range, array $kit_ids ) {
 	}
 
 	return $map;
+}
+
+/**
+ * Get a kit's last-downloaded date, if it has ever been downloaded.
+ *
+ * Not range-scoped, same as get_the_modified_date() for the 'updated' field — this
+ * reflects the kit's real download history regardless of which time range the
+ * dashboard happens to be filtered to.
+ *
+ * @param int $kit_id Post ID of the activity kit.
+ * @return string|null 'Y-m-d', or null if the kit has never been downloaded.
+ */
+function get_last_downloaded_date( $kit_id ) {
+	$timestamp = get_post_meta( $kit_id, '_activity_last_downloaded', true );
+
+	if ( ! $timestamp ) {
+		return null;
+	}
+
+	return gmdate( 'Y-m-d', strtotime( $timestamp ) );
+}
+
+/**
+ * Get, for each kit, the most recent date Jetpack recorded a view for it.
+ *
+ * Jetpack Stats has no dedicated "last viewed" field, so this is approximated from
+ * WPCOM_Stats::get_post_views()'s per-post view history (the 'weeks' field is the one
+ * part of that response confirmed to carry day-level granularity). This runs only when
+ * an admin loads the stats dashboard — an infrequent, authenticated read, not the
+ * per-visitor-page-load case that ruled out custom view tracking for this project.
+ *
+ * There's no batched form of this specific Jetpack call (unlike get_jetpack_post_views(),
+ * which fetches up to 100 kits per request) — get_post_views() is a single-post endpoint,
+ * so this is one Jetpack API call per kit on a cache miss. The cache TTL below is
+ * intentionally longer than an hour to keep that cost infrequent; if the kit library
+ * grows large enough that even a once-a-day cache-miss burst becomes noticeable, the
+ * next step would be warming this cache from a scheduled cron event instead of on-demand
+ * from the dashboard request.
+ *
+ * @param int[] $kit_ids Post IDs of the activity kits to fetch last-viewed dates for.
+ * @return array         Map of post_id (int) => 'Y-m-d' (string). Kits with no cached
+ *                        or parseable result are omitted, not set to null.
+ */
+function get_last_viewed_dates( array $kit_ids ) {
+	if ( ! class_exists( '\Automattic\Jetpack\Stats\WPCOM_Stats' ) || empty( $kit_ids ) ) {
+		return array();
+	}
+
+	$stats = new \Automattic\Jetpack\Stats\WPCOM_Stats();
+	$map   = array();
+
+	foreach ( $kit_ids as $kit_id ) {
+		$cache_key = 'ak_last_viewed_' . $kit_id;
+		$cached    = wp_cache_get( $cache_key, 'activity_kit_stats' );
+
+		if ( false !== $cached ) {
+			if ( $cached ) {
+				$map[ $kit_id ] = $cached;
+			}
+			continue;
+		}
+
+		$result = $stats->get_post_views( $kit_id, array( 'fields' => 'weeks' ) );
+		$date   = is_wp_error( $result ) ? null : extract_last_viewed_date( $result );
+
+		/* Cache the miss too (as an empty string), so a kit with no recorded views doesn't trigger a fresh API call on every dashboard load for the next several hours. */
+		wp_cache_set( $cache_key, $date ?? '', 'activity_kit_stats', 6 * HOUR_IN_SECONDS );
+
+		if ( $date ) {
+			$map[ $kit_id ] = $date;
+		}
+	}
+
+	return $map;
+}
+
+/**
+ * Pull the most recent date with a nonzero view count out of a get_post_views() response.
+ *
+ * The exact shape of the 'weeks' field isn't fully documented publicly, so this is
+ * intentionally defensive: it tolerates either an associative 'Y-m-d' => count shape or a
+ * nested 'Y-m-d' => array( 'days' => array( 'Y-m-d' => count ) ) shape, and returns null
+ * (rather than a wrong-but-plausible date) on anything else. Verify this against a live
+ * Jetpack connection before relying on it — see the PR description.
+ *
+ * @param array $result Response from WPCOM_Stats::get_post_views().
+ * @return string|null 'Y-m-d', or null if no parseable, nonzero-view date was found.
+ */
+function extract_last_viewed_date( $result ) {
+	if ( ! is_array( $result ) || empty( $result['weeks'] ) || ! is_array( $result['weeks'] ) ) {
+		return null;
+	}
+
+	$last_viewed = null;
+
+	foreach ( $result['weeks'] as $date => $value ) {
+		$days = is_array( $value ) && isset( $value['days'] ) ? $value['days'] : array( $date => $value );
+
+		if ( ! is_array( $days ) ) {
+			continue;
+		}
+
+		foreach ( $days as $day => $count ) {
+			if ( (int) $count > 0 && ( null === $last_viewed || $day > $last_viewed ) ) {
+				$last_viewed = $day;
+			}
+		}
+	}
+
+	return $last_viewed;
 }

--- a/wp-content/plugins/wporg-learn/inc/activity-kit-stats-page.php
+++ b/wp-content/plugins/wporg-learn/inc/activity-kit-stats-page.php
@@ -271,22 +271,31 @@ function render_page() {
 							<th data-col="title" data-type="string">
 								<?php esc_html_e( 'Kit Name', 'wporg-learn' ); ?> <span class="ak-sort-arrow"></span>
 							</th>
-							<th data-col="views" data-type="number" class="ak-col-number is-sorted" id="ak-th-views">
+							<th data-col="views" data-type="number" class="ak-col-number is-sorted" id="ak-th-views" title="<?php esc_attr_e( 'Page views recorded by Jetpack Stats for the selected time range.', 'wporg-learn' ); ?>">
 								<?php esc_html_e( 'Views', 'wporg-learn' ); ?> <span class="ak-sort-arrow">↓</span>
 							</th>
-							<th data-col="downloads" data-type="number" class="ak-col-number" id="ak-th-downloads">
+							<th data-col="downloads" data-type="number" class="ak-col-number" id="ak-th-downloads" title="<?php esc_attr_e( "Total number of times this kit's ZIP was downloaded, including repeat downloads by the same person.", 'wporg-learn' ); ?>">
 								<?php esc_html_e( 'Downloads', 'wporg-learn' ); ?> <span class="ak-sort-arrow"></span>
 							</th>
-							<th data-col="rate" data-type="number" class="ak-col-number" id="ak-th-rate">
+							<th data-col="unique_downloaders" data-type="number" class="ak-col-number" id="ak-th-unique-downloaders" title="<?php esc_attr_e( "Number of distinct people who downloaded this kit's ZIP on any single day, summed across the selected range. Deduplication is per day, not per range — the same person downloading on two different days is counted twice, since the privacy-preserving visitor hash is reset daily by design and can't identify the same person across days.", 'wporg-learn' ); ?>">
+								<?php esc_html_e( 'Unique Daily Downloaders', 'wporg-learn' ); ?> <span class="ak-sort-arrow"></span>
+							</th>
+							<th data-col="rate" data-type="number" class="ak-col-number" id="ak-th-rate" title="<?php esc_attr_e( 'Unique Daily Downloaders ÷ Views × 100 — an approximation of the share of visitors who went on to download the kit. Since Unique Daily Downloaders can count the same person more than once across a multi-day range, this rate is most accurate for a single-day range.', 'wporg-learn' ); ?>">
 								<?php esc_html_e( 'Download Rate', 'wporg-learn' ); ?> <span class="ak-sort-arrow"></span>
 							</th>
-							<th data-col="updated" data-type="string">
-								<?php esc_html_e( 'Last Updated', 'wporg-learn' ); ?> <span class="ak-sort-arrow"></span>
+							<th data-col="last_downloaded" data-type="string" id="ak-th-last-downloaded" title="<?php esc_attr_e( 'The most recent date this kit was downloaded.', 'wporg-learn' ); ?>">
+								<?php esc_html_e( 'Last Downloaded', 'wporg-learn' ); ?> <span class="ak-sort-arrow"></span>
+							</th>
+							<th data-col="last_viewed" data-type="string" id="ak-th-last-viewed" title="<?php esc_attr_e( "The most recent date Jetpack recorded a view for this kit. Approximate — based on Jetpack's own view history, not a dedicated timestamp.", 'wporg-learn' ); ?>">
+								<?php esc_html_e( 'Last Viewed', 'wporg-learn' ); ?> <span class="ak-sort-arrow"></span>
+							</th>
+							<th data-col="updated" data-type="string" title="<?php esc_attr_e( "The date this kit's content was last edited.", 'wporg-learn' ); ?>">
+								<?php esc_html_e( 'Kit Last Updated', 'wporg-learn' ); ?> <span class="ak-sort-arrow"></span>
 							</th>
 						</tr>
 					</thead>
 					<tbody id="ak-stats-table-body">
-						<tr><td colspan="5"><?php esc_html_e( 'Loading…', 'wporg-learn' ); ?></td></tr>
+						<tr><td colspan="8"><?php esc_html_e( 'Loading…', 'wporg-learn' ); ?></td></tr>
 					</tbody>
 				</table>
 			</div>

--- a/wp-content/plugins/wporg-learn/js/activity-kit-stats/index.js
+++ b/wp-content/plugins/wporg-learn/js/activity-kit-stats/index.js
@@ -41,6 +41,9 @@ if ( filterKit && tableBody && chartCanvas ) {
 	const kitBannerName = document.getElementById( 'ak-kit-banner-name' );
 	const thViews = document.getElementById( 'ak-th-views' );
 	const thDownloads = document.getElementById( 'ak-th-downloads' );
+	const thUniqueDownloaders = document.getElementById( 'ak-th-unique-downloaders' );
+	const thLastDownloaded = document.getElementById( 'ak-th-last-downloaded' );
+	const thLastViewed = document.getElementById( 'ak-th-last-viewed' );
 	const exportBtn = document.getElementById( 'ak-export-csv' );
 	const chartSliderWrap = document.getElementById( 'ak-chart-slider-wrap' );
 	const chartSlider = document.getElementById( 'ak-chart-slider' );
@@ -54,9 +57,9 @@ if ( filterKit && tableBody && chartCanvas ) {
 		return ( num ?? 0 ).toLocaleString();
 	}
 
-	// Formats downloads/views as a percentage; '—' when there are no views to divide by.
-	function formatRate( views, downloads ) {
-		return views > 0 ? ( ( downloads / views ) * 100 ).toFixed( 1 ) + '%' : '—';
+	// Formats a numerator (e.g. unique downloaders) as a percentage of views; '—' when there are no views to divide by.
+	function formatRate( views, numerator ) {
+		return views > 0 ? ( ( numerator / views ) * 100 ).toFixed( 1 ) + '%' : '—';
 	}
 
 	function formatDate( dateStr ) {
@@ -96,7 +99,7 @@ if ( filterKit && tableBody && chartCanvas ) {
 	function msgRow( text ) {
 		const row = document.createElement( 'tr' );
 		const cell = document.createElement( 'td' );
-		cell.colSpan = 5;
+		cell.colSpan = 8;
 		cell.textContent = text;
 		row.appendChild( cell );
 		return row;
@@ -128,7 +131,8 @@ if ( filterKit && tableBody && chartCanvas ) {
 		const isSingle = !! activeKit;
 		const totalV = data.reduce( ( sum, row ) => sum + ( row.views ?? 0 ), 0 );
 		const totalD = data.reduce( ( sum, row ) => sum + ( row.downloads ?? 0 ), 0 );
-		const rate = formatRate( totalV, totalD );
+		const totalUD = data.reduce( ( sum, row ) => sum + ( row.unique_downloaders ?? 0 ), 0 );
+		const rate = formatRate( totalV, totalUD );
 
 		if ( summaryViews ) {
 			summaryViews.textContent = fmt( totalV );
@@ -276,26 +280,30 @@ if ( filterKit && tableBody && chartCanvas ) {
 				}
 				return 0;
 			}
-			if ( sortCol === 'updated' ) {
+			if ( sortCol === 'updated' || sortCol === 'last_downloaded' || sortCol === 'last_viewed' ) {
 				return sortDir === 'asc'
-					? ( a.updated || '' ).localeCompare( b.updated || '' )
-					: ( b.updated || '' ).localeCompare( a.updated || '' );
+					? ( a[ sortCol ] || '' ).localeCompare( b[ sortCol ] || '' )
+					: ( b[ sortCol ] || '' ).localeCompare( a[ sortCol ] || '' );
 			}
 			let valueA;
 			if ( sortCol === 'views' ) {
 				valueA = a.views ?? 0;
 			} else if ( sortCol === 'downloads' ) {
 				valueA = a.downloads ?? 0;
+			} else if ( sortCol === 'unique_downloaders' ) {
+				valueA = a.unique_downloaders ?? 0;
 			} else {
-				valueA = ( a.views ?? 0 ) > 0 ? ( a.downloads ?? 0 ) / ( a.views ?? 0 ) : 0;
+				valueA = ( a.views ?? 0 ) > 0 ? ( a.unique_downloaders ?? 0 ) / ( a.views ?? 0 ) : 0;
 			}
 			let valueB;
 			if ( sortCol === 'views' ) {
 				valueB = b.views ?? 0;
 			} else if ( sortCol === 'downloads' ) {
 				valueB = b.downloads ?? 0;
+			} else if ( sortCol === 'unique_downloaders' ) {
+				valueB = b.unique_downloaders ?? 0;
 			} else {
-				valueB = ( b.views ?? 0 ) > 0 ? ( b.downloads ?? 0 ) / ( b.views ?? 0 ) : 0;
+				valueB = ( b.views ?? 0 ) > 0 ? ( b.unique_downloaders ?? 0 ) / ( b.views ?? 0 ) : 0;
 			}
 			return sortDir === 'asc' ? valueA - valueB : valueB - valueA;
 		} );
@@ -304,7 +312,8 @@ if ( filterKit && tableBody && chartCanvas ) {
 		sorted.forEach( ( row ) => {
 			const views = row.views ?? 0;
 			const downloads = row.downloads ?? 0;
-			const rate = formatRate( views, downloads );
+			const uniqueDownloaders = row.unique_downloaders ?? 0;
+			const rate = formatRate( views, uniqueDownloaders );
 			const isSelected = row.slug === activeKit;
 			const tableRow = document.createElement( 'tr' );
 			if ( isSelected ) {
@@ -313,6 +322,9 @@ if ( filterKit && tableBody && chartCanvas ) {
 
 			const viewsClass = 'ak-col-number' + ( activeMetric === 'downloads' ? ' ak-hidden-col' : '' );
 			const dlClass = 'ak-col-number' + ( activeMetric === 'views' ? ' ak-hidden-col' : '' );
+			const udClass = 'ak-col-number' + ( activeMetric === 'views' ? ' ak-hidden-col' : '' );
+			const lastDlClass = activeMetric === 'views' ? 'ak-hidden-col' : '';
+			const lastViewedClass = activeMetric === 'downloads' ? 'ak-hidden-col' : '';
 
 			const tdTitle = document.createElement( 'td' );
 			const link = document.createElement( 'a' );
@@ -333,14 +345,26 @@ if ( filterKit && tableBody && chartCanvas ) {
 			tdDl.className = dlClass;
 			tdDl.textContent = fmt( downloads );
 
+			const tdUniqueDl = document.createElement( 'td' );
+			tdUniqueDl.className = udClass;
+			tdUniqueDl.textContent = fmt( uniqueDownloaders );
+
 			const tdRate = document.createElement( 'td' );
 			tdRate.className = 'ak-col-number';
 			tdRate.textContent = rate;
 
+			const tdLastDl = document.createElement( 'td' );
+			tdLastDl.className = lastDlClass;
+			tdLastDl.textContent = formatDate( row.last_downloaded );
+
+			const tdLastViewed = document.createElement( 'td' );
+			tdLastViewed.className = lastViewedClass;
+			tdLastViewed.textContent = formatDate( row.last_viewed );
+
 			const tdUpdated = document.createElement( 'td' );
 			tdUpdated.textContent = formatDate( row.updated );
 
-			tableRow.append( tdTitle, tdViews, tdDl, tdRate, tdUpdated );
+			tableRow.append( tdTitle, tdViews, tdDl, tdUniqueDl, tdRate, tdLastDl, tdLastViewed, tdUpdated );
 			tableRow.addEventListener( 'click', ( event ) => {
 				if ( event.target.tagName !== 'A' ) {
 					setKit( row.slug );
@@ -390,6 +414,15 @@ if ( filterKit && tableBody && chartCanvas ) {
 		}
 		if ( thDownloads ) {
 			thDownloads.classList.toggle( 'ak-hidden-col', activeMetric === 'views' );
+		}
+		if ( thUniqueDownloaders ) {
+			thUniqueDownloaders.classList.toggle( 'ak-hidden-col', activeMetric === 'views' );
+		}
+		if ( thLastDownloaded ) {
+			thLastDownloaded.classList.toggle( 'ak-hidden-col', activeMetric === 'views' );
+		}
+		if ( thLastViewed ) {
+			thLastViewed.classList.toggle( 'ak-hidden-col', activeMetric === 'downloads' );
 		}
 
 		if ( backLinkBar ) {
@@ -477,12 +510,33 @@ if ( filterKit && tableBody && chartCanvas ) {
 
 	function exportCSV() {
 		const data = activeKit ? allData.filter( ( row ) => row.slug === activeKit ) : allData;
-		const rows = [ [ 'Kit Name', 'Views', 'Downloads', 'Download Rate', 'Last Updated' ] ];
+		const rows = [
+			[
+				'Kit Name',
+				'Views',
+				'Downloads',
+				'Unique Daily Downloaders',
+				'Download Rate',
+				'Last Downloaded',
+				'Last Viewed',
+				'Kit Last Updated',
+			],
+		];
 		data.forEach( ( row ) => {
 			const views = row.views ?? 0;
 			const downloads = row.downloads ?? 0;
-			const rate = formatRate( views, downloads );
-			rows.push( [ row.title, views, downloads, rate, row.updated || '' ] );
+			const uniqueDownloaders = row.unique_downloaders ?? 0;
+			const rate = formatRate( views, uniqueDownloaders );
+			rows.push( [
+				row.title,
+				views,
+				downloads,
+				uniqueDownloaders,
+				rate,
+				row.last_downloaded || '',
+				row.last_viewed || '',
+				row.updated || '',
+			] );
 		} );
 		const csv = rows.map( ( row ) => row.map( csvCell ).join( ',' ) ).join( '\n' );
 		const blob = new Blob( [ csv ], { type: 'text/csv' } );

--- a/wp-content/plugins/wporg-learn/wporg-learn.php
+++ b/wp-content/plugins/wporg-learn/wporg-learn.php
@@ -91,6 +91,7 @@ function load_files() {
 	require_once get_includes_path() . 'upload.php';
 	require_once get_includes_path() . 'utils.php';
 	require_once get_includes_path() . 'activity-kit-rest.php';
+	require_once get_includes_path() . 'activity-kit-downloads-db.php';
 	require_once get_includes_path() . 'activity-kit-settings.php';
 	require_once get_includes_path() . 'activity-kit-stats-page.php';
 	require_once get_includes_path() . 'activity-kit-import.php';


### PR DESCRIPTION
## What

The Activity Kit Stats dashboard (Activity Kits → Stats) currently shows a "Download Rate" computed as raw total downloads ÷ views. Since a visitor can download the same kit's ZIP more than once, total downloads can exceed views, producing a rate over 100% — not a meaningful "did visitors convert" signal. The dashboard also had no history of *when* a kit was last downloaded or last viewed, and the "Last Updated" column name was ambiguous.

This PR:

- Adds **unique-downloader tracking** via a new custom table (`wp_activity_kit_downloads`), extending the already-shipped, low-frequency download-tracking endpoint (#3592) rather than adding new per-page-view tracking.
- Redefines **"Download Rate"** as `unique downloaders ÷ views × 100`, fixing the >100% issue.
- Adds **"Last Downloaded"** (postmeta timestamp) and **"Last Viewed"** (approximated from Jetpack's per-post view history, fetched only on dashboard load) columns.
- Renames **"Last Updated"** to **"Kit Last Updated"** for clarity.
- Adds **hover tooltips** to every metric column header explaining what it surfaces, including an explicit note that "Unique Daily Downloaders" dedupes per day, not per selected range.

## Why not track unique page visitors too?

Jetpack Stats has no per-post unique-visitor data anywhere in its public API — only site-wide aggregates. A prior PR on this repo (#3496) had a similar "record on every page view" tracking endpoint explicitly rejected by WordPress.org infra (dd32) for caching/scale reasons (writing to the DB on every page view defeats edge caching), not privacy. This PR deliberately doesn't repeat that pattern — no new page-view tracking is added. Downloads are a different story: they're a comparatively rare, already-server-side-tracked event, so extending that with one more low-frequency write (a dedup record per kit/visitor/day) is consistent with the precedent that already shipped, not the one that was rejected.

## Privacy design

Visitors are identified by a one-way hash: `hash(daily_salt . ip . user_agent . kit_id)`, where the daily salt is `hash_hmac('sha256', $day, $site_secret)`. No raw IP is ever stored — only the hash. Because the salt is derived per-day from a secret that never leaves the server, the same visitor produces an unrelated hash on a different day, so no persistent per-visitor identifier is ever stored or derivable. This is the same pattern privacy-focused analytics tools (Plausible, Fathom) use to avoid needing cookie consent.

One consequence of this design, called out explicitly in the "Unique Daily Downloaders" column's tooltip: dedup resets daily, so the same person downloading on two different days within a multi-day range is counted twice, not once. This was verified directly in local testing.

## Verified locally in wp-env

- Table auto-creates via the `init` hook on a fresh, anonymous, unauthenticated request (not gated behind an admin ever loading wp-admin first).
- The real `/wp-json/activity-kits/v1/download/{id}` REST endpoint records a unique-downloader row and updates `_activity_last_downloaded`.
- Unique-downloader counts dedupe correctly within a day, and correctly do *not* dedupe across days (matching the disclosed tooltip behavior).
- Dashboard renders all 8 columns, tooltips, and CSV export correctly.
- Full `WordPress` phpcs standard: clean on all touched files (one pre-existing false-positive `$wpdb->prepare()` placeholder-count warning already present identically in trunk's `get_download_counts()`, not introduced here). JS lint clean. No stacked `//` comments.
- Ran a `/code-review` pass; all 8 findings addressed (6 fixed, 2 explicitly left unchanged with reasoning documented in code comments — see `activity-kit-downloads-db.php` and `activity-kit-rest.php`).

## Pre-merge follow-ups (not blockers, flagging for reviewers)

- Verify the real Jetpack `weeks` response shape against a live Jetpack connection (staging or Jurassic Tube) — `extract_last_viewed_date()` was written defensively but the exact day-level shape wasn't confirmed against live data.
- Get a quick sign-off from whoever owns the WordPress.org privacy policy for this new visitor-hash tracking.
- Confirm with WordPress.org meta/infra whether production table creation needs a manual provisioning step, per the existing `wporg_user_sessions` precedent (that table's schema is documented as a comment only, not created via `dbDelta()` in production).

🤖 Generated with [Claude Code](https://claude.com/claude-code)