### PR TITLE
Render the Learn patterns only for the post types they are written for

### DIFF
--- a/wp-content/plugins/wporg-learn/inc/post-meta.php
+++ b/wp-content/plugins/wporg-learn/inc/post-meta.php
@@ -291,6 +291,26 @@ function register_common_meta() {
 		);
 	}
 
+	/*
+	 * `register_post_meta()` scopes a `sanitize_callback` to one object subtype, so the callbacks
+	 * below only run for the post types they are registered against. These keys hold URLs that
+	 * the theme prints, so also register them without a subtype: `sanitize_meta()` then has a
+	 * callback to fall back on for post types with no registration of their own.
+	 */
+	$url_meta_keys = array( 'video_url', 'slides_view_url', 'slides_download_url' );
+	foreach ( $url_meta_keys as $url_meta_key ) {
+		register_meta(
+			'post',
+			$url_meta_key,
+			array(
+				'type'              => 'string',
+				'single'            => true,
+				'sanitize_callback' => 'esc_url_raw',
+				'show_in_rest'      => false,
+			)
+		);
+	}
+
 	// Video URL field.
 	$post_types = array( 'wporg_workshop', 'lesson' );
 	foreach ( $post_types as $post_type ) {
@@ -702,7 +722,8 @@ function save_workshop_meta_fields( $post_id ) {
 		return;
 	}
 
-	$video_url = filter_input( INPUT_POST, 'video-url', FILTER_SANITIZE_URL );
+	// Use the same escaper the meta key is registered with.
+	$video_url = esc_url_raw( (string) filter_input( INPUT_POST, 'video-url' ) );
 	update_post_meta( $post_id, 'video_url', $video_url );
 
 	$duration = filter_input( INPUT_POST, 'duration', FILTER_SANITIZE_NUMBER_INT, FILTER_REQUIRE_ARRAY );

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/sidebar-lesson-plan.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/sidebar-lesson-plan.php
@@ -9,6 +9,15 @@
 
 $current_post = get_post();
 
+/*
+ * A registered pattern can be rendered outside the template it was written for, and this file
+ * reads post meta off the current post. That meta is registered per post type, so only render
+ * for the type this pattern is designed around.
+ */
+if ( ! $current_post || 'lesson-plan' !== get_post_type( $current_post ) ) {
+	return;
+}
+
 ?>
 
 <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|40"}},"className":"wporg-learn-sidebar-meta-info","layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
@@ -23,7 +32,7 @@ $current_post = get_post();
 				<?php if ( $current_post->slides_view_url ) : ?>
 					<!-- wp:button {"textAlign":"center","width":100,"style":{"border":{"radius":"2px"},"spacing":{"padding":{"left":"13px","right":"13px","top":"16px","bottom":"16px"}},"typography":{"lineHeight":0,"fontStyle":"normal","fontWeight":"400"}},"className":"aligncenter is-style-fill","fontSize":"normal","fontFamily":"inter"} -->
 					<div class="wp-block-button has-custom-width wp-block-button__width-100 has-custom-font-size aligncenter is-style-fill has-inter-font-family has-normal-font-size" style="font-style:normal;font-weight:400;line-height:0">
-						<a class="wp-block-button__link has-text-align-center wp-element-button" href="<?php echo esc_attr( $current_post->slides_view_url ); ?>" style="border-radius:2px;padding-top:16px;padding-right:13px;padding-bottom:16px;padding-left:13px" target="_blank" rel="noreferrer noopener">
+						<a class="wp-block-button__link has-text-align-center wp-element-button" href="<?php echo esc_url( $current_post->slides_view_url ); ?>" style="border-radius:2px;padding-top:16px;padding-right:13px;padding-bottom:16px;padding-left:13px" target="_blank" rel="noreferrer noopener">
 							<?php esc_html_e( 'View slides ↗', 'wporg-learn' ); ?>
 						</a>
 					</div>
@@ -32,7 +41,7 @@ $current_post = get_post();
 				<?php if ( $current_post->slides_view_url && $current_post->slides_download_url ) : ?>
 					<!-- wp:button {"textAlign":"center","width":100,"style":{"border":{"radius":"2px"},"spacing":{"margin":{"bottom":"40px"},"padding":{"left":"13px","right":"13px","top":"16px","bottom":"16px"}},"typography":{"lineHeight":0,"fontStyle":"normal","fontWeight":"400"}},"className":"aligncenter is-style-text","fontSize":"normal","fontFamily":"inter"} -->
 					<div class="wp-block-button has-custom-width wp-block-button__width-100 has-custom-font-size aligncenter is-style-text has-inter-font-family has-normal-font-size" style="font-style:normal;font-weight:400;line-height:0">
-						<a class="wp-block-button__link has-text-align-center wp-element-button" href="<?php echo esc_attr( $current_post->slides_download_url ); ?>" style="border-radius:2px;padding-top:16px;padding-right:13px;padding-bottom:16px;padding-left:13px" target="_blank" rel="noreferrer noopener">
+						<a class="wp-block-button__link has-text-align-center wp-element-button" href="<?php echo esc_url( $current_post->slides_download_url ); ?>" style="border-radius:2px;padding-top:16px;padding-right:13px;padding-bottom:16px;padding-left:13px" target="_blank" rel="noreferrer noopener">
 							<?php esc_html_e( 'Download slides ↗', 'wporg-learn' ); ?>
 						</a>
 					</div>
@@ -40,7 +49,7 @@ $current_post = get_post();
 				<?php elseif ( $current_post->slides_download_url ) : ?>
 					<!-- wp:button {"textAlign":"center","width":100,"style":{"border":{"radius":"2px"},"spacing":{"padding":{"left":"13px","right":"13px","top":"16px","bottom":"16px"}},"typography":{"lineHeight":0,"fontStyle":"normal","fontWeight":"400"}},"className":"aligncenter is-style-fill","fontSize":"normal","fontFamily":"inter"} -->
 					<div class="wp-block-button has-custom-width wp-block-button__width-100 has-custom-font-size aligncenter is-style-fill has-inter-font-family has-normal-font-size" style="font-style:normal;font-weight:400;line-height:0">
-						<a class="wp-block-button__link has-text-align-center wp-element-button" href="<?php echo esc_attr( $current_post->slides_download_url ); ?>" style="border-radius:2px;padding-top:16px;padding-right:13px;padding-bottom:16px;padding-left:13px" target="_blank" rel="noreferrer noopener">
+						<a class="wp-block-button__link has-text-align-center wp-element-button" href="<?php echo esc_url( $current_post->slides_download_url ); ?>" style="border-radius:2px;padding-top:16px;padding-right:13px;padding-bottom:16px;padding-left:13px" target="_blank" rel="noreferrer noopener">
 							<?php esc_html_e( 'Download slides ↗', 'wporg-learn' ); ?>
 						</a>				
 					</div>

--- a/wp-content/themes/pub/wporg-learn-2024/patterns/single-tutorial-embed.php
+++ b/wp-content/themes/pub/wporg-learn-2024/patterns/single-tutorial-embed.php
@@ -8,17 +8,30 @@
 global $wp_embed;
 global $post;
 
-if ( ! isset( $post->video_url ) ) {
+/*
+ * A registered pattern can be rendered outside the template it was written for, and this file
+ * reads post meta off the global `$post`. That meta is registered per post type, so only render
+ * for the type this pattern is designed around.
+ */
+if ( ! $post instanceof WP_Post || 'wporg_workshop' !== get_post_type( $post ) ) {
+	return;
+}
+
+// `autoembed()` returns its input unchanged when no provider matches, and the result is echoed
+// unescaped below to keep the provider markup intact, so make sure it is a URL first.
+$video_url = esc_url_raw( (string) $post->video_url );
+
+if ( ! $video_url ) {
 	return;
 }
 
 ?>
 
-<!-- wp:embed {"url":"<?php echo esc_url( $post->video_url ); ?>","type":"video","providerNameSlug":"wordpress-tv","responsive":true,"className":"wp-embed-aspect-16-9 wp-has-aspect-ratio","autoembed":true} -->
+<!-- wp:embed {"url":"<?php echo esc_url( $video_url ); ?>","type":"video","providerNameSlug":"wordpress-tv","responsive":true,"className":"wp-embed-aspect-16-9 wp-has-aspect-ratio","autoembed":true} -->
 <figure class="wp-block-embed is-type-video is-provider-wordpress-tv wp-block-embed-wordpress-tv wp-embed-aspect-16-9 wp-has-aspect-ratio">
 
 	<div class="wp-block-embed__wrapper">
-		<?php echo $wp_embed->autoembed( $post->video_url ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+		<?php echo $wp_embed->autoembed( $video_url ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 	</div>
 
 </figure>


### PR DESCRIPTION
## What

`single-tutorial-embed` and `sidebar-lesson-plan` read post meta off the current post and print it. Both assume they are only ever rendered from their own template, but a registered pattern can be rendered outside the template it was written for — `Inserter: no` controls inserter visibility, not registration.

That assumption also reaches the sanitizers. `video_url`, `slides_view_url` and `slides_download_url` are registered with `register_post_meta()`, which scopes a `sanitize_callback` to a single object subtype, so the `esc_url_raw` callbacks do not run for post types the plugin does not register the key against.

## Changes

- Guard both patterns on the post type they are designed around, so the post they read meta from is always one whose meta is registered.
- Treat the tutorial video value as a URL before handing it to `autoembed()`, whose return value is deliberately printed unescaped so provider markup survives.
- Use `esc_url()` rather than `esc_attr()` for the slides `href` values, so the scheme is checked against `wp_allowed_protocols()`.
- Also register the three URL keys without a subtype, giving `sanitize_meta()` a callback to fall back on for other post types.
- Store the admin form's video URL with the same escaper the meta key is registered with.

## How to test

**1. Tutorial embed still works (main regression check).** Open a Tutorial with a WordPress.tv video URL in `video_url`. The video should render exactly as it does on `trunk` — compare the two side by side. Check one tutorial whose URL is a supported provider and one whose URL is not.

**2. Empty value.** On a Tutorial, set `video_url` to an empty string. The page should render with no embed figure at all. On `trunk` it prints an empty `<figure>`; this is an intentional change.

**3. Non-URL value.** Set `video_url` on a Tutorial to a plain string such as `not a url`. The tutorial page should still render, and the value should appear as inert text rather than as markup. View source to confirm nothing was interpreted as HTML.

**4. Lesson plan slides still work (regression).** Open a Lesson Plan with `slides_view_url` and `slides_download_url` set to normal `https://` URLs. Both buttons should render and link correctly, unchanged from `trunk`.

**5. Scheme handling.** Set `slides_view_url` to `javascript:void(0)`. The rendered `href` should come out empty rather than carrying the value through.

**6. Patterns are inert outside their own post type.** Using the post editor's code editor, add these to the content of an ordinary post or page:

```
<!-- wp:pattern {"slug":"wporg-learn-2024/single-tutorial-embed"} /-->
<!-- wp:pattern {"slug":"wporg-learn-2024/sidebar-lesson-plan"} /-->
```

View the post. Neither should produce any output. On `trunk` both render against whatever post they are placed in.

**7. Templates unaffected.** Confirm the single Tutorial and single Lesson Plan templates still render their patterns normally — those are the legitimate call sites and must be unchanged.

**8. Admin form.** Edit a Tutorial through the Workshop Details metabox, save a normal video URL, and confirm it round-trips correctly.

## Notes for reviewers

- The pattern guards are hardcoded to `wporg_workshop` and `lesson-plan`. Each pattern has exactly one call site today (`single-wporg_workshop.html` and `single-lesson-plan.html`), so nothing else should regress — but if either pattern is ever reused from another template, the guard needs updating alongside it.
- `single-activity-kit-content` and `page-course-complete-content` read meta the same way. Their keys are all underscore-prefixed and their output is already escaped, so they are deliberately left alone.
