### PR TITLE
Profiles: escape values interpolated into activity messages

### DIFF
--- a/wp-content/plugins/wporg-learn/inc/profiles.php
+++ b/wp-content/plugins/wporg-learn/inc/profiles.php
@@ -67,7 +67,7 @@ function notify_workshop_presenter( $post ) {
 
 	$unique_presenter_wporg_username = array_unique( array_map( 'trim', explode( ',', $presenter_wporg_username ) ) );
 	$permalink                       = get_permalink( $post );
-	$title                           = wp_kses_data( $post->post_title );
+	$title                           = esc_html( $post->post_title );
 	$content                         = wp_trim_words(
 		strip_shortcodes( has_excerpt( $post ) ? $post->post_excerpt : $post->post_content ),
 		55
@@ -90,7 +90,7 @@ function notify_workshop_presenter( $post ) {
 				'content'      => $content,
 				'message'      => sprintf(
 					'Assigned as a presenter on the Learn WordPress tutorial, <i><a href="%s">%s</a></i>',
-					$permalink,
+					esc_url( $permalink ),
 					$title,
 				),
 			)
@@ -117,8 +117,8 @@ function add_course_completed_activity( string $status, int $user_id, int $cours
 			'item_id'      => $course_id,
 			'message'      => sprintf(
 				'Completed the course <em><a href="%s">%s</a></em> on learn.wordpress.org',
-				$course_url,
-				wp_kses_data( get_the_title( $course_id ) )
+				esc_url( $course_url ),
+				esc_html( get_the_title( $course_id ) )
 			),
 		)
 	);


### PR DESCRIPTION
`inc/profiles.php` has two call sites that build an anchor with `sprintf()` and interpolate the permalink and post title without escaping, then post the result to the Profiles activity handler.

- `notify_workshop_presenter()` — `esc_url()` on the permalink, and `esc_html()` in place of `wp_kses_data()` for the title
- `add_course_completed_activity()` — the same two changes

Nothing renders wrong today: both URLs come from `get_permalink()`, and the handler on the receiving end filters what it is given before storing it. But that filtering happens in a different codebase and a network hop away from where the string is built, so the markup here is only correct by arrangement. Escaping at the point of construction makes it correct on its own terms.

`esc_html()` rather than `wp_kses_data()` for the link text because that is a text position — `wp_kses_data()` is a content filter and will pass inline markup in a title straight through into the anchor.

I could not run the repo's PHPCS locally: `phpcs.xml.dist` passes `text_domain` as a comma-separated string, which PHP_CodeSniffer 4.x rejects. That is unrelated to this change and predates it. The edits are four one-line substitutions using standard escaping functions in the surrounding style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)