### PR TITLE
Align the Learn capability mirror with the editorial workflow

### DIFF
--- a/wp-content/plugins/wporg-learn/inc/capabilities.php
+++ b/wp-content/plugins/wporg-learn/inc/capabilities.php
@@ -8,6 +8,7 @@ defined( 'WPINC' ) || die();
  * Actions and filters.
  */
 add_filter( 'user_has_cap', __NAMESPACE__ . '\set_post_type_caps' );
+add_action( 'pre_get_posts', __NAMESPACE__ . '\scope_learn_content_list_to_author' );
 add_filter( 'user_has_cap', __NAMESPACE__ . '\set_caps_for_internal_notes' );
 add_filter( 'map_meta_cap', __NAMESPACE__ . '\map_meta_caps', 20, 4 ); // Needs to fire after meta caps in wporg-internal-notes.
 add_action( 'init', __NAMESPACE__ . '\add_or_update_lesson_plan_editor_role' );
@@ -18,6 +19,12 @@ add_action( 'init', __NAMESPACE__ . '\add_or_update_workshop_reviewer_role' );
  *
  * Example: If a user has the `edit_others_posts` cap (from Editor role), this will also give them
  * the equivalent `edit_others_lesson_plans` and `edit_others_workshops` caps.
+ *
+ * Below the Editor threshold only the authoring caps are mirrored. Learn content reaches the
+ * site through the submission form in `inc/form.php`, which files applications as
+ * `needs-vetting` for a reviewer to triage, so Contributors and Authors create and edit their
+ * own unpublished content while publishing and maintaining live content stays with the
+ * reviewer roles.
  *
  * @param bool[] $user_caps A list of primitive caps (keys) and whether user has them (boolean values).
  *
@@ -30,6 +37,13 @@ function set_post_type_caps( $user_caps ) {
 		array( 'activity_kit', 'activity_kits' ),
 	);
 
+	// `edit_others_posts` is the Editor threshold; the Lesson Plan Editor and Tutorial Reviewer
+	// roles and the administrator hold it, Contributor and Author do not.
+	$has_editor_caps = ! empty( $user_caps['edit_others_posts'] );
+
+	// Deliberately excludes `publish_posts`, `edit_published_posts` and `delete_published_posts`.
+	$authoring_caps = array( 'edit_posts', 'delete_posts' );
+
 	foreach ( $capability_types as $capability_type ) {
 		// Generate the caps for a capability type.
 		$cap_args = array(
@@ -40,13 +54,50 @@ function set_post_type_caps( $user_caps ) {
 		$cap_map = (array) get_post_type_capabilities( (object) $cap_args );
 
 		foreach ( $user_caps as $cap_slug => $granted ) {
-			if ( $granted && isset( $cap_map[ $cap_slug ] ) ) {
-				$user_caps[ $cap_map[ $cap_slug ] ] = true;
+			if ( ! $granted || ! isset( $cap_map[ $cap_slug ] ) ) {
+				continue;
 			}
+
+			if ( ! $has_editor_caps && ! in_array( $cap_slug, $authoring_caps, true ) ) {
+				continue;
+			}
+
+			$user_caps[ $cap_map[ $cap_slug ] ] = true;
 		}
 	}
 
 	return $user_caps;
+}
+
+/**
+ * Restrict the Learn content list tables to the current user's own posts.
+ *
+ * `wp-admin/edit.php` does not author-scope its query for every post status, so scope it here
+ * for users who cannot edit other people's content.
+ *
+ * @param \WP_Query $query
+ *
+ * @return void
+ */
+function scope_learn_content_list_to_author( $query ) {
+	global $pagenow;
+
+	if ( ! is_admin() || 'edit.php' !== $pagenow || ! $query->is_main_query() ) {
+		return;
+	}
+
+	$learn_post_types = array( 'lesson-plan', 'wporg_workshop', 'activity_kit' );
+	$post_type        = $query->get( 'post_type' );
+
+	if ( ! in_array( $post_type, $learn_post_types, true ) ) {
+		return;
+	}
+
+	$post_type_object = get_post_type_object( $post_type );
+
+	if ( $post_type_object && ! current_user_can( $post_type_object->cap->edit_others_posts ) ) {
+		$query->set( 'author', get_current_user_id() );
+	}
 }
 
 /**


### PR DESCRIPTION
## What

`set_post_type_caps()` is a `user_has_cap` filter that mirrors a user's `post` capabilities onto the Learn capability types (`lesson_plans`, `tutorials`, `activity_kits`). It currently mirrors the user's **entire** capability set, so roles below Editor end up with rights over Learn content that the editorial workflow reserves for reviewers.

This aligns the mirror with the workflow the plugin already implements: the submission form in `inc/form.php` files applications as `needs-vetting` for a Tutorial Reviewer to triage.

## Changes

- Mirror the full equivalent set only for users holding `edit_others_posts`.
- Below that threshold, mirror only `edit_posts` and `delete_posts` — not `publish_posts`, `edit_published_posts` or `delete_published_posts`.
- Scope the Learn list tables to the user's own posts when they cannot edit other people's, since `wp-admin/edit.php` does not author-scope its query for every post status.

Contributors and Authors keep creating and editing their own unpublished Learn content. Publishing, and editing or deleting content that is already live, moves to the reviewer roles.

## Effect by role

| Role | Before | After |
|---|---|---|
| Subscriber | nothing | unchanged |
| Contributor | edit + delete | unchanged |
| Author | edit + delete + **publish, edit/delete published** | edit + delete |
| Editor | full set | unchanged |
| Tutorial Reviewer | full set | unchanged |
| Lesson Plan Editor | stored role caps | unchanged |
| Administrator | full set | unchanged |

Contributors are unaffected: they already lacked `publish_tutorials`. Authors are the only role that changes.

## How to test

**1. Capability matrix.** With one user per role on a Learn environment:

```bash
wp eval --url=<site> '
foreach ( array( "contributor", "author", "editor", "workshop_reviewer", "lesson_plan_editor" ) as $role ) {
  $u = get_users( array( "role" => $role, "number" => 1, "fields" => "ID" ) );
  if ( ! $u ) { echo "$role: none\n"; continue; }
  $caps = array();
  foreach ( array( "edit_tutorials","delete_tutorials","publish_tutorials","edit_published_tutorials",
                   "edit_others_tutorials","edit_lesson_plans","publish_lesson_plans",
                   "edit_activity_kits","publish_activity_kits" ) as $c ) {
    $caps[$c] = user_can( $u[0], $c ) ? "YES" : "no";
  }
  echo "\n$role:\n"; print_r( $caps );
}'
```

Expected after the patch:

- Contributor and Author: `edit_*` and `delete_*` YES; `publish_*`, `edit_published_*`, `edit_others_*` **no**.
- Editor, Tutorial Reviewer, administrator: all YES, identical to before the patch.
- Run this on `trunk` first and diff the two outputs — only the Author row should change.

**2. Authoring still works.** As a Contributor and again as an Author: create a Tutorial and a Lesson Plan, save as draft, reopen and edit. Both should work throughout.

**3. Publishing is reserved.** As an Author, confirm a Tutorial cannot be published (no publish action; a direct `POST` to `/wp-json/wp/v2/wporg_workshop` with `"status":"publish"` returns 403). Then as a Tutorial Reviewer, publish that same draft — it should succeed.

**4. Reviewer workflow unchanged.** As a Tutorial Reviewer: create, publish, edit someone else's Tutorial, and edit an already-published one. All should behave exactly as on `trunk`. Same check as Lesson Plan Editor against Lesson Plans.

**5. List table scoping.** Create drafts under two different Contributors. Signed in as one of them, `wp-admin/edit.php?post_type=wporg_workshop` should list only their own, including under the status filters (`draft`, `pending`, `needs-vetting`). As an Editor or Tutorial Reviewer the full list should still appear.

**6. Submission form.** Submit through the public Tutorial application form and confirm the post is still created as `needs-vetting`.

## Notes for reviewers

- An Author who published Learn content in the past can no longer edit that published item themselves; a reviewer makes the edit. On the live site that is a small number of items.
- The mirror runs through `user_has_cap`, so effective capabilities will not match `wp_roles` or the Users screen. Test with `user_can()` against a real user, not by reading role definitions.
