### PR TITLE
Plugin: Sync the workshop internal notes cap mapping with the Internal Notes plugin

### DIFF
--- a/wp-content/plugins/wporg-learn/inc/capabilities.php
+++ b/wp-content/plugins/wporg-learn/inc/capabilities.php
@@ -158,7 +158,7 @@ function map_meta_caps( $required_caps, $current_cap, $user_id, $args ) {
 
 			// `delete-note` is checked against the note itself, not the post it belongs to.
 			if ( $parent && 'delete-note' === $current_cap ) {
-				$parent = get_post( $parent->post_parent );
+				$parent = get_post_parent( $parent );
 			}
 
 			if ( $parent && 'wporg_workshop' === get_post_type( $parent ) ) {

--- a/wp-content/plugins/wporg-learn/inc/capabilities.php
+++ b/wp-content/plugins/wporg-learn/inc/capabilities.php
@@ -146,11 +146,21 @@ function map_meta_caps( $required_caps, $current_cap, $user_id, $args ) {
 			$required_caps[] = 'do_not_allow';
 			break;
 
-		case 'read-internal-notes':
-		case 'create-internal-note':
-		case 'delete-internal-note':
+		case 'read-notes':
+		case 'create-note':
+		case 'delete-note':
 			// Override the meta caps set up in the Internal Notes plugin, specifically for the workshop post type.
+			if ( in_array( 'do_not_allow', $required_caps, true ) ) {
+				break;
+			}
+
 			$parent = ! empty( $args[0] ) ? get_post( $args[0] ) : false;
+
+			// `delete-note` is checked against the note itself, not the post it belongs to.
+			if ( $parent && 'delete-note' === $current_cap ) {
+				$parent = get_post( $parent->post_parent );
+			}
+
 			if ( $parent && 'wporg_workshop' === get_post_type( $parent ) ) {
 				$required_caps = array( 'manage_workshop_internal_notes' );
 			}


### PR DESCRIPTION
The Internal Notes plugin checks `read-notes`, `create-note` and `delete-note`, and passes the note rather than its parent post when checking `delete-note`. Learn's workshop-specific override in `inc/capabilities.php` still matched an older set of names, so it was not being applied.

This updates the override to the current names, resolves the parent post for `delete-note`, and leaves the Internal Notes plugin's own `do_not_allow` results in place so log notes and unsupported post types behave as before.

## Testing

Ran both plugins' `map_meta_cap` callbacks in hook order against workshop, lesson plan, log note, plain post and missing post cases for an Editor and a Tutorial Reviewer. Workshop notes resolve to `manage_workshop_internal_notes`; other post types resolve to the Internal Notes plugin's default mapping.

`phpcs` passes on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
