### PR TITLE
Assign Credits Graduate badge upon completion of wordpress-credits-designer-track course

### DIFF
--- a/wp-content/plugins/wporg-learn/inc/profiles.php
+++ b/wp-content/plugins/wporg-learn/inc/profiles.php
@@ -128,6 +128,7 @@ function add_course_completed_activity( string $status, int $user_id, int $cours
 		case '50-hours-wordpress-credits':
 		case 'wordpress-credits':
 		case 'wordpress-credits-developer-track':
+		case 'wordpress-credits-designer-track':
 		case 'wordpress-credits-self-onboarding-pilot':
 			Profiles_API\assign_badge( 'credits-graduate', $user_id );
 			break;


### PR DESCRIPTION
 I have added a line to get the new Designer track course students from WP Credits to get their badge after completion. Thanks!